### PR TITLE
fix(#21): stop disabled sync plugins from running; persist SFTP show-hidden

### DIFF
--- a/src/components/filetransfer/FilePane.tsx
+++ b/src/components/filetransfer/FilePane.tsx
@@ -116,7 +116,11 @@ export function FilePane({
   const [sortDir, setSortDir] = useState<SortDir>("asc");
   const [colWidths, setColWidths] = useState<ColumnWidths>(DEFAULT_COLUMN_WIDTHS);
   const [visibleCols, setVisibleCols] = useState<VisibleCols>(initialVisibleCols ?? DEFAULT_VISIBLE_COLS);
-  const [showHidden, setShowHidden] = useState(false);
+  // Persisted + shared across every pane so enabling it once sticks (matches
+  // mainstream SFTP clients). Lives in the store, not local state, so it no
+  // longer resets on remount/navigation.
+  const showHidden = useSftpSettingsStore((s) => s.showHidden);
+  const setShowHidden = useSftpSettingsStore((s) => s.setShowHidden);
   const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
   const [viewMenuPos, setViewMenuPos] = useState<{ x: number; y: number } | null>(null);
   const [confirmDialog, setConfirmDialog] = useState<{ title: string; message: string; resolve: (ok: boolean) => void } | null>(null);

--- a/src/plugins/gist-sync/index.ts
+++ b/src/plugins/gist-sync/index.ts
@@ -45,6 +45,7 @@ export const register: PluginRegisterFn = (api: PluginAPI) => {
   });
 
   // Functional hooks only when the plugin is enabled
+  let offBeforeQuit: (() => void) | null = null;
   if (api.isActive()) {
     (async () => {
       if (!(await isConfigured())) return;
@@ -53,12 +54,15 @@ export const register: PluginRegisterFn = (api: PluginAPI) => {
       startPoll(interval);
     })();
 
-    api.lifecycle.onBeforeQuit(async () => {
+    offBeforeQuit = api.lifecycle.onBeforeQuit(async () => {
       if (await isConfigured()) await push().catch(() => {});
     });
   }
 
   return () => {
     stopPoll();
+    // Drop the quit-time push handler too, otherwise a disabled plugin would
+    // still sync on app exit.
+    offBeforeQuit?.();
   };
 };

--- a/src/plugins/gist-sync/register.test.ts
+++ b/src/plugins/gist-sync/register.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { register } from "./index";
+import type { PluginAPI } from "@/plugins/api";
+
+// Minimal PluginAPI stub. getPat()/getRegisteredGists() resolve to null, so
+// isConfigured() is false and the poll IIFE early-returns — leaving the
+// onBeforeQuit lifecycle wiring as the behaviour under test.
+
+function makeApi(active: boolean) {
+  const offBeforeQuit = vi.fn();
+  const onBeforeQuit = vi.fn(() => offBeforeQuit);
+
+  const api = {
+    isActive: () => active,
+    vault: { get: vi.fn(async () => null), set: vi.fn(), delete: vi.fn() },
+    storage: { get: vi.fn(async () => null), set: vi.fn(async () => {}), delete: vi.fn(async () => {}) },
+    ui: { registerSettingsPage: vi.fn(() => () => {}) },
+    lifecycle: { onBeforeQuit, waitForLoginSync: vi.fn(() => Promise.resolve()) },
+    notifications: { toast: vi.fn(), banner: vi.fn(), progress: vi.fn() },
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as unknown as PluginAPI;
+
+  return { api, onBeforeQuit, offBeforeQuit };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("gist-sync register cleanup", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("cleanup unsubscribes the quit-time push handler", async () => {
+    const { api, onBeforeQuit, offBeforeQuit } = makeApi(true);
+    const cleanup = register(api);
+    await flush();
+
+    expect(onBeforeQuit).toHaveBeenCalledTimes(1);
+    expect(offBeforeQuit).not.toHaveBeenCalled();
+
+    if (typeof cleanup === "function") cleanup();
+    expect(offBeforeQuit).toHaveBeenCalledTimes(1);
+  });
+
+  test("disabled plugin registers no quit handler", async () => {
+    const { api, onBeforeQuit } = makeApi(false);
+    const cleanup = register(api);
+    await flush();
+
+    expect(onBeforeQuit).not.toHaveBeenCalled();
+    if (typeof cleanup === "function") cleanup();
+  });
+});

--- a/src/plugins/ssh-config/index.ts
+++ b/src/plugins/ssh-config/index.ts
@@ -504,6 +504,21 @@ function createSettingsComponent(api: PluginAPI): React.FC {
 // ─── Register ─────────────────────────────────────────────────────────────────
 
 export const register: PluginRegisterFn = (api) => {
+  // Settings page is registered regardless of active state so a disabled
+  // plugin can still be reviewed/configured before re-enabling. Kept out of the
+  // active cleanup below so disabling never removes it (matches gist-sync).
+  api.ui.registerSettingsPage({
+    id: `${manifest.id}:settings`,
+    label: "SSH Config Sync",
+    icon: "lucide:file-code",
+    component: createSettingsComponent(api),
+  });
+
+  // Everything below is active-only work. A disabled plugin must stay fully
+  // inert — no file watcher, no auto-sync — until it is re-enabled, at which
+  // point setPluginActive re-runs register() with isActive() === true.
+  if (!api.isActive()) return () => {};
+
   let stopWatch: (() => void) | null = null;
 
   const startWatcher = (intervalMs: number) => {
@@ -541,17 +556,9 @@ export const register: PluginRegisterFn = (api) => {
     sync(api).catch((e) => api.log.error("ssh-config manual sync failed", e));
   });
 
-  const unregisterSettings = api.ui.registerSettingsPage({
-    id: `${manifest.id}:settings`,
-    label: "SSH Config Sync",
-    icon: "lucide:file-code",
-    component: createSettingsComponent(api),
-  });
-
   return () => {
     stopWatch?.();
     offEvent();
     offSyncNow();
-    unregisterSettings();
   };
 };

--- a/src/plugins/ssh-config/register.test.ts
+++ b/src/plugins/ssh-config/register.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { register } from "./index";
+import type { PluginAPI } from "@/plugins/api";
+
+// ─── Mock API builder ──────────────────────────────────────────────────────
+// Minimal PluginAPI stub exercising only the surface ssh-config's register()
+// and sync() touch. isActive is parameterised so we can assert the plugin stays
+// inert while disabled.
+
+function makeApi(active: boolean) {
+  const watch = vi.fn(() => () => {});
+  const registerSettingsPage = vi.fn(() => () => {});
+  const connectionsList = vi.fn(async () => []);
+
+  const api = {
+    isActive: () => active,
+    fs: {
+      // No ~/.ssh/config present → sync() would early-return, but if exists is
+      // called at all it proves the initial sync fired.
+      exists: vi.fn(async () => false),
+      readText: vi.fn(async () => ""),
+      writeText: vi.fn(async () => {}),
+      watch,
+    },
+    connections: { list: connectionsList },
+    keys: { list: vi.fn(async () => []) },
+    identities: { list: vi.fn(async () => []) },
+    storage: {
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+    },
+    events: { on: vi.fn(() => () => {}), emit: vi.fn() },
+    ui: { registerSettingsPage },
+    lifecycle: { waitForLoginSync: vi.fn(() => Promise.resolve()) },
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as unknown as PluginAPI;
+
+  return { api, watch, registerSettingsPage, connectionsList };
+}
+
+// Let every scheduled microtask/`.then` chain settle.
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("ssh-config register honors isActive()", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("disabled plugin does not watch or sync", async () => {
+    const { api, watch, connectionsList, registerSettingsPage } = makeApi(false);
+    const cleanup = register(api);
+    await flush();
+    await flush();
+
+    expect(watch).not.toHaveBeenCalled();
+    expect(connectionsList).not.toHaveBeenCalled();
+    // Settings page must still be available while disabled.
+    expect(registerSettingsPage).toHaveBeenCalledTimes(1);
+
+    if (typeof cleanup === "function") cleanup();
+  });
+
+  test("enabled plugin starts the file watcher", async () => {
+    const { api, watch } = makeApi(true);
+    const cleanup = register(api);
+    await flush();
+    await flush();
+
+    expect(watch).toHaveBeenCalled();
+
+    if (typeof cleanup === "function") cleanup();
+  });
+});

--- a/src/stores/sftpSettingsStore.ts
+++ b/src/stores/sftpSettingsStore.ts
@@ -12,6 +12,10 @@ interface SftpSettingsStore {
   setEditorAutoSave: (v: boolean) => void;
   editorMaxBytes: number;
   setEditorMaxBytes: (n: number) => void;
+  /** Show dotfiles in file panes. Persisted so the choice sticks across panes,
+   *  sessions, and relaunches (as mainstream SFTP clients do). */
+  showHidden: boolean;
+  setShowHidden: (v: boolean) => void;
 }
 
 export const useSftpSettingsStore = create<SftpSettingsStore>()(
@@ -23,6 +27,8 @@ export const useSftpSettingsStore = create<SftpSettingsStore>()(
       setEditorAutoSave: (v) => { set({ editorAutoSave: v }); useAppSettingsTimestampStore.getState().touch(); },
       editorMaxBytes: DEFAULT_EDITOR_MAX_BYTES,
       setEditorMaxBytes: (n) => { set({ editorMaxBytes: n }); useAppSettingsTimestampStore.getState().touch(); },
+      showHidden: false,
+      setShowHidden: (v) => { set({ showHidden: v }); useAppSettingsTimestampStore.getState().touch(); },
     }),
     { name: "voltius-sftp-settings" },
   ),


### PR DESCRIPTION
Fixes #21.

## 1. SSH Config Sync & GitHub Gist Sync keep triggering while disabled

The plugin runtime's contract is that `register()` always runs and each plugin self-gates active-only work behind `api.isActive()` (documented on `setPluginActive`, with gist-sync as the reference implementation).

- **SSH Config Sync** never checked `api.isActive()`, so its `~/.ssh/config` file watcher and initial sync ran even when the plugin was toggled **off** — re-adding hosts/keys and firing toasts. Now the settings page registers unconditionally (so a disabled plugin can still be reviewed) and all active work is gated behind `isActive()`.
- **GitHub Gist Sync** self-gated its poll but **discarded** the `onBeforeQuit` unsubscribe, so a disabled plugin still pushed to the gist on every app quit. The unsubscribe is now captured and called in cleanup.

## 2. SFTP hidden files cannot be displayed

The backend returns dotfiles unfiltered; the only gate was a frontend `showHidden` flag that defaulted to `false`, lived in per-component `useState` (reset on every remount/navigation), and was reachable only via a non-obvious "View options" menu. Moved it into the persisted `sftpSettingsStore` so the choice sticks across panes, sessions, and relaunches (as mainstream SFTP clients do).

## Tests
- New `register.test.ts` for both plugins covering the disabled-state contract (no watcher/sync/quit-handler while disabled; settings page still available).
- `npx tsc --noEmit` clean; `npx vitest run` — 317 passed (+4 new).