### PR TITLE
chore(tooling): pin pnpm to 11.5.2 across host, CI and the cross-compile image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,6 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@v7
         with:
@@ -78,8 +76,6 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/publish-crypto-wasm.yml
+++ b/.github/workflows/publish-crypto-wasm.yml
@@ -27,8 +27,6 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: Publish to npm
         run: cd crates/voltius-crypto-wasm/pkg && pnpm publish --access public --no-git-checks

--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -76,8 +76,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       # Pinned, not lts/*: the hash guard below compares this job's freshly built
       # bytes against what an existing release tag already carries. An unrelated

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,8 +155,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Setup node
         uses: actions/setup-node@v7
@@ -242,8 +240,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Setup node
         uses: actions/setup-node@v7

--- a/Dockerfile.cross-compile
+++ b/Dockerfile.cross-compile
@@ -15,6 +15,16 @@ RUN apt-get update && apt-get install -y \
 # Node & PNPM — pnpm is pinned: unversioned `corepack prepare` takes the `latest`
 # dist-tag at image-build time, which has resolved to a 12.x alpha whose bin layout
 # corepack cannot launch, breaking the image on a rebuild alone.
+#
+# Keep in step with `packageManager` in package.json so corepack does not fetch
+# a second pnpm once the build reaches the mounted repo.
+#
+# Separately: this container resolves storeDir to /project/.pnpm-store, while a
+# host install uses ~/.local/share/pnpm/store. pnpm reads that as an
+# incompatible node_modules and asks to purge it — fatal with no TTY, and
+# destructive to the host's tree under CI=true. Give the build its own
+# node_modules instead:
+#   docker run ... -v "$PWD:/project" -v <a-named-volume>:/project/node_modules ...
 ARG PNPM_VERSION=11.5.2
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "voltius",
   "version": "0.21.1",
+  "packageManager": "pnpm@11.5.2",
   "type": "module",
   "scripts": {
     "prepare": "git config core.hooksPath .githooks || true",


### PR DESCRIPTION
## Why

The repo was running three different pnpm versions at once:

| Where | Version |
|---|---|
| CI (`pnpm/action-setup`, 5 steps) | `10` |
| CI (`publish-crypto-wasm`) | `latest` |
| `Dockerfile.cross-compile` | `11.5.2` (baked) |
| A developer's machine | whatever corepack's `latest` resolved to (currently `11.21.0`) |

Nothing named the version, so every environment picked its own.

## What changed

- `package.json` gains `"packageManager": "pnpm@11.5.2"` — the version the cross-compile image already bakes, so that image needs no rebuild.
- The six `pnpm/action-setup` steps drop their own `version:`. `action-setup` reads `packageManager` instead, and errors out if both are present and disagree — which is why they had to go in the same change.
- `Dockerfile.cross-compile` keeps `ARG PNPM_VERSION=11.5.2`, now with a comment tying it to `packageManager`.

## Verified locally

- corepack switches the host to 11.5.2; `pnpm install` reports *Already up to date*.
- `pnpm-lock.yaml` unchanged (`lockfileVersion 9.0`, read by both 10 and 11).
- Full suite green under 11.5.2: **389 files, 2827 tests**. `tsc --noEmit` clean.

## What this does NOT fix

A cross-build still needs its own `node_modules` volume. I originally thought the version skew caused pnpm to purge the mounted tree; it does not. The container resolves `storeDir` to `/project/.pnpm-store/v11` while a host install uses `~/.local/share/pnpm/store/v11`, and pnpm reads that as an incompatible `node_modules`. Mounting the host store into the container does not help either. The working invocation is now documented in `Dockerfile.cross-compile`:

```
docker run ... -v "$PWD:/project" -v <named-volume>:/project/node_modules ...
```

## Risk

CI moves from pnpm 10 to 11.5.2, and `publish-crypto-wasm` from `latest` to 11.5.2. That can only be verified by this PR's own CI run — which is the reason this is a PR rather than a push to `dev`.