### PR TITLE
fix(hosts): stop cross-device & team session card shadows clipping at the scroll edge

### DIFF
--- a/src/components/hosts/RemoteDeviceSessions.tsx
+++ b/src/components/hosts/RemoteDeviceSessions.tsx
@@ -38,7 +38,7 @@ export function RemoteDeviceSessions() {
         </p>
       </div>
 
-      <div className="flex gap-3 overflow-x-auto pb-1" style={{ scrollbarWidth: "none" }}>
+      <div className="flex gap-3 overflow-x-auto p-8 -m-8" style={{ scrollbarWidth: "none" }}>
         {joinable.map((a) => (
           <BaseCard
             key={a.sessionId}

--- a/src/components/hosts/TeamSessions.tsx
+++ b/src/components/hosts/TeamSessions.tsx
@@ -236,7 +236,7 @@ export function TeamSessions() {
 
       {showJoinModal && <JoinByCodeModal />}
 
-      <div className="flex gap-3 overflow-x-auto pb-1" style={{ scrollbarWidth: "none" }}>
+      <div className="flex gap-3 overflow-x-auto p-8 -m-8" style={{ scrollbarWidth: "none" }}>
         {activeSessions.map((session) => {
           const alreadyIn = myMpSessionIds.has(session.id);
 


### PR DESCRIPTION
Fixes the "Active on other devices" card shadow clipping reported by @ezhkov-ph in #30, and the identical issue on the adjacent Team Sessions strip.

## Problem
The horizontal card strips in `RemoteDeviceSessions` and `TeamSessions` used `overflow-x-auto pb-1`. `overflow-x: auto` forces `overflow-y` to compute to `auto` as well, so the container clips the cards' `box-shadow` on **every** side — with only `pb-1` (4px) of room there was nowhere for the shadow to render. On strong-shadow themes (like the reporter's custom theme) this left a hard rectangular cut around the cards.

## Fix
One line per strip: give the scroll container generous padding for shadow room and cancel it with an equal negative margin, so the shadow has space to render while the cards' layout position is unchanged.

```diff
- <div className="flex gap-3 overflow-x-auto pb-1" ...>
+ <div className="flex gap-3 overflow-x-auto p-8 -m-8" ...>
```

Applied to both `hosts/RemoteDeviceSessions.tsx` and `hosts/TeamSessions.tsx` (adjacent sections in the same `HostsPage`, same parent padding).

- Layout-neutral: padding ↔ negative margin cancel, so nothing shifts.
- Interactivity-safe: the transparent padding overlaps only non-interactive neighbours, and following sections render above it.
- 32px comfortably clears strong custom-theme shadows.

## Verification
- Reproduced and fixed live in a dev build on `RemoteDeviceSessions` (before: hard clip; after: smooth fade, positions unchanged) — screenshots shared with the maintainer. `TeamSessions` is the identical layout/card/parent, so the same fix behaves identically.
- `tsc --noEmit` clean; full suite green.

## Follow-up (not in this PR)
`MobileRemoteDeviceSessions.tsx` has the same `overflow-x-auto` pattern but a tighter parent (`px-3`), so it needs its own sizing + verification — deferred to a separate change.

Not affected (checked): `FilePane`, `EditorTabStrip`, `TitleBar`, `MobileTerminalTopBar` — their `box-shadow`s are inset rings / focus outlines, which don't clip.
