### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 (GHSA-4w2j-m93h-cj5j)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4917,9 +4917,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
Closes Dependabot alert #29 (high).

`quinn-proto` < 0.11.15 is vulnerable to remote memory exhaustion via unbounded out-of-order stream reassembly (GHSA-4w2j-m93h-cj5j).

Transitive dependency: `reqwest` -> `quinn` -> `quinn-proto`. Lockfile-only patch bump, no manifest or source changes.

Verified with `cargo check --manifest-path src-tauri/Cargo.toml --locked` (green, lockfile unchanged by the check).

The three open `russh` alerts (GHSA-5xvq-cp9x-6p6r, GHSA-g9hv-x236-4qp3, GHSA-cqjc-rmpq-xprq) are already fixed on `dev` at 0.62.4 and will close once `dev` reaches `main`.