### PR TITLE
fix: instant hide the window and proces in background

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",
+    "core:window:allow-hide",
     {
       "identifier": "opener:allow-open-url",
       "allow": [

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -184,6 +184,7 @@ async function ensureQuitHandler() {
   const win = getCurrentWindow();
   await win.onCloseRequested(async (event) => {
     event.preventDefault();
+    win.hide().catch(() => {});
     const callbacks = [..._onBeforeQuit];
     await Promise.race([
       Promise.allSettled(callbacks.map((cb) => cb())),


### PR DESCRIPTION
This pull request introduces improvements to window management permissions and the quit handler behavior in the application. The main focus is on allowing the window to be hidden and ensuring the window is hidden before executing quit logic.

**Window management enhancements:**

* Added the `core:window:allow-hide` capability to the `default.json` configuration, enabling the application to programmatically hide the window.

**Quit handler improvements:**

* Updated the `ensureQuitHandler` function in `runtime.ts` to call `win.hide()` when a close is requested, ensuring the window is hidden before running quit callbacks.