### PR TITLE
fix(ssh): lost keystrokes inside sudo -i with shell integration enabled

### DIFF
--- a/src-tauri/src/shell_integration.rs
+++ b/src-tauri/src/shell_integration.rs
@@ -170,17 +170,26 @@ function global:prompt {\n\
 /// safe to send regardless of the remote login shell's syntax (fish/csh
 /// would otherwise choke on POSIX case/heredoc).
 ///
-/// The `</dev/tty` on every exec is load-bearing: when run via
+/// The `<&2` on every exec is load-bearing: when run via
 /// `echo b64 | base64 -d | sh`, the inner sh's stdin is the pipe from
-/// base64. After exec, the new shell inherits that already-closed pipe and
-/// would immediately exit on EOF (printing "exit" and looping reconnect).
-/// Reopening stdin from /dev/tty restores the real PTY.
+/// base64. After exec, the new shell would inherit that already-closed pipe
+/// and immediately exit on EOF (printing "exit" and looping reconnect).
+/// Duplicating stderr — which still holds the pty file description sshd
+/// created — restores the real PTY.
+///
+/// Do NOT reopen by path (`</dev/tty`): that creates a *different* file
+/// description of the tty, and sudo's `use_pty` mode (default on modern
+/// Ubuntu/Debian) then fails to recognize the shell's stdin as the user's
+/// terminal. Input handling splits between sudo's pty relay and the command,
+/// and most keystrokes are silently lost inside `sudo -i` (a key had to be
+/// pressed several times for one to register). Same reasoning as the
+/// persistent wrapper's `<&2` (see `persistent_exec_command`).
 ///
 /// The temp file leaks intentionally — /tmp is cleared on reboot, and trying
 /// to rm it from inside the rcfile races with bash/zsh reading it.
 const SSH_WRAPPER: &str = r#"case "$(basename "${SHELL:-/bin/sh}")" in
 zsh)
-  ZDOTDIR_TMP=$(mktemp -d 2>/dev/null) || exec zsh -l -i </dev/tty
+  ZDOTDIR_TMP=$(mktemp -d 2>/dev/null) || exec zsh -l -i <&2
   export ZDOTDIR_ORIG="${ZDOTDIR:-$HOME}"
   cat > "$ZDOTDIR_TMP/.zshenv" <<'EOF'
 if [ -n "${ZDOTDIR_ORIG-}" ]; then ZDOTDIR="$ZDOTDIR_ORIG"; else unset ZDOTDIR; fi
@@ -191,14 +200,14 @@ typeset -ag precmd_functions
 (($precmd_functions[(I)__voltius_pwd])) || precmd_functions+=(__voltius_pwd)
 __voltius_pwd 2>/dev/null
 EOF
-  ZDOTDIR="$ZDOTDIR_TMP" exec zsh -l -i </dev/tty
+  ZDOTDIR="$ZDOTDIR_TMP" exec zsh -l -i <&2
   ;;
 fish)
-  exec fish -l -i </dev/tty
+  exec fish -l -i <&2
   ;;
 *)
   if command -v bash >/dev/null 2>&1; then
-  RCFILE_TMP=$(mktemp 2>/dev/null) || exec bash -l -i </dev/tty
+  RCFILE_TMP=$(mktemp 2>/dev/null) || exec bash -l -i <&2
   cat > "$RCFILE_TMP" <<'EOF'
 # Replicate bash's own startup so the session matches a normal interactive
 # login: --rcfile otherwise skips /etc/profile, /etc/bash.bashrc and the
@@ -218,18 +227,18 @@ case ";${PROMPT_COMMAND-};" in
 esac
 __voltius_pwd 2>/dev/null
 EOF
-  exec bash --rcfile "$RCFILE_TMP" -i </dev/tty
+  exec bash --rcfile "$RCFILE_TMP" -i <&2
   else
   # No bash on the remote (busybox/dash-only host). Hooking OSC 7 into a POSIX
   # sh via an $ENV file keeps integration working; without this branch the
   # `exec bash` above would fail with 127, the sh would exit, and the session
   # would loop disconnect/reconnect.
-  ENVF=$(mktemp 2>/dev/null) || exec sh -i </dev/tty
+  ENVF=$(mktemp 2>/dev/null) || exec sh -i <&2
   cat > "$ENVF" <<'EOF'
 __voltius_pwd() { printf '\033]7;file://%s%s\007' "${HOSTNAME:-}" "$PWD"; }
 PS1='$(__voltius_pwd)'"${PS1:-$ }"
 EOF
-  ENV="$ENVF" exec sh -i </dev/tty
+  ENV="$ENVF" exec sh -i <&2
   fi
   ;;
 esac
@@ -545,7 +554,7 @@ const WSL_WRAPPER: &str = r#"WSL_DISTRO_NAME="${WSL_DISTRO_NAME:-Linux}"
 export WSL_DISTRO_NAME
 case "$(basename "${SHELL:-/bin/sh}")" in
 zsh)
-  ZDOTDIR_TMP=$(mktemp -d 2>/dev/null) || exec zsh -i </dev/tty
+  ZDOTDIR_TMP=$(mktemp -d 2>/dev/null) || exec zsh -i <&2
   export ZDOTDIR_ORIG="${ZDOTDIR:-$HOME}"
   cat > "$ZDOTDIR_TMP/.zshenv" <<'EOF'
 if [ -n "${ZDOTDIR_ORIG-}" ]; then ZDOTDIR="$ZDOTDIR_ORIG"; else unset ZDOTDIR; fi
@@ -556,13 +565,13 @@ typeset -ag precmd_functions
 (($precmd_functions[(I)__voltius_pwd])) || precmd_functions+=(__voltius_pwd)
 __voltius_pwd 2>/dev/null
 EOF
-  ZDOTDIR="$ZDOTDIR_TMP" exec zsh -i </dev/tty
+  ZDOTDIR="$ZDOTDIR_TMP" exec zsh -i <&2
   ;;
 fish)
-  exec fish -i -C 'function __voltius_wsl_pwd --on-event fish_prompt; printf "\e]7;file://wsl.localhost/%s%s\a" "$WSL_DISTRO_NAME" "$PWD"; end' </dev/tty
+  exec fish -i -C 'function __voltius_wsl_pwd --on-event fish_prompt; printf "\e]7;file://wsl.localhost/%s%s\a" "$WSL_DISTRO_NAME" "$PWD"; end' <&2
   ;;
 *)
-  RCFILE_TMP=$(mktemp 2>/dev/null) || exec bash -i </dev/tty
+  RCFILE_TMP=$(mktemp 2>/dev/null) || exec bash -i <&2
   cat > "$RCFILE_TMP" <<'EOF'
 [ -f "$HOME/.bashrc" ] && source "$HOME/.bashrc"
 __voltius_pwd() { printf '\e]7;file://wsl.localhost/%s%s\a' "$WSL_DISTRO_NAME" "$PWD"; }
@@ -572,7 +581,7 @@ case ";${PROMPT_COMMAND-};" in
 esac
 __voltius_pwd 2>/dev/null
 EOF
-  exec bash --rcfile "$RCFILE_TMP" -i </dev/tty
+  exec bash --rcfile "$RCFILE_TMP" -i <&2
   ;;
 esac
 "#;

--- a/src/components/settings/sections/AppearanceSection.tsx
+++ b/src/components/settings/sections/AppearanceSection.tsx
@@ -37,6 +37,7 @@ export default function AppearanceSection() {
   const pluginThemeMap = usePluginStore((s) => s.pluginThemes);
   const [scrollMinimapEnabled, setScrollMinimapEnabled] = useToggle("scroll-minimap");
   const [selectToCopy, setSelectToCopy] = useToggle("select-to-copy");
+  const [ignoreBracketedPaste, setIgnoreBracketedPaste] = useToggle("ignore-bracketed-paste");
   const scrollbackLines = useTerminalSettingsStore((s) => s.scrollbackLines);
   const setScrollbackLines = useTerminalSettingsStore((s) => s.setScrollbackLines);
 
@@ -123,6 +124,21 @@ export default function AppearanceSection() {
             )}
             {selectToCopy !== TOGGLE_DEFS["select-to-copy"].default && <DirtyDot />}
             <Toggle checked={selectToCopy} onChange={setSelectToCopy} />
+          </div>
+        </div>
+        <div className="group mt-4 rounded-xl bg-(--t-bg-card) border border-(--t-border) p-4 flex items-center justify-between gap-4">
+          <div>
+            <div className="text-sm font-medium text-(--t-text-primary)">{t("settings.appearance.ignoreBracketedPaste.title")}</div>
+            <div className="text-xs mt-1 text-(--t-text-dim)">
+              {t("settings.appearance.ignoreBracketedPaste.desc")}
+            </div>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            {ignoreBracketedPaste !== TOGGLE_DEFS["ignore-bracketed-paste"].default && (
+              <ResetButton onReset={() => setIgnoreBracketedPaste(TOGGLE_DEFS["ignore-bracketed-paste"].default)} />
+            )}
+            {ignoreBracketedPaste !== TOGGLE_DEFS["ignore-bracketed-paste"].default && <DirtyDot />}
+            <Toggle checked={ignoreBracketedPaste} onChange={setIgnoreBracketedPaste} />
           </div>
         </div>
       </div>

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -12,6 +12,7 @@ import { serialWrite, onSerialOutput, onSerialClosed } from "@/services/serial";
 import { useThemeStore } from "@/stores/themeStore";
 import { useUIStore } from "@/stores/uiStore";
 import { useTerminalSettingsStore } from "@/stores/terminalSettingsStore";
+import { getToggle, useToggleSettingsStore } from "@/stores/toggleSettingsStore";
 import { matchShortcut } from "@/stores/shortcutStore";
 import { useSessionStore } from "@/stores/sessionStore";
 import { useTerminalCwdStore } from "@/stores/terminalCwdStore";
@@ -662,6 +663,10 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
         theme: activeTheme.terminal,
         overviewRuler: { width: 4 },
         allowProposedApi: true,
+        // Some remote prompts/programs (e.g. sudo password entry) don't
+        // support bracketed paste and echo the \x1b[200~/201~ markers back
+        // literally, corrupting the buffer. Let users opt out entirely.
+        ignoreBracketedPasteMode: getToggle("ignore-bracketed-paste"),
       });
 
       const fitAddon = new FitAddon();
@@ -984,6 +989,15 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [sessionId, sessionType, encoding],
   );
+
+  // Live bracketed-paste toggle updates
+  useEffect(() => {
+    return useToggleSettingsStore.subscribe(() => {
+      const entry = terminalCache.get(sessionId);
+      if (!entry) return;
+      entry.terminal.options.ignoreBracketedPasteMode = getToggle("ignore-bracketed-paste");
+    });
+  }, [sessionId]);
 
   // Live theme updates
   useEffect(() => {

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -16,6 +16,10 @@
         "title": "Select to copy",
         "desc": "Show a copy button when text is selected in a terminal."
       },
+      "ignoreBracketedPaste": {
+        "title": "Plain paste (no bracketed paste)",
+        "desc": "Paste as plain text without the \\x1b[200~ / \\x1b[201~ markers. Fixes garbled input (e.g. \"200~\") when pasting into sudo prompts or CLI apps that don't support bracketed paste."
+      },
       "colorTheme": "Color Theme",
       "import": "Import",
       "importTitle": "Import theme(s)",
@@ -582,6 +586,7 @@
     "toggleDefs": {
       "scrollMinimap": { "label": "Scroll Minimap" },
       "selectToCopy": { "label": "Select to Copy" },
+      "ignoreBracketedPaste": { "label": "Plain Paste (No Bracketed Paste)" },
       "autoForward": { "label": "Automatic Port Forwarding" },
       "forwardingNotifications": { "label": "Port Forwarding Notifications" },
       "sftpTar": { "label": "SFTP Tar Acceleration" },

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -16,6 +16,10 @@
         "title": "Sélectionner pour copier",
         "desc": "Afficher un bouton de copie lorsqu'on sélectionne du texte dans un terminal."
       },
+      "ignoreBracketedPaste": {
+        "title": "Collage simple (sans collage entre crochets)",
+        "desc": "Coller en texte brut sans les marqueurs \\x1b[200~ / \\x1b[201~. Corrige un affichage corrompu (ex. « 200~ ») lors d'un collage dans un prompt sudo ou une application CLI qui ne prend pas en charge le collage entre crochets."
+      },
       "colorTheme": "Thème de couleurs",
       "import": "Importer",
       "importTitle": "Importer un ou plusieurs thèmes",
@@ -582,6 +586,7 @@
     "toggleDefs": {
       "scrollMinimap": { "label": "Minimap de défilement" },
       "selectToCopy": { "label": "Sélectionner pour copier" },
+      "ignoreBracketedPaste": { "label": "Collage simple (sans crochets)" },
       "autoForward": { "label": "Transfert de ports automatique" },
       "forwardingNotifications": { "label": "Notifications de transfert de ports" },
       "sftpTar": { "label": "Accélération Tar SFTP" },

--- a/src/stores/toggleSettingsStore.ts
+++ b/src/stores/toggleSettingsStore.ts
@@ -38,6 +38,13 @@ export const TOGGLE_DEFS = {
     keywords: ["copy", "select", "clipboard", "terminal", "auto"],
     default: true,
   },
+  "ignore-bracketed-paste": {
+    labelKey: "settings.toggleDefs.ignoreBracketedPaste.label",
+    icon: "lucide:clipboard-x",
+    descriptionKey: "settings.toggleDefs.category.appearance",
+    keywords: ["paste", "bracketed", "clipboard", "terminal", "sudo", "garbage", "200~"],
+    default: false,
+  },
   "auto-forward": {
     labelKey: "settings.toggleDefs.autoForward.label",
     icon: "lucide:arrow-left-right",


### PR DESCRIPTION
## Problem

With shell integration enabled (the default), typing inside `sudo -i` on hosts where sudo runs in `use_pty` mode (default on modern Ubuntu/Debian) loses most keystrokes: a key has to be pressed several times for one character to register, Backspace behaves the same way, and pasting arrives garbled (literal `200~`/`201~` fragments). Outside `sudo` the same session types perfectly, and other SSH clients are unaffected on the same host.

## Root cause

The SSH/WSL shell-integration wrappers re-attached the final shell's stdin by reopening the terminal **by path** (`</dev/tty`). That yields a *different file description* of the tty. sudo's `use_pty` relay then fails to recognize the shell's stdin as the user's terminal, input handling splits between sudo's pty relay and the command, and each keystroke races between two readers — most lose.

Confirmed bidirectionally on Ubuntu:
- in a broken session, `exec bash -i <&2` fixes typing under `sudo -i`;
- in a healthy session, `exec bash -i </dev/tty` reproduces the loss.

Diagnostic logging also confirmed the client sends every byte exactly once (sudo password entry — canonical mode — was always lossless; loss started exactly when the raw-mode pty relay took over).

## Fix

Duplicate the inherited stderr descriptor (`<&2`) instead — stderr still holds the pty file description sshd created. This matches what the persistent (tmux/screen) wrapper already does, where reopening by path was independently documented as breaking modern tmux. Applied to all `SSH_WRAPPER` and `WSL_WRAPPER` branches (bash/zsh/fish/sh).

## Also included

`feat(terminal)`: an off-by-default **Plain paste** toggle (xterm.js `ignoreBracketedPasteMode`) for remote endpoints that advertise bracketed paste but mishandle it — serial consoles, legacy network gear, minimal busybox shells. No behavior change unless enabled.

## Testing

- `cargo test shell_integration` — 14 passed
- `cargo fmt --all --check` — clean
- `vitest run` — 317 passed (87 files)
- Manually verified on Ubuntu over SSH: `sudo -i` typing/Backspace/paste now correct with shell integration and persistent sessions enabled; plain `request_shell` sessions unchanged