### PR TITLE
feat(sessions): duplicate opens in the source session's directory

### DIFF
--- a/src-tauri/src/commands/ssh.rs
+++ b/src-tauri/src/commands/ssh.rs
@@ -36,6 +36,7 @@ pub async fn ssh_connect(
     cols: Option<u32>,
     rows: Option<u32>,
     legacy_algorithms: Option<bool>,
+    initial_cwd: Option<String>,
 ) -> Result<(), String> {
     let connected = client::connect(
         app,
@@ -61,6 +62,7 @@ pub async fn ssh_connect(
         cols.filter(|c| *c > 0).unwrap_or(80),
         rows.filter(|r| *r > 0).unwrap_or(24),
         legacy_algorithms.unwrap_or(false),
+        initial_cwd,
     )
     .await?;
 

--- a/src-tauri/src/local/session.rs
+++ b/src-tauri/src/local/session.rs
@@ -139,7 +139,9 @@ impl LocalSessionManager {
             CommandBuilder::new(&shell)
         };
         cmd.env("TERM", "xterm-256color");
-        if let Some(dir) = cwd {
+        // A directory that has since been removed would fail the spawn outright;
+        // starting in the default one beats not starting at all.
+        if let Some(dir) = cwd.filter(|d| std::path::Path::new(d).is_dir()) {
             cmd.cwd(dir);
         }
 

--- a/src-tauri/src/shell_integration.rs
+++ b/src-tauri/src/shell_integration.rs
@@ -166,7 +166,7 @@ function global:prompt {\n\
 
 /// POSIX wrapper that detects $SHELL at runtime, writes a per-session rcfile
 /// under /tmp, and execs into a hooked interactive shell. NOT invoked
-/// directly — `ssh_exec_command()` wraps it in a base64 bootstrap so it's
+/// directly — `ssh_exec_command` wraps it in a base64 bootstrap so it's
 /// safe to send regardless of the remote login shell's syntax (fish/csh
 /// would otherwise choke on POSIX case/heredoc).
 ///
@@ -254,8 +254,12 @@ pub const MOTD_PREAMBLE: &str = "[ ! -e $HOME/.hushlogin ] && { [ -r /run/motd.d
 /// sh` — a syntax common to every Unix shell. The decoded POSIX wrapper then
 /// runs under /bin/sh and execs into the user's actual shell with OSC 7
 /// emission hooked.
-pub fn ssh_exec_command() -> String {
-    encode_wrapper(&format!("{MOTD_PREAMBLE}\n{SSH_WRAPPER}"))
+///
+/// `prefix` (a `cd` into the session's starting directory, or empty) runs
+/// inside the decoded wrapper. Prefixing the outer payload instead would put it
+/// in front of the login shell, which may be csh or fish; inside, it is /bin/sh.
+pub fn ssh_exec_command(prefix: &str) -> String {
+    encode_wrapper(&format!("{prefix}\n{MOTD_PREAMBLE}\n{SSH_WRAPPER}"))
 }
 
 /// Longest `exec` payload we will put on the wire. dropbear's `MAX_STRING_LEN`
@@ -632,7 +636,7 @@ mod tests {
 
     #[test]
     fn persistent_wrapper_embeds_inner_and_all_branches() {
-        let inner = ssh_exec_command();
+        let inner = ssh_exec_command("");
         let cmd = persistent_exec_command("voltius_s1", &inner);
         let script = decode_bootstrap(&cmd);
         assert!(script.contains("command -v tmux"));
@@ -657,12 +661,23 @@ mod tests {
 
     #[test]
     fn ssh_wrapper_reproduces_motd() {
-        let decoded = decode_bootstrap(&ssh_exec_command());
+        let decoded = decode_bootstrap(&ssh_exec_command(""));
         assert!(decoded.contains("/run/motd.dynamic"));
         assert!(decoded.contains("/etc/motd"));
         assert!(decoded.contains(".hushlogin"));
         // Quote-free so it can also be embedded in the persist inner.
         assert!(!MOTD_PREAMBLE.contains('"'));
+    }
+
+    #[test]
+    fn ssh_wrapper_runs_the_cd_prefix_before_the_shell() {
+        let decoded = decode_bootstrap(&ssh_exec_command("cd '/srv/app' 2>/dev/null; "));
+        let cd = decoded
+            .find("cd '/srv/app'")
+            .expect("prefix is in the wrapper");
+        // Inside the decoded /bin/sh wrapper, and before it execs the login shell.
+        assert!(cd < decoded.find(SSH_WRAPPER).unwrap());
+        assert!(!decode_bootstrap(&ssh_exec_command("")).contains("cd '"));
     }
 
     #[test]
@@ -717,7 +732,7 @@ mod tests {
 
     #[test]
     fn persistent_wrapper_keeps_pty_redirects() {
-        let inner = ssh_exec_command();
+        let inner = ssh_exec_command("");
         let cmd = persistent_exec_command("voltius_s1", &inner);
         let script = decode_bootstrap(&cmd);
         // The multiplexer re-attaches over the stderr pty (`<&2`), not `/dev/tty`.
@@ -728,7 +743,7 @@ mod tests {
 
     #[test]
     fn ssh_wrapper_zsh_uses_zshenv_trampoline() {
-        let decoded = decode_bootstrap(&ssh_exec_command());
+        let decoded = decode_bootstrap(&ssh_exec_command(""));
         assert!(
             decoded.contains("$ZDOTDIR_TMP/.zshenv"),
             "SSH wrapper zsh branch must write .zshenv, got:\n{decoded}"
@@ -925,7 +940,7 @@ mod tests {
         // each branch put this at ~21.7 KB against OpenWrt/ImmortalWrt routers.
         let key = tmux_session_key("0f8b1c22-4d7e-4a19-9f3b-2c6d5e8a7b41");
         for inner in [
-            ssh_exec_command(),
+            ssh_exec_command(""),
             format!("{MOTD_PREAMBLE}; exec ${{SHELL:-/bin/sh}} -l"),
         ] {
             let cmd = persistent_exec_command(&key, &inner);

--- a/src-tauri/src/ssh/client.rs
+++ b/src-tauri/src/ssh/client.rs
@@ -563,6 +563,7 @@ pub async fn connect(
     pty_cols: u32,
     pty_rows: u32,
     legacy_algorithms: bool,
+    initial_cwd: Option<String>,
 ) -> Result<ConnectedSession, String> {
     let config = Arc::new(client::Config {
         // interval 0 = keepalive disabled.
@@ -884,13 +885,24 @@ pub async fn connect(
         }
     }
 
+    // `cd` into the starting directory from inside the exec'd command rather than
+    // by writing to the shell's stdin: no line in the scrollback, no entry in the
+    // shell's history, and no race with the shell (or the multiplexer) coming up.
+    // The persistent wrappers embed their inner command in a double-quoted
+    // assignment, so a path the outer shell would expand is dropped rather than
+    // mangled — the session then just starts in the default directory.
+    let cd_prefix = initial_cwd
+        .filter(|p| !p.is_empty() && !p.contains(['"', '$', '`', '\\', '\n', '\r']))
+        .map(|p| format!("cd {} 2>/dev/null; ", shell_escape(&p)))
+        .unwrap_or_default();
+
     // When shell integration is enabled we replace the standard shell channel
     // request with an exec of our wrapper script. The wrapper detects the
     // remote $SHELL and execs into it with OSC 7 emission already hooked
     // (writes a temp rcfile under /tmp). Falling back to request_shell keeps
     // the historical behavior available via the setting.
     let exec_cmd = if shell_integration {
-        let inner = crate::shell_integration::ssh_exec_command();
+        let inner = crate::shell_integration::ssh_exec_command(&cd_prefix);
         Some(if persist {
             let key = crate::shell_integration::tmux_session_key(&session_id);
             if attach_only {
@@ -908,7 +920,8 @@ pub async fn connect(
         // on attach doesn't wipe it.
         let key = crate::shell_integration::tmux_session_key(&session_id);
         let inner = format!(
-            "{}; exec ${{SHELL:-/bin/sh}} -l",
+            "{}{}; exec ${{SHELL:-/bin/sh}} -l",
+            cd_prefix,
             crate::shell_integration::MOTD_PREAMBLE
         );
         Some(if attach_only {
@@ -924,7 +937,11 @@ pub async fn connect(
     // string passes its 9000-byte MAX_STRING_LEN, which reads as a hang right
     // after authentication rather than an error (#85). Servers that small are
     // better served by a plain shell than by a session that never opens.
-    match exec_cmd.filter(|c| c.len() <= crate::shell_integration::MAX_EXEC_COMMAND_LEN) {
+    let exec_cmd = exec_cmd.filter(|c| c.len() <= crate::shell_integration::MAX_EXEC_COMMAND_LEN);
+    // A plain `request_shell` has nowhere to carry the prefix, so it goes in over
+    // stdin below instead.
+    let cd_over_stdin = exec_cmd.is_none() && !cd_prefix.is_empty();
+    match exec_cmd {
         Some(cmd) => channel
             .exec(false, cmd.as_bytes())
             .await
@@ -947,6 +964,12 @@ pub async fn connect(
             exports.push_str(&format!("export {}={}\n", key, shell_escape(value)));
         }
         let _ = writer.write_all(exports.as_bytes()).await;
+    }
+
+    // Before pre_command: a host command that changes directory itself must win.
+    if cd_over_stdin && !remote_is_windows {
+        let _ = writer.write_all(cd_prefix.trim_end().as_bytes()).await;
+        let _ = writer.write_all(b"\n").await;
     }
 
     if let Some(cmd) = pre_command {

--- a/src/services/duplicateSession.test.ts
+++ b/src/services/duplicateSession.test.ts
@@ -1,8 +1,8 @@
 import { describe, test, expect, vi, beforeEach } from "vitest";
 import type { TerminalSession } from "@/types";
 
-const beginSession = vi.fn((connectionId: string) => `sess-of-${connectionId}`);
-const beginLocalSession = vi.fn((shell?: string) => `local-of-${shell ?? "default"}`);
+const beginSession = vi.fn((connectionId: string, _cwd?: string) => `sess-of-${connectionId}`);
+const beginLocalSession = vi.fn((shell?: string, _cwd?: string) => `local-of-${shell ?? "default"}`);
 const setActive = vi.fn();
 
 let sessions: TerminalSession[] = [];
@@ -15,6 +15,7 @@ vi.mock("@/stores/sessionStore", () => ({
 vi.mock("@/services/launch", () => ({ goToTerminal: vi.fn() }));
 
 import { useLayoutStore, getPaneSessionIds, findLeafBySession } from "@/stores/layoutStore";
+import { useTerminalCwdStore } from "@/stores/terminalCwdStore";
 import { canDuplicateSession, duplicateSession, findSessionPane, handleDuplicateShortcut } from "./duplicateSession";
 
 const ssh: TerminalSession = { id: "s1", connectionId: "c1", connectionName: "srv", status: "connected", type: "ssh" };
@@ -22,6 +23,7 @@ const ssh: TerminalSession = { id: "s1", connectionId: "c1", connectionName: "sr
 beforeEach(() => {
   vi.clearAllMocks();
   sessions = [ssh];
+  useTerminalCwdStore.setState({ cwds: {} });
   useLayoutStore.setState({
     root: null, activePaneId: null, maximizedPaneId: null, broadcastActive: false,
     splitTabActive: false, splitTabs: [], activeSplitTabId: null, titlebarOrder: [],
@@ -45,7 +47,7 @@ describe("canDuplicateSession", () => {
 describe("duplicateSession", () => {
   test("tab target opens a second session on the same connection and activates it", () => {
     const id = duplicateSession("s1", "tab");
-    expect(beginSession).toHaveBeenCalledWith("c1");
+    expect(beginSession).toHaveBeenCalledWith("c1", undefined);
     expect(id).toBe("sess-of-c1");
     expect(setActive).toHaveBeenCalledWith("sess-of-c1");
     expect(useLayoutStore.getState().splitTabs).toHaveLength(0);
@@ -54,9 +56,34 @@ describe("duplicateSession", () => {
   test("local sessions duplicate their own shell rather than a connection", () => {
     sessions = [{ ...ssh, type: "local", connectionId: "local", localShell: "/bin/zsh" }];
     const id = duplicateSession("s1", "tab");
-    expect(beginLocalSession).toHaveBeenCalledWith("/bin/zsh");
+    expect(beginLocalSession).toHaveBeenCalledWith("/bin/zsh", undefined);
     expect(id).toBe("local-of-/bin/zsh");
     expect(beginSession).not.toHaveBeenCalled();
+  });
+
+  test("opens in the source session's directory", () => {
+    useTerminalCwdStore.getState().setCwd("s1", "/srv/app");
+    duplicateSession("s1", "tab");
+    expect(beginSession).toHaveBeenCalledWith("c1", "/srv/app");
+  });
+
+  test("local duplicates carry the directory too", () => {
+    sessions = [{ ...ssh, type: "local", connectionId: "local", localShell: "/bin/zsh" }];
+    useTerminalCwdStore.getState().setCwd("s1", "/home/kipavy/work");
+    duplicateSession("s1", "tab");
+    expect(beginLocalSession).toHaveBeenCalledWith("/bin/zsh", "/home/kipavy/work");
+  });
+
+  test("falls back to the default directory when the source never reported one", () => {
+    duplicateSession("s1", "tab");
+    expect(beginSession).toHaveBeenCalledWith("c1", undefined);
+  });
+
+  test("takes the source session's directory, not the anchor pane's", () => {
+    useTerminalCwdStore.getState().setCwd("s1", "/srv/app");
+    useTerminalCwdStore.getState().setCwd("s9", "/tmp");
+    duplicateSession("s1", "right", { sessionId: "s9" });
+    expect(beginSession).toHaveBeenCalledWith("c1", "/srv/app");
   });
 
   test("refuses a session that cannot be duplicated", () => {
@@ -124,7 +151,7 @@ describe("handleDuplicateShortcut", () => {
 
   test("claims and runs the tab shortcut on keydown", () => {
     expect(handleDuplicateShortcut(event(), "s1")).toBe(true);
-    expect(beginSession).toHaveBeenCalledWith("c1");
+    expect(beginSession).toHaveBeenCalledWith("c1", undefined);
   });
 
   test("claims keyup without duplicating, so the key never reaches the PTY twice", () => {

--- a/src/services/duplicateSession.ts
+++ b/src/services/duplicateSession.ts
@@ -1,5 +1,6 @@
 import { findLeafBySession, useLayoutStore, type SplitPosition, type SplitTab } from "@/stores/layoutStore";
 import { useSessionStore } from "@/stores/sessionStore";
+import { useTerminalCwdStore } from "@/stores/terminalCwdStore";
 import { matchShortcut } from "@/stores/shortcutStore";
 import { goToTerminal } from "@/services/launch";
 import type { TerminalSession } from "@/types";
@@ -38,16 +39,28 @@ function placeSplit(anchor: DuplicateAnchor, newSessionId: string, position: Spl
   useLayoutStore.getState().splitPane(existing.paneId, newSessionId, position);
 }
 
+/**
+ * Directory the duplicate opens in: the source session's, as last reported by
+ * OSC 7 (so it needs shell integration). Undefined falls back to the host's
+ * default directory. A full-screen program holds the shell past its last prompt,
+ * so the value is where it was launched from — which is what a duplicate wants.
+ */
+function inheritedCwd(sessionId: string): string | undefined {
+  return useTerminalCwdStore.getState().cwds[sessionId];
+}
+
 /** Second session on the same host. Returns the new session id, or null when it can't be duplicated. */
 export function duplicateSession(sessionId: string, target: DuplicateTarget, anchor?: DuplicateAnchor): string | null {
   const store = useSessionStore.getState();
   const session = store.sessions.find((s) => s.id === sessionId);
   if (!session || !canDuplicateSession(session)) return null;
 
+  const cwd = inheritedCwd(sessionId);
+
   // begin* return synchronously so the pane appears before the SSH handshake.
   const newSessionId = session.type === "local"
-    ? store.beginLocalSession(session.localShell)
-    : store.beginSession(session.connectionId);
+    ? store.beginLocalSession(session.localShell, cwd)
+    : store.beginSession(session.connectionId, cwd);
 
   if (target === "tab") useLayoutStore.getState().setSplitTabActive(false);
   else placeSplit(anchor ?? { sessionId }, newSessionId, target);

--- a/src/services/ssh.ts
+++ b/src/services/ssh.ts
@@ -35,6 +35,9 @@ export async function sshConnect(params: {
   attachOnly?: boolean;
   cols?: number;
   rows?: number;
+  /** Directory the shell starts in. First connect only — a reconnect must not
+   * move a session the user has since navigated elsewhere. */
+  initialCwd?: string;
 }): Promise<void> {
   return invoke("ssh_connect", {
     sessionId: params.sessionId,
@@ -59,6 +62,7 @@ export async function sshConnect(params: {
     attachOnly: params.attachOnly ?? null,
     cols: params.cols ?? null,
     rows: params.rows ?? null,
+    initialCwd: params.initialCwd ?? null,
   });
 }
 

--- a/src/stores/sessionStore.ts
+++ b/src/stores/sessionStore.ts
@@ -47,12 +47,12 @@ interface SessionStore {
   activeSessionId: string | null;
   connect: (connectionId: string, options?: OpenOptions) => Promise<string>;
   /** connect() without the wait: the session appears now, connects in the background. */
-  beginSession: (connectionId: string) => string;
+  beginSession: (connectionId: string, initialCwd?: string) => string;
   connectMany: (connectionIds: string[]) => Promise<string[]>;
   connectDirect: (connection: Connection) => Promise<void>;
   connectLocal: () => Promise<void>;
   connectLocalAt: (cwd: string) => Promise<void>;
-  beginLocalSession: (shell?: string) => string;
+  beginLocalSession: (shell?: string, cwd?: string) => string;
   connectAt: (connectionId: string, cwd: string) => Promise<void>;
   connectSerial: (connectionId: string) => Promise<void>;
   connectSerialEphemeral: (initialPort?: string) => Promise<void>;
@@ -239,6 +239,7 @@ async function connectSshSession(
   password?: string,
   privateKey?: string,
   passphrase?: string,
+  initialCwd?: string,
 ) {
   const hasConfiguredAuth = !!connection.identity_id || !!connection.key_id;
   const preflightError = preflightConnect(connection.username, password, privateKey, hasConfiguredAuth);
@@ -264,6 +265,7 @@ async function connectSshSession(
         privateKey,
         passphrase,
         connectionId: connection.id,
+        initialCwd,
         ...opts,
       }),
     );
@@ -489,7 +491,7 @@ async function materializeSavedConnection(
   return target;
 }
 
-function beginConnection(set: SessionSetter, connectionId: string): string {
+function beginConnection(set: SessionSetter, connectionId: string, initialCwd?: string): string {
   const connection = findConnection(connectionId);
   if (!connection) throw new Error(i18n.t("common.error.connectionNotFound"));
 
@@ -511,7 +513,7 @@ function beginConnection(set: SessionSetter, connectionId: string): string {
   void resolveConnectionCredentials(connection)
     .then((credentials) => {
       const resolvedConnection = { ...connection, username: credentials.username };
-      return connectSshSession(set, resolvedConnection, sessionId, credentials.password, credentials.privateKey, credentials.passphrase);
+      return connectSshSession(set, resolvedConnection, sessionId, credentials.password, credentials.privateKey, credentials.passphrase, initialCwd);
     })
     .catch((err) => markSessionError(set, sessionId, err));
 
@@ -572,7 +574,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     return connectConnection(set as SessionSetter, connectionId, options);
   },
 
-  beginSession: (connectionId) => beginConnection(set as SessionSetter, connectionId),
+  beginSession: (connectionId, initialCwd) => beginConnection(set as SessionSetter, connectionId, initialCwd),
 
   connectMany: async (connectionIds) => {
     const uniqueIds = [...new Set(connectionIds)];
@@ -649,7 +651,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     }
   },
 
-  beginLocalSession: (shell) => {
+  beginLocalSession: (shell, cwd) => {
     const sessionId = crypto.randomUUID();
     const session: TerminalSession = {
       id: sessionId,
@@ -660,7 +662,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
       localShell: shell ?? undefined,
     };
     addSession(set as SessionSetter, session);
-    void localConnect(sessionId, 80, 24, shell, undefined, getToggle("shell-integration")).then(() => {
+    void localConnect(sessionId, 80, 24, shell, cwd, getToggle("shell-integration")).then(() => {
       set((s) => ({
         sessions: s.sessions.map((sess) =>
           sess.id === sessionId ? { ...sess, status: "connected" as const } : sess,


### PR DESCRIPTION
A duplicate is meant to be a second terminal on what you are doing now, so it starts where the source shell is rather than in the host's default directory — matching tmux's `-c pane_current_path`, VS Code's `terminal.integrated.splitCwd: inherit`, and iTerm2's "reuse previous session's directory".

The path comes from `useTerminalCwdStore` — OSC 7, or the multiplexer poll for a persistent session — so a host without shell integration simply falls back to the default. A reconnect never sends it: the session may have moved on since.

## How the `cd` gets there

SSH carries it **inside** the exec'd payload instead of typing `cd` into the shell: nothing lands in the scrollback or in shell history, and there is no race with the shell — or the multiplexer — coming up. It rides inside the base64 wrapper rather than in front of it, since the remote login shell may be csh (no `2>/dev/null`) or fish.

- A path the persist wrappers' double-quoted assignment would expand (`" $ \` \` CR/LF) is dropped rather than mangled — that session just starts in the default directory.
- Only the plain `request_shell` path (shell integration and persistence both off) has nowhere to put it and writes it over stdin, ahead of `pre_command` so a host command that changes directory itself still wins.

Local sessions pass it to the PTY spawn, which now ignores a directory that no longer exists — that would have failed the spawn outright.

## Verification

Unit: 4 new frontend tests, 1 new Rust test proving the prefix runs inside the wrapper before the shell exec. Full suites green (373 frontend, `cargo test --lib shell_integration` 20/20), `tsc --noEmit` clean, `cargo fmt` applied.

Live, in the headless stack:

- Local — source at `/var/log`, Ctrl+Shift+D, new tab `pwd` = `/var/log`, no `cd` in the scrollback.
- SSH to `ssh-host-1` — source `cd /etc/ssh`, duplicate connects straight to a `/etc/ssh` prompt; `history` in the duplicate lists only what the user typed.

## Noticed, not fixed here

Duplicating an **unsaved quick-connect** session fails with "Authentication failed" — the ephemeral password is not reusable by a second session. Pre-existing and unrelated to this change; worth its own fix.