### PR TITLE
chore(plugins): bump four first-party plugin manifests to green the CI gate

### DIFF
--- a/src/plugins/docker/manifest.json
+++ b/src/plugins/docker/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "plugin-docker",
   "name": "Docker",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "minAppVersion": "0.18.0",
   "description": "Manage Docker containers, images, volumes, and networks for local and SSH sessions.",
   "permissions": ["sessions:read", "right-panel", "storage", "notifications", "docker:read", "docker:manage", "ui", "mcp:contribute"],

--- a/src/plugins/monitoring/manifest.json
+++ b/src/plugins/monitoring/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "plugin-monitoring",
   "name": "System Metrics",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "minAppVersion": "0.18.0",
   "description": "Real-time CPU, RAM, network, and disk metrics for local and SSH sessions.",
   "permissions": ["metrics:read", "sessions:read", "right-panel", "ui", "mcp:contribute"],

--- a/src/plugins/process-manager/manifest.json
+++ b/src/plugins/process-manager/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "plugin-process-manager",
   "name": "Process Manager",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "minAppVersion": "0.18.0",
   "description": "Monitor and manage running processes for local and SSH sessions.",
   "permissions": ["processes:read", "processes:manage", "sessions:read", "right-panel", "ui", "mcp:contribute"],

--- a/src/plugins/proxmox/manifest.json
+++ b/src/plugins/proxmox/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "plugin-proxmox",
   "name": "Proxmox LXC",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "minAppVersion": "0.18.0",
   "description": "Manage Proxmox VE LXC containers and snapshots over SSH.",
   "permissions": [


### PR DESCRIPTION
The `plugin-versions` gate has failed on dev since dfc1bee. Two refactors changed bundled source under four plugin folders without touching their manifests:

- 74aedcc — `useActiveSession` and the mobile screen header moved onto `@voltius/ui` (docker, monitoring, process-manager, proxmox)
- ffce6e1 — docker log-stream lifecycle extracted into `useLogStream`

Publishing those unchanged versions would overwrite bytes the live marketplace catalogue pins a hash to, which is exactly what the gate exists to stop. Both changes are refactor-only, so these are patch bumps: docker 1.3.0→1.3.1, monitoring/process-manager/proxmox 1.2.0→1.2.1.

`node scripts/check-plugin-versions.mjs` now reports `all 6 plugins OK` locally.