### PR TITLE
fix(panes): stop a new split tab from cloning the previous tab's terminals

### DIFF
--- a/src/hooks/useTerminal.reattach.test.tsx
+++ b/src/hooks/useTerminal.reattach.test.tsx
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { useTerminal } from "@/hooks/useTerminal";
+
+vi.mock("@xterm/xterm", () => {
+  class FakeTerminal {
+    element: HTMLElement | null = null;
+    options: Record<string, unknown> = {};
+    cols = 80;
+    rows = 24;
+    buffer = {
+      active: { length: 0, viewportY: 0, baseY: 0, cursorY: 0, getLine: () => null },
+      onBufferChange: () => ({ dispose() {} }),
+    };
+    open(container: HTMLElement) {
+      this.element = document.createElement("div");
+      container.appendChild(this.element);
+    }
+    parser = { registerOscHandler: () => ({ dispose() {} }) };
+    loadAddon() {}
+    write() {}
+    focus() {}
+    dispose() {}
+    attachCustomKeyEventHandler() {}
+    attachCustomWheelEventHandler() {}
+    onData() { return { dispose() {} }; }
+    onBinary() { return { dispose() {} }; }
+    onResize() { return { dispose() {} }; }
+    onScroll() { return { dispose() {} }; }
+    onLineFeed() { return { dispose() {} }; }
+    onRender() { return { dispose() {} }; }
+    onWriteParsed() { return { dispose() {} }; }
+    registerLinkProvider() { return { dispose() {} }; }
+    registerDecoration() { return null; }
+  }
+  return { Terminal: FakeTerminal };
+});
+vi.mock("@xterm/addon-fit", () => ({ FitAddon: class { fit() {} proposeDimensions() { return { cols: 80, rows: 24 }; } } }));
+vi.mock("@xterm/addon-webgl", () => ({ WebglAddon: class { onContextLoss() { return { dispose() {} }; } dispose() {} } }));
+vi.mock("@xterm/addon-web-links", () => ({ WebLinksAddon: class {} }));
+vi.mock("@xterm/addon-search", () => ({
+  SearchAddon: class {
+    findNext() { return false; }
+    findPrevious() { return false; }
+    clearDecorations() {}
+    onDidChangeResults() { return { dispose() {} }; }
+  },
+}));
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn() }));
+vi.mock("@/services/ssh", () => ({
+  sshSendInput: vi.fn(), sshResize: vi.fn(),
+  onSshOutput: vi.fn(async () => () => {}), onSshClosed: vi.fn(async () => () => {}), onSshCwd: vi.fn(async () => () => {}),
+}));
+vi.mock("@/services/local", () => ({
+  localSendInput: vi.fn(), localResize: vi.fn(),
+  onLocalOutput: vi.fn(async () => () => {}), onLocalClosed: vi.fn(async () => () => {}),
+}));
+vi.mock("@/services/serial", () => ({
+  serialWrite: vi.fn(), onSerialOutput: vi.fn(async () => () => {}), onSerialClosed: vi.fn(async () => () => {}),
+}));
+vi.mock("@/components/terminal/terminalClipboard", () => ({
+  attachTerminalClipboard: () => ({ dispose() {} }),
+}));
+
+globalThis.ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+function Harness({ sessionId }: { sessionId: string }) {
+  const { attach } = useTerminal({ sessionId, sessionType: "local" });
+  return <div data-testid="host" ref={attach} />;
+}
+
+describe("useTerminal re-attach on session change", () => {
+  it("swaps the terminal element when the same mount switches sessions", () => {
+    const { container, rerender } = render(<Harness sessionId="session-a" />);
+    const host = container.querySelector("[data-testid=host]")!;
+    const firstTerm = host.firstElementChild;
+    expect(firstTerm).toBeTruthy();
+
+    rerender(<Harness sessionId="session-b" />);
+
+    const secondTerm = host.firstElementChild;
+    expect(host.childElementCount).toBe(1);
+    expect(secondTerm).not.toBe(firstTerm);
+  });
+});

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -657,9 +657,44 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
     }
   });
 
+  // Container-specific listeners, registered on each mount and torn down when
+  // the ref detaches. The teardown also pulls the terminal element out of the
+  // container: a pane that switches session keeps the same container node, so
+  // leaving the old element behind would show the previous session's buffer.
+  const bindContainer = useCallback((terminal: Terminal, fitAddon: FitAddon, container: HTMLDivElement) => {
+    const clip = attachTerminalClipboard(terminal, container, { osc52: true });
+    clipRef.current = clip;
+
+    const handleWindowResize = () => fitAddon.fit();
+    window.addEventListener("resize", handleWindowResize);
+
+    let fitTimer: ReturnType<typeof setTimeout> | null = null;
+    const resizeObserver = new ResizeObserver(() => {
+      if (fitTimer !== null) clearTimeout(fitTimer);
+      fitTimer = setTimeout(() => { fitTimer = null; fitAddon.fit(); }, 50);
+    });
+    resizeObserver.observe(container);
+
+    mountCleanupRef.current = () => {
+      clip.dispose();
+      if (clipRef.current === clip) clipRef.current = null;
+      window.removeEventListener("resize", handleWindowResize);
+      resizeObserver.disconnect();
+      if (fitTimer !== null) clearTimeout(fitTimer);
+      terminal.element?.remove();
+      mountCleanupRef.current = null;
+    };
+  }, []);
+
   const attach = useCallback(
     (container: HTMLDivElement | null) => {
-      if (!container || mountCleanupRef.current) return;
+      // React hands the ref a null when the callback identity changes (session
+      // switch on a live pane) as well as on unmount — both mean "detach".
+      if (!container) {
+        mountCleanupRef.current?.();
+        return;
+      }
+      if (mountCleanupRef.current) return;
 
       const existing = terminalCache.get(sessionId);
 
@@ -674,28 +709,7 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
 
         fitAddon.fit();
 
-        // Container-specific listeners (re-registered on each mount)
-        const clip = attachTerminalClipboard(terminal, container, { osc52: true });
-        clipRef.current = clip;
-
-        const handleWindowResize = () => fitAddon.fit();
-        window.addEventListener("resize", handleWindowResize);
-
-        let fitTimer: ReturnType<typeof setTimeout> | null = null;
-        const resizeObserver = new ResizeObserver(() => {
-          if (fitTimer !== null) clearTimeout(fitTimer);
-          fitTimer = setTimeout(() => { fitTimer = null; fitAddon.fit(); }, 50);
-        });
-        resizeObserver.observe(container);
-
-        mountCleanupRef.current = () => {
-          clip.dispose();
-          if (clipRef.current === clip) clipRef.current = null;
-          window.removeEventListener("resize", handleWindowResize);
-          resizeObserver.disconnect();
-          if (fitTimer !== null) clearTimeout(fitTimer);
-          mountCleanupRef.current = null;
-        };
+        bindContainer(terminal, fitAddon, container);
         return;
       }
 
@@ -1104,28 +1118,7 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
         term.dispose();
       };
 
-      // Container-specific listeners (registered on each mount, torn down on unmount)
-      const clip = attachTerminalClipboard(term, container, { osc52: true });
-      clipRef.current = clip;
-
-      const handleWindowResize = () => fitAddon.fit();
-      window.addEventListener("resize", handleWindowResize);
-
-      let fitTimer: ReturnType<typeof setTimeout> | null = null;
-      const resizeObserver = new ResizeObserver(() => {
-        if (fitTimer !== null) clearTimeout(fitTimer);
-        fitTimer = setTimeout(() => { fitTimer = null; fitAddon.fit(); }, 50);
-      });
-      resizeObserver.observe(container);
-
-      mountCleanupRef.current = () => {
-        clip.dispose();
-        if (clipRef.current === clip) clipRef.current = null;
-        window.removeEventListener("resize", handleWindowResize);
-        resizeObserver.disconnect();
-        if (fitTimer !== null) clearTimeout(fitTimer);
-        mountCleanupRef.current = null;
-      };
+      bindContainer(term, fitAddon, container);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [sessionId, sessionType, encoding],


### PR DESCRIPTION
## Problem

With one multi-pane tab already open, dragging a session tab onto another session created a second multi-pane tab — but both tabs rendered the same terminals. The second group was a visual clone of the first.

The layout store was correct throughout: the new tab's leaves held the right session ids. Only the DOM was wrong.

## Root cause

`PaneView` renders panes without keys, so switching the active split tab hands the same `TerminalView` instance a new `sessionId` over the same container node. `attach` is a `useCallback` keyed on `[sessionId, sessionType, encoding]`, so its identity changes and React calls the old ref with `null`, then the new ref with the container. Both calls hit the same guard in `useTerminal`:

```ts
if (!container || mountCleanupRef.current) return;
```

- the `null` call returned without detaching, leaving `mountCleanupRef` set
- the re-attach then returned early as well

So the previous session's xterm element stayed parented in the reused container, and the new session never attached.

## Fix

- a `null` container now means detach (runs `mountCleanupRef`)
- the mount teardown removes `terminal.element` from its container
- the duplicated container-listener and teardown blocks on the reuse and create paths collapse into one `bindContainer` helper

The same stale-attach path applied to an `encoding` change on a live pane — fixed by the same change.

## Verification

- New regression test `src/hooks/useTerminal.reattach.test.tsx`: rerender the same mount with a new `sessionId`, assert the terminal element swaps. Fails on the old code, passes on the fix.
- Full suite: 390 files / 2828 tests passed.
- `tsc --noEmit` clean.
- Live headless dev build, four local shells each carrying a distinct marker: reproduced the clone before the fix; after it, group 2 shows MARKER_3 / MARKER_4, group 1 shows MARKER_1 / MARKER_2, and switching between them keeps them distinct.