### PR TITLE
fix(plugins): hide the window before running quit hooks (#94)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",
+    "core:window:allow-hide",
     {
       "identifier": "opener:allow-open-url",
       "allow": [

--- a/src/plugins/runtime.quitHandler.test.ts
+++ b/src/plugins/runtime.quitHandler.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { loadPlugin, unloadPlugin } from "./runtime";
+import type { PluginAPI, PluginManifest } from "./api";
+
+type CloseHandler = (event: { preventDefault: () => void }) => unknown;
+
+const { closeHandlers, hide, invoke } = vi.hoisted(() => ({
+  closeHandlers: [] as CloseHandler[],
+  hide: vi.fn(() => Promise.resolve()),
+  invoke: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    hide,
+    onCloseRequested: (cb: CloseHandler) => {
+      closeHandlers.push(cb);
+      return Promise.resolve(() => {});
+    },
+  }),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+
+function manifest(id: string): PluginManifest {
+  return { id, name: id, version: "1", permissions: [] };
+}
+
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+async function fireClose(): Promise<void> {
+  const handler = closeHandlers[closeHandlers.length - 1];
+  if (!handler) throw new Error("no close handler registered");
+  await handler({ preventDefault: () => {} });
+}
+
+/** Registers `cb` as a quit hook and returns the unsubscribe. */
+async function registerQuitHook(cb: () => void | Promise<void>): Promise<() => void> {
+  let api: PluginAPI | null = null;
+  loadPlugin(manifest("q"), (a) => { api = a; return () => {}; }, true, false);
+  const off = api!.lifecycle.onBeforeQuit(cb);
+  await flush();
+  return off;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  hide.mockClear();
+  invoke.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  try { unloadPlugin("q"); } catch { /* noop */ }
+});
+
+describe("the close handler", () => {
+  test("hides the window before waiting on a quit hook", async () => {
+    let hiddenBeforeHook = false;
+    const off = await registerQuitHook(() => { hiddenBeforeHook = hide.mock.calls.length > 0; });
+
+    await fireClose();
+
+    expect(hiddenBeforeHook).toBe(true);
+    expect(invoke).toHaveBeenCalledWith("force_quit");
+    off();
+  });
+
+  test("leaves the window up when no plugin registered a quit hook", async () => {
+    const off = await registerQuitHook(() => {});
+    off();
+
+    await fireClose();
+
+    expect(hide).not.toHaveBeenCalled();
+    expect(invoke).toHaveBeenCalledWith("force_quit");
+  });
+
+  test("still exits when a quit hook throws synchronously", async () => {
+    const off = await registerQuitHook(() => { throw new Error("boom"); });
+
+    await fireClose();
+
+    expect(invoke).toHaveBeenCalledWith("force_quit");
+    off();
+  });
+
+  test("exits on the cap when a quit hook never settles, and only once", async () => {
+    const off = await registerQuitHook(() => new Promise<void>(() => {}));
+
+    const closed = fireClose();
+    await vi.advanceTimersByTimeAsync(5000);
+    await closed;
+    expect(invoke).toHaveBeenCalledWith("force_quit");
+
+    // The fallback exit must have been disarmed by the normal path.
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(invoke).toHaveBeenCalledTimes(1);
+    off();
+  });
+});

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -230,18 +230,32 @@ async function ensureQuitHandler() {
   _quitHandlerRegistered = true;
   const { getCurrentWindow } = await import("@tauri-apps/api/window");
   const win = getCurrentWindow();
+  // win.destroy() deadlocks on Windows (message pump waiting for handler
+  // to return, handler waiting for destroy to be processed by message pump).
+  // Use a Rust-side exit instead, which bypasses the JS/WebView2 layer.
+  const quit = () => { invoke("force_quit").catch(() => {}); };
   await win.onCloseRequested(async (event) => {
     event.preventDefault();
     const callbacks = [..._onBeforeQuit];
-    await Promise.race([
-      Promise.allSettled(callbacks.map((cb) => cb())),
-      new Promise<void>((r) => setTimeout(r, 5000)),
-    ]);
-    // win.destroy() deadlocks on Windows (message pump waiting for handler
-    // to return, handler waiting for destroy to be processed by message pump).
-    // Use a Rust-side exit instead, which bypasses the JS/WebView2 layer.
-    const { invoke } = await import("@tauri-apps/api/core");
-    invoke("force_quit").catch(() => {});
+    if (callbacks.length === 0) {
+      quit();
+      return;
+    }
+    // Without this the window stays up for the whole wait, which reads as a
+    // hang when a quit hook does network work (gist-sync pushes on exit).
+    win.hide().catch(() => {});
+    // A hidden window over a live process is worse than a slow close, so the
+    // exit is armed up front: it survives a throw or an invoke that never lands.
+    const fallback = setTimeout(quit, 6000);
+    try {
+      await Promise.race([
+        Promise.allSettled(callbacks.map(async (cb) => cb())),
+        new Promise<void>((r) => setTimeout(r, 5000)),
+      ]);
+    } finally {
+      clearTimeout(fallback);
+      quit();
+    }
   });
 }
 


### PR DESCRIPTION
Fixes #94. Based on @Flash303's diagnosis and patch in #95 — the approach here is theirs, with two extra safety fixes.

## Cause

`ensureQuitHandler()` (`src/plugins/runtime.ts`) intercepts `onCloseRequested`, calls `preventDefault()`, and then awaits every plugin `onBeforeQuit` callback (capped at 5s) before triggering the Rust-side exit. The window stays on screen for that entire wait. The gist-sync plugin pushes to GitHub in its quit hook, so closing the app looked frozen for ~2s. With no plugin registering a quit hook the handler is never installed at all, which is why this only reproduces with a plugin like gist-sync enabled.

## Change

- Hide the window before awaiting the hooks, so the wait is invisible and the app appears to close instantly. Requires the `core:window:allow-hide` capability (not part of `core:default`).
- Only hide when a quit hook is actually registered; with none, close immediately as before.
- Arm the Rust-side exit up front with a fallback timer and call it from a `finally` block. Without this, a throwing hook or an `invoke` that never lands would leave a hidden window over a live process — worse than a slow close.
- Wrap hook invocation in an async function so a synchronous throw becomes a rejection instead of escaping the handler.

## Tests

New `src/plugins/runtime.quitHandler.test.ts` covers: hide precedes the hook, no hide when there are zero hooks, exit still happens when a hook throws, and exit on the 5s cap with the fallback timer disarmed (`force_quit` invoked exactly once). `pnpm tsc --noEmit` clean; `pnpm vitest run src/plugins` green (73 files, 593 tests).

## Live verification

Debug build driven under Xvfb/WebKitGTK through tauri-driver, with a test plugin whose quit hook runs for ~2.4s:

- Close fired, hook ran, `plugin:window|is_visible` sampled from inside the hook: `false` at every sample from 303ms onward through 2429ms — the window is gone while the sync is still running.
- Process exited 2.97s after the close was fired, i.e. right after the hook finished, not on the 6s fallback.
- With the hook unregistered, the process exited 240ms after the close was fired (that figure includes the harness round-trip), and no hide occurred.

Not verified on Windows — no Windows machine here. The mechanism is platform-independent, but @Flash303 confirmed the original symptom and fix on Windows 11.
