### PR TITLE
fix(android): keep theme creator Save/Cancel out from under the status bar

### DIFF
--- a/src/components/theme-creator/ThemeCreator.tsx
+++ b/src/components/theme-creator/ThemeCreator.tsx
@@ -622,7 +622,12 @@ export default function ThemeCreator() {
       <div
         ref={panelRef}
         className="fixed right-0 top-0 bottom-0 z-200 flex flex-col border-l border-(--t-border) bg-(--t-bg-modal)"
-        style={{ width: 320 }}
+        style={{
+          width: 320,
+          paddingTop: "env(safe-area-inset-top)",
+          paddingBottom: "env(safe-area-inset-bottom)",
+          paddingRight: "env(safe-area-inset-right)",
+        }}
       >
         {/* Panel header */}
         <div className="flex items-center gap-2 px-4 py-3 shrink-0 border-b border-(--t-border)">


### PR DESCRIPTION
## Summary
- The theme creator panel (opened from Settings → Appearance → create/edit theme) was pinned with `position: fixed; top: 0`, unlike other full-screen mobile components (e.g. `MobileSettings.tsx`) which already inset themselves with `env(safe-area-inset-*)`.
- On Android (edge-to-edge WebView), this pushed the panel header — containing the pipette, Cancel, and Save buttons — underneath the system status bar, making Save/Cancel nearly impossible to tap.
- Added `env(safe-area-inset-top/bottom/right)` padding to the panel container, matching the existing pattern used elsewhere in the mobile UI.