### PR TITLE
feat(ssh-config): adopt matching connections instead of creating duplicates

### DIFF
--- a/src/plugins/ssh-config/index.ts
+++ b/src/plugins/ssh-config/index.ts
@@ -168,7 +168,7 @@ async function ensureKey(
   return key.id;
 }
 
-async function sync(api: PluginAPI): Promise<void> {
+export async function sync(api: PluginAPI): Promise<void> {
   const exists = await api.fs.exists(SSH_CONFIG_PATH);
   if (!exists) return;
 

--- a/src/plugins/ssh-config/index.ts
+++ b/src/plugins/ssh-config/index.ts
@@ -396,15 +396,18 @@ function createSettingsComponent(api: PluginAPI): React.FC {
   return function SshConfigSettings() {
     const [intervalMs, setIntervalMs] = useState<number>(DEFAULT_POLL_INTERVAL);
     const [notificationsEnabled, setNotificationsEnabled] = useState<boolean>(DEFAULT_NOTIFICATIONS_ENABLED);
+    const [adoptEnabled, setAdoptEnabled] = useState<boolean>(DEFAULT_ADOPT_UNTAGGED_ENABLED);
     const [syncing, setSyncing] = useState(false);
 
     useEffect(() => {
       void Promise.all([
         api.storage.get<number>(POLL_INTERVAL_KEY),
         api.storage.get<boolean>(NOTIFICATIONS_ENABLED_KEY),
-      ]).then(([interval, notify]) => {
+        api.storage.get<boolean>(ADOPT_UNTAGGED_ENABLED_KEY),
+      ]).then(([interval, notify, adopt]) => {
         if (interval != null) setIntervalMs(interval);
         if (notify != null) setNotificationsEnabled(notify);
+        if (adopt != null) setAdoptEnabled(adopt);
       });
     }, []);
 
@@ -419,6 +422,12 @@ function createSettingsComponent(api: PluginAPI): React.FC {
       const next = !notificationsEnabled;
       setNotificationsEnabled(next);
       void api.storage.set(NOTIFICATIONS_ENABLED_KEY, next);
+    };
+
+    const handleAdoptToggle = () => {
+      const next = !adoptEnabled;
+      setAdoptEnabled(next);
+      void api.storage.set(ADOPT_UNTAGGED_ENABLED_KEY, next);
     };
 
     const handleSyncNow = () => {
@@ -440,26 +449,26 @@ function createSettingsComponent(api: PluginAPI): React.FC {
       color: "var(--t-text-primary)",
       outline: "none",
     };
-    const toggleTrackStyle = {
+    const toggleTrack = (on: boolean) => ({
       width: 36,
       height: 20,
       borderRadius: 10,
-      background: notificationsEnabled ? "var(--t-accent)" : "var(--t-border)",
+      background: on ? "var(--t-accent)" : "var(--t-border)",
       position: "relative" as const,
       cursor: "pointer",
       transition: "background 0.15s",
       flexShrink: 0,
-    };
-    const toggleThumbStyle = {
+    });
+    const toggleThumb = (on: boolean) => ({
       position: "absolute" as const,
       top: 2,
-      left: notificationsEnabled ? 18 : 2,
+      left: on ? 18 : 2,
       width: 16,
       height: 16,
       borderRadius: "50%",
       background: "white",
       transition: "left 0.15s",
-    };
+    });
     const syncBtnStyle = {
       ...inputStyle,
       padding: "4px 12px",
@@ -532,8 +541,28 @@ function createSettingsComponent(api: PluginAPI): React.FC {
             ),
             React.createElement(
               "div",
-              { style: toggleTrackStyle, onClick: handleNotificationsToggle },
-              React.createElement("div", { style: toggleThumbStyle })
+              { style: toggleTrack(notificationsEnabled), onClick: handleNotificationsToggle },
+              React.createElement("div", { style: toggleThumb(notificationsEnabled) })
+            )
+          ),
+          divider,
+          React.createElement(
+            "div",
+            { className: "flex items-center justify-between" },
+            React.createElement(
+              "div",
+              null,
+              React.createElement("p", { className: "text-sm font-medium", style: labelStyle }, "Adopt matching connections"),
+              React.createElement(
+                "p",
+                { className: "text-xs mt-0.5", style: dimStyle },
+                "Reuse an existing connection (same host, port, and user) instead of creating a duplicate. Your label and auth stay untouched, and adopted connections are never auto-deleted."
+              )
+            ),
+            React.createElement(
+              "div",
+              { style: toggleTrack(adoptEnabled), onClick: handleAdoptToggle },
+              React.createElement("div", { style: toggleThumb(adoptEnabled) })
             )
           )
         )

--- a/src/plugins/ssh-config/index.ts
+++ b/src/plugins/ssh-config/index.ts
@@ -188,6 +188,7 @@ export async function sync(api: PluginAPI): Promise<void> {
   const keyMap: KeyMap = (await api.storage.get<KeyMap>(KEY_MAP_KEY)) ?? {};
   const identityMap: IdentityMap = (await api.storage.get<IdentityMap>(IDENTITY_MAP_KEY)) ?? {};
   const notifyEnabled = (await api.storage.get<boolean>(NOTIFICATIONS_ENABLED_KEY)) ?? DEFAULT_NOTIFICATIONS_ENABLED;
+  const adoptEnabled = (await api.storage.get<boolean>(ADOPT_UNTAGGED_ENABLED_KEY)) ?? DEFAULT_ADOPT_UNTAGGED_ENABLED;
 
   // Hosts present in the config file (keyed by alias)
   const configAliases = new Set(hosts.map((h) => h.alias));
@@ -213,6 +214,58 @@ export async function sync(api: PluginAPI): Promise<void> {
 
   // ── Add/update connections for each host in the config ──────────────────
   for (const host of hosts) {
+    // Resolve the existing connection first — an adopted (untagged) match skips
+    // key/identity work and preserves the user's fields, so the decision comes
+    // before any key/identity creation.
+    const existingId = aliasMap[host.alias];
+    // aliasMap is authoritative: search ALL connections by id so a previously
+    // adopted (untagged) connection is always re-found. The content fallback
+    // stays scoped to tagged connections unless adoption is enabled.
+    let existing =
+      (existingId ? allConnections.find((c) => c.id === existingId) : undefined) ??
+      taggedConnections.find(
+        (c) =>
+          c.host === host.hostname &&
+          c.port === host.port &&
+          c.username === host.user,
+      );
+
+    // Adoption: reuse an untagged user connection that matches by host/port/user
+    // instead of creating a duplicate. First match wins.
+    if (!existing && adoptEnabled) {
+      existing = allConnections.find(
+        (c) =>
+          !c.tags.includes(SSH_CONFIG_TAG) &&
+          c.host === host.hostname &&
+          c.port === host.port &&
+          c.username === host.user,
+      );
+    }
+
+    // A managed connection that is untagged can only be an adopted one.
+    const adopted = !!existing && !existing.tags.includes(SSH_CONFIG_TAG);
+
+    if (existing) {
+      aliasMap[host.alias] = existing.id;
+    }
+
+    // Adopted: preserve the user's fields; only propagate host/port/user changes.
+    if (adopted && existing) {
+      const changed =
+        existing.host !== host.hostname ||
+        existing.port !== host.port ||
+        existing.username !== host.user;
+      if (changed) {
+        await api.connections.update(existing.id, {
+          host: host.hostname,
+          port: host.port,
+          username: host.user,
+        });
+      }
+      continue;
+    }
+
+    // Plugin-managed: ensure key/identity, then create or fully update.
     let identityId: string | undefined;
     if (host.identityFile) {
       const keyId = await ensureKey(api, host.identityFile, keyMap, allKeys, notifyEnabled);
@@ -226,7 +279,6 @@ export async function sync(api: PluginAPI): Promise<void> {
           }
         }
         if (!identityId) {
-          // Fallback: reuse existing identity if the map was lost/stale
           const existingIdentity = allIdentities.find(
             (i) => i.name === host.alias && i.username === host.user && i.key_id === keyId,
           );
@@ -246,23 +298,6 @@ export async function sync(api: PluginAPI): Promise<void> {
           }
         }
       }
-    }
-
-    const existingId = aliasMap[host.alias];
-    // Always try both the stored ID and the content-based fallback so that a
-    // stale/cleared map never bypasses dedup.
-    const existing =
-      (existingId ? taggedConnections.find((c) => c.id === existingId) : undefined) ??
-      taggedConnections.find(
-        (c) =>
-          c.host === host.hostname &&
-          c.port === host.port &&
-          c.username === host.user,
-      );
-
-    // Keep aliasMap in sync with the actual connection id
-    if (existing) {
-      aliasMap[host.alias] = existing.id;
     }
 
     const data: PluginConnectionInput = {
@@ -348,6 +383,8 @@ const POLL_INTERVAL_KEY = "poll_interval_ms";
 const DEFAULT_POLL_INTERVAL = 5000;
 const NOTIFICATIONS_ENABLED_KEY = "notifications_enabled";
 const DEFAULT_NOTIFICATIONS_ENABLED = true;
+const ADOPT_UNTAGGED_ENABLED_KEY = "adopt_untagged_enabled";
+const DEFAULT_ADOPT_UNTAGGED_ENABLED = true;
 const RESTART_EVENT = "ssh-config:restart-watcher";
 const SYNC_NOW_EVENT = "ssh-config:sync-now";
 

--- a/src/plugins/ssh-config/index.ts
+++ b/src/plugins/ssh-config/index.ts
@@ -341,6 +341,10 @@ export async function sync(api: PluginAPI): Promise<void> {
     const connId = aliasMap[host.alias];
     if (!connId) continue;
 
+    // Never overwrite jump_hosts on an adopted (untagged) user connection.
+    const targetConn = allConnectionsNow.find((c) => c.id === connId);
+    if (targetConn && !targetConn.tags.includes(SSH_CONFIG_TAG)) continue;
+
     const hops = host.proxyJump.split(",").map((h) => h.trim()).filter(Boolean);
     const jumpHosts: JumpHost[] = [];
 

--- a/src/plugins/ssh-config/sync.test.ts
+++ b/src/plugins/ssh-config/sync.test.ts
@@ -181,6 +181,23 @@ describe("ssh-config sync — adoption", () => {
     const created = h.connections.find((c) => c.id.startsWith("gen-"))!;
     expect(created.tags).toContain(TAG);
   });
+
+  test("an adopted match with an IdentityFile still skips key/identity creation", async () => {
+    const h = makeSyncApi({
+      config: cfg("Oracle", "1.2.3.4", "ubuntu", 22, "  IdentityFile ~/.ssh/id_ed25519\n"),
+      connections: [
+        conn({ id: "user-1", name: "Serv Oracle", host: "1.2.3.4", port: 22, username: "ubuntu", auth_type: "password", tags: [] }),
+      ],
+    });
+    await sync(h.api);
+    expect(h.api.keys.create).not.toHaveBeenCalled();
+    expect(h.api.identities.create).not.toHaveBeenCalled();
+    expect(h.create).not.toHaveBeenCalled();
+    const c = h.connections.find((x) => x.id === "user-1")!;
+    expect(c.tags).toEqual([]);
+    expect(c.auth_type).toBe("password");
+    expect(c.identity_id).toBeUndefined();
+  });
 });
 
 describe("ssh-config sync — ProxyJump + adoption", () => {
@@ -203,6 +220,27 @@ describe("ssh-config sync — ProxyJump + adoption", () => {
     expect(app.jump_hosts).toBeUndefined();
     const jumpWrites = h.update.mock.calls.filter(([, data]) => "jump_hosts" in (data as object));
     expect(jumpWrites).toHaveLength(0);
+  });
+
+  test("writes jump_hosts onto a plugin-created (tagged) connection", async () => {
+    const h = makeSyncApi({
+      config:
+        cfg("bastion", "bastion.com", "root") +
+        cfg("app", "app.com", "ubuntu", 22, "  ProxyJump bastion\n"),
+      connections: [],
+    });
+    await sync(h.api);
+
+    const bastion = h.connections.find((c) => c.name === "bastion")!;
+    const app = h.connections.find((c) => c.name === "app")!;
+    expect(bastion.tags).toContain(TAG);
+    expect(app.tags).toContain(TAG);
+
+    const jumpWrites = h.update.mock.calls.filter(
+      ([id, data]) => id === app.id && "jump_hosts" in (data as object),
+    );
+    expect(jumpWrites).toHaveLength(1);
+    expect(app.jump_hosts?.[0]?.connection_id).toBe(bastion.id);
   });
 });
 

--- a/src/plugins/ssh-config/sync.test.ts
+++ b/src/plugins/ssh-config/sync.test.ts
@@ -182,3 +182,26 @@ describe("ssh-config sync — adoption", () => {
     expect(created.tags).toContain(TAG);
   });
 });
+
+describe("ssh-config sync — ProxyJump + adoption", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("does not write jump_hosts onto an adopted connection", async () => {
+    const h = makeSyncApi({
+      config:
+        cfg("bastion", "bastion.com", "root") +
+        cfg("app", "app.com", "ubuntu", 22, "  ProxyJump bastion\n"),
+      connections: [
+        conn({ id: "user-b", name: "Bastion", host: "bastion.com", port: 22, username: "root", tags: [] }),
+        conn({ id: "user-a", name: "App", host: "app.com", port: 22, username: "ubuntu", tags: [] }),
+      ],
+    });
+    await sync(h.api);
+    // Both hosts adopted; the plugin must not write jump_hosts onto the adopted connection,
+    // even though ProxyJump resolves to another adopted host.
+    const app = h.connections.find((c) => c.id === "user-a")!;
+    expect(app.jump_hosts).toBeUndefined();
+    const jumpWrites = h.update.mock.calls.filter(([, data]) => "jump_hosts" in (data as object));
+    expect(jumpWrites).toHaveLength(0);
+  });
+});

--- a/src/plugins/ssh-config/sync.test.ts
+++ b/src/plugins/ssh-config/sync.test.ts
@@ -149,6 +149,8 @@ describe("ssh-config sync — adoption", () => {
     expect(h.api.keys.create).not.toHaveBeenCalled();
     expect(h.api.identities.create).not.toHaveBeenCalled();
     expect(h.update).not.toHaveBeenCalled(); // host/port/user already match → no-op
+    expect(h.create).not.toHaveBeenCalled();
+    expect(h.connections).toHaveLength(1);
   });
 
   test("first untagged match wins; the rest are left untouched", async () => {

--- a/src/plugins/ssh-config/sync.test.ts
+++ b/src/plugins/ssh-config/sync.test.ts
@@ -241,6 +241,7 @@ describe("ssh-config sync — adopted connection lifecycle", () => {
     });
     await sync(h.api);
     vi.clearAllMocks();
+    h.store.set("adopt_untagged_enabled", false); // isolate the alias_map id-based re-find from the content fallback
     await sync(h.api);
     expect(h.create).not.toHaveBeenCalled();
     expect(h.connections).toHaveLength(1);

--- a/src/plugins/ssh-config/sync.test.ts
+++ b/src/plugins/ssh-config/sync.test.ts
@@ -113,3 +113,70 @@ describe("ssh-config sync — baseline behavior (characterization)", () => {
     expect(h.connections).toHaveLength(1);
   });
 });
+
+describe("ssh-config sync — adoption", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("adopts an untagged match instead of creating a duplicate", async () => {
+    const h = makeSyncApi({
+      config: cfg("Oracle", "1.2.3.4", "ubuntu"),
+      connections: [
+        conn({ id: "user-1", name: "Serv Oracle", host: "1.2.3.4", port: 22, username: "ubuntu", tags: [] }),
+      ],
+    });
+    await sync(h.api);
+    expect(h.create).not.toHaveBeenCalled();
+    expect(h.connections).toHaveLength(1);
+    expect(h.store.get("alias_map")).toEqual({ Oracle: "user-1" });
+  });
+
+  test("preserves the user's label, auth, identity and tags; creates no key/identity", async () => {
+    const h = makeSyncApi({
+      config: cfg("Oracle", "1.2.3.4", "ubuntu"),
+      connections: [
+        conn({
+          id: "user-1", name: "Serv Oracle", host: "1.2.3.4", port: 22, username: "ubuntu",
+          auth_type: "key", identity_id: "id-9", tags: [],
+        }),
+      ],
+    });
+    await sync(h.api);
+    const c = h.connections[0];
+    expect(c.name).toBe("Serv Oracle");
+    expect(c.auth_type).toBe("key");
+    expect(c.identity_id).toBe("id-9");
+    expect(c.tags).toEqual([]);
+    expect(h.api.keys.create).not.toHaveBeenCalled();
+    expect(h.api.identities.create).not.toHaveBeenCalled();
+    expect(h.update).not.toHaveBeenCalled(); // host/port/user already match → no-op
+  });
+
+  test("first untagged match wins; the rest are left untouched", async () => {
+    const h = makeSyncApi({
+      config: cfg("Oracle", "1.2.3.4", "ubuntu"),
+      connections: [
+        conn({ id: "user-1", name: "First", host: "1.2.3.4", port: 22, username: "ubuntu", tags: [] }),
+        conn({ id: "user-2", name: "Second", host: "1.2.3.4", port: 22, username: "ubuntu", tags: [] }),
+      ],
+    });
+    await sync(h.api);
+    expect(h.create).not.toHaveBeenCalled();
+    expect(h.connections).toHaveLength(2);
+    expect(h.store.get("alias_map")).toEqual({ Oracle: "user-1" });
+  });
+
+  test("setting OFF ignores the untagged connection and creates a tagged duplicate", async () => {
+    const h = makeSyncApi({
+      config: cfg("Oracle", "1.2.3.4", "ubuntu"),
+      connections: [
+        conn({ id: "user-1", name: "Serv Oracle", host: "1.2.3.4", port: 22, username: "ubuntu", tags: [] }),
+      ],
+      storage: { adopt_untagged_enabled: false },
+    });
+    await sync(h.api);
+    expect(h.create).toHaveBeenCalledTimes(1);
+    expect(h.connections).toHaveLength(2);
+    const created = h.connections.find((c) => c.id.startsWith("gen-"))!;
+    expect(created.tags).toContain(TAG);
+  });
+});

--- a/src/plugins/ssh-config/sync.test.ts
+++ b/src/plugins/ssh-config/sync.test.ts
@@ -1,0 +1,115 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { sync } from "./index";
+import type { PluginAPI, PluginConnection, PluginConnectionInput } from "@/plugins/api";
+
+const TAG = "ssh-config";
+
+interface HarnessOpts {
+  config: string;
+  connections?: PluginConnection[];
+  storage?: Record<string, unknown>;
+}
+
+// Stateful mock: a mutable connection list backed by create/update/delete, a
+// Map-backed storage, and a swappable ~/.ssh/config for multi-sync tests.
+function makeSyncApi(opts: HarnessOpts) {
+  const connections: PluginConnection[] = (opts.connections ?? []).map((c) => ({ ...c }));
+  const store = new Map<string, unknown>(Object.entries(opts.storage ?? {}));
+  let config = opts.config;
+  let idSeq = 1000;
+
+  const create = vi.fn(async (data: PluginConnectionInput) => {
+    const conn: PluginConnection = {
+      id: `gen-${idSeq++}`,
+      name: data.name,
+      host: data.host,
+      port: data.port,
+      username: data.username,
+      auth_type: data.auth_type,
+      tags: data.tags ?? [],
+      identity_id: data.identity_id,
+      jump_hosts: data.jump_hosts,
+    };
+    connections.push(conn);
+    return { ...conn };
+  });
+  const update = vi.fn(async (id: string, data: Partial<PluginConnectionInput>) => {
+    const c = connections.find((x) => x.id === id);
+    if (c) Object.assign(c, data);
+  });
+  const del = vi.fn(async (id: string) => {
+    const i = connections.findIndex((x) => x.id === id);
+    if (i >= 0) connections.splice(i, 1);
+  });
+
+  const api = {
+    isActive: () => true,
+    fs: {
+      exists: vi.fn(async (p: string) => p === "~/.ssh/config"),
+      readText: vi.fn(async () => config),
+      writeText: vi.fn(async () => {}),
+      watch: vi.fn(() => () => {}),
+    },
+    connections: {
+      list: vi.fn(async () => connections.map((c) => ({ ...c }))),
+      create,
+      update,
+      delete: del,
+    },
+    keys: { list: vi.fn(async () => []), create: vi.fn(), delete: vi.fn() },
+    identities: { list: vi.fn(async () => []), create: vi.fn(), delete: vi.fn() },
+    storage: {
+      get: vi.fn(async (k: string) => (store.has(k) ? store.get(k) : null)),
+      set: vi.fn(async (k: string, v: unknown) => { store.set(k, v); }),
+      delete: vi.fn(async (k: string) => { store.delete(k); }),
+    },
+    notifications: { toast: vi.fn() },
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as unknown as PluginAPI;
+
+  return {
+    api,
+    connections,
+    store,
+    create,
+    update,
+    del,
+    setConfig: (c: string) => { config = c; },
+  };
+}
+
+const cfg = (alias: string, host: string, user: string, port = 22, extra = "") =>
+  `Host ${alias}\n  HostName ${host}\n  User ${user}\n  Port ${port}\n${extra}`;
+
+const conn = (over: Partial<PluginConnection> & { id: string }): PluginConnection => ({
+  name: undefined,
+  host: "h",
+  port: 22,
+  username: "u",
+  auth_type: "password",
+  tags: [],
+  ...over,
+});
+
+describe("ssh-config sync — baseline behavior (characterization)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("no ~/.ssh/config → early return, no connection reads", async () => {
+    const h = makeSyncApi({ config: "" });
+    (h.api.fs.exists as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    await sync(h.api);
+    expect(h.api.connections.list).not.toHaveBeenCalled();
+  });
+
+  test("a tagged connection matching a config host is not duplicated", async () => {
+    const h = makeSyncApi({
+      config: cfg("Oracle", "1.2.3.4", "ubuntu"),
+      connections: [
+        conn({ id: "t-1", name: "Oracle", host: "1.2.3.4", port: 22, username: "ubuntu", tags: [TAG] }),
+      ],
+    });
+    await sync(h.api);
+    expect(h.create).not.toHaveBeenCalled();
+    expect(h.connections).toHaveLength(1);
+  });
+});

--- a/src/plugins/ssh-config/sync.test.ts
+++ b/src/plugins/ssh-config/sync.test.ts
@@ -228,3 +228,43 @@ describe("ssh-config sync — adopted connections are never deleted", () => {
     expect(h.store.get("alias_map")).toEqual({});
   });
 });
+
+describe("ssh-config sync — adopted connection lifecycle", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("re-finds the adopted connection on a second sync (no duplicate)", async () => {
+    const h = makeSyncApi({
+      config: cfg("Oracle", "1.2.3.4", "ubuntu"),
+      connections: [
+        conn({ id: "user-1", name: "Serv Oracle", host: "1.2.3.4", port: 22, username: "ubuntu", tags: [] }),
+      ],
+    });
+    await sync(h.api);
+    vi.clearAllMocks();
+    await sync(h.api);
+    expect(h.create).not.toHaveBeenCalled();
+    expect(h.connections).toHaveLength(1);
+  });
+
+  test("propagates host/port config edits to the adopted connection, nothing else", async () => {
+    const h = makeSyncApi({
+      config: cfg("Oracle", "1.2.3.4", "ubuntu"),
+      connections: [
+        conn({ id: "user-1", name: "Serv Oracle", host: "1.2.3.4", port: 22, username: "ubuntu", tags: [] }),
+      ],
+    });
+    await sync(h.api);
+    vi.clearAllMocks();
+    h.setConfig(cfg("Oracle", "5.6.7.8", "ubuntu", 2222));
+    await sync(h.api);
+
+    const c = h.connections.find((x) => x.id === "user-1")!;
+    expect(c.host).toBe("5.6.7.8");
+    expect(c.port).toBe(2222);
+    expect(c.name).toBe("Serv Oracle"); // untouched
+    expect(c.tags).toEqual([]);         // still untagged
+    // The only write is the host/port/user update.
+    expect(h.update).toHaveBeenCalledTimes(1);
+    expect(h.update.mock.calls[0][1]).toEqual({ host: "5.6.7.8", port: 2222, username: "ubuntu" });
+  });
+});

--- a/src/plugins/ssh-config/sync.test.ts
+++ b/src/plugins/ssh-config/sync.test.ts
@@ -205,3 +205,26 @@ describe("ssh-config sync — ProxyJump + adoption", () => {
     expect(jumpWrites).toHaveLength(0);
   });
 });
+
+describe("ssh-config sync — adopted connections are never deleted", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("removing the alias from config keeps the adopted connection, clears alias_map", async () => {
+    const h = makeSyncApi({
+      config: cfg("Oracle", "1.2.3.4", "ubuntu"),
+      connections: [
+        conn({ id: "user-1", name: "Serv Oracle", host: "1.2.3.4", port: 22, username: "ubuntu", tags: [] }),
+      ],
+    });
+    await sync(h.api);
+    expect(h.store.get("alias_map")).toEqual({ Oracle: "user-1" });
+
+    vi.clearAllMocks();
+    h.setConfig(""); // alias removed from config
+    await sync(h.api);
+
+    expect(h.del).not.toHaveBeenCalled();
+    expect(h.connections.some((c) => c.id === "user-1")).toBe(true);
+    expect(h.store.get("alias_map")).toEqual({});
+  });
+});


### PR DESCRIPTION
## What & why

The **SSH Config Sync** plugin scopes its deduplication to connections it owns (those tagged `ssh-config`). A connection you created by hand — e.g. "Serv Oracle" — is untagged, so the plugin can't see it and creates a duplicate ("Oracle") when the same server appears in `~/.ssh/config`. This adds an opt-out setting (**on by default**) that lets the plugin **adopt** a matching untagged connection instead of duplicating it.

Closes the duplicate-on-import behavior reported for hosts that already exist in Voltius under a different label.

## Behavior

When a config host matches an existing **untagged** connection by `host` + `port` + `username`:
- The plugin **reuses** it instead of creating a duplicate.
- It's **gentle**: your label, auth type, identity, tags, and `jump_hosts` are preserved. Only `host`/`port`/`username` edits from the config propagate.
- Adopted connections are **never auto-deleted** — even if the alias later disappears from `~/.ssh/config`.
- If several untagged connections match, the **first wins** (deterministic).

## Design notes

- **Adoption is derived from the tag**, not persisted separately: plugin-created connections are tagged `ssh-config`; adopted ones are deliberately left untagged. So there's **no new storage state**, and "never delete" is *structural* — the removal pass only ever touches tagged connections.
- The setting gates only the untagged content-fallback search; the `alias_map` by-id lookup is unconditional, so already-adopted connections stay managed even if the setting is later turned off.
- The ProxyJump second pass is guarded so it never overwrites an adopted connection's `jump_hosts`.

New setting: **Settings → SSH Config Sync → "Adopt matching connections"** (on by default).

## Tests

New `sync.test.ts` (stateful mock harness) — 14 tests covering: adoption match/no-duplicate, field preservation, first-match-wins, setting-off duplicate, never-delete, re-find on second sync (isolated from the content fallback), host/port propagation, ProxyJump-not-overwritten-on-adopted vs written-on-tagged, and adopted-host-with-IdentityFile skip. `npx vitest run src/plugins/ssh-config/` → 14/14; `tsc --noEmit` clean.

## Not yet verified

The new settings **toggle has not been clicked in a running app** — the headless UI environment was unavailable this session. The `sync()` adoption logic is fully unit-tested; the UI is a straightforward mirror of the existing Notifications toggle, but the render/persist behavior is unverified live.
