### PR TITLE
fix(sessions): keep quick-connect auth for duplicates and reconnects

### DIFF
--- a/src/services/credentials.ts
+++ b/src/services/credentials.ts
@@ -3,6 +3,7 @@ import { useIdentityStore } from "@/stores/identityStore";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { getSecret } from "@/services/vault";
 import { resolveCredentials, type ResolvedCredentials } from "@/services/credentialLogic";
+import { withEphemeralCredentials } from "@/services/ephemeralCredentials";
 
 export type { ResolvedCredentials } from "@/services/credentialLogic";
 
@@ -82,5 +83,6 @@ export async function resolveJumpHosts(conn: Connection): Promise<ResolvedJumpHo
 }
 
 export async function resolveConnectionCredentials(conn: Connection): Promise<ResolvedCredentials> {
-  return resolveCredentials(conn, findIdentity, (key) => getSecret(key).catch(() => null));
+  const resolved = await resolveCredentials(conn, findIdentity, (key) => getSecret(key).catch(() => null));
+  return withEphemeralCredentials(conn.id, resolved);
 }

--- a/src/services/ephemeralCredentials.ts
+++ b/src/services/ephemeralCredentials.ts
@@ -1,0 +1,39 @@
+import type { ResolvedCredentials } from "@/services/credentialLogic";
+
+/**
+ * Auth the user typed into the connect overlay for a quick-connect (unsaved)
+ * host. Quick-connect never writes to the vault, so without this every path
+ * that re-resolves credentials by connection id — duplicate, manual reconnect,
+ * auto-reconnect backoff — would dial with no password and fail. Held in memory
+ * only (never the keychain), dropped when the last session on that connection
+ * id closes or when the host is saved for real.
+ */
+const ephemeralCredentials = new Map<string, ResolvedCredentials>();
+
+export function setEphemeralCredentials(connectionId: string, credentials: ResolvedCredentials): void {
+  ephemeralCredentials.set(connectionId, credentials);
+}
+
+export function clearEphemeralCredentials(connectionId: string): void {
+  ephemeralCredentials.delete(connectionId);
+}
+
+/**
+ * Layer cached quick-connect auth under what the vault resolved. Stored secrets
+ * win, so a saved host is never affected — for an ephemeral id there are none.
+ */
+export function withEphemeralCredentials(
+  connectionId: string,
+  resolved: ResolvedCredentials,
+): ResolvedCredentials {
+  const cached = ephemeralCredentials.get(connectionId);
+  if (!cached) return resolved;
+  return {
+    // The overlay username is the one that actually authenticated; the ephemeral
+    // record still holds whatever was typed in the quick-connect box.
+    username: cached.username || resolved.username,
+    password: resolved.password ?? cached.password,
+    privateKey: resolved.privateKey ?? cached.privateKey,
+    passphrase: resolved.passphrase ?? cached.passphrase,
+  };
+}

--- a/src/stores/sessionStore.ts
+++ b/src/stores/sessionStore.ts
@@ -21,6 +21,7 @@ import { getGlobalKeepalivePreset, resolvePersistSession } from "@/stores/connec
 import { localConnect, localDisconnect } from "@/services/local";
 import { serialConnect, serialDisconnect } from "@/services/serial";
 import { resolveConnectionCredentials, resolveJumpHosts } from "@/services/credentials";
+import { setEphemeralCredentials, clearEphemeralCredentials } from "@/services/ephemeralCredentials";
 import { storeSecret, getSecret } from "@/services/vault";
 import { saveTeamVaultSecretForVault } from "@/services/teamVaultSecrets";
 import { useIdentityStore } from "@/stores/identityStore";
@@ -82,6 +83,12 @@ type SessionSetter = (fn: (s: { sessions: TerminalSession[]; activeSessionId: st
 // otherwise fail to find them. Registered on connectDirect, cleared on
 // removeSession.
 const ephemeralConnections = new Map<string, Connection>();
+
+/** Forget an ephemeral host: both its record and the auth cached against it. */
+function dropEphemeralConnection(connectionId: string): void {
+  ephemeralConnections.delete(connectionId);
+  clearEphemeralCredentials(connectionId);
+}
 
 function findConnection(connectionId: string): Connection | undefined {
   const { connections, teamConnections } = useConnectionStore.getState();
@@ -1125,7 +1132,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
                 : sess,
             ),
           }));
-          ephemeralConnections.delete(oldId);
+          dropEphemeralConnection(oldId);
           connection = target;
         } else {
           await persistConnectAuth(connection, merged).catch(() => {});
@@ -1149,6 +1156,13 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
         }),
       );
       connectOverrides.delete(sessionId);
+      // The overrides map is session-scoped and just went away. For an unsaved
+      // quick-connect host nothing else holds this auth, so hand it to the
+      // connection-scoped memory cache: duplicate and reconnect resolve
+      // credentials by connection id and would otherwise dial with none.
+      if (ephemeralConnections.has(conn.id)) {
+        setEphemeralCredentials(conn.id, { username, password, privateKey, passphrase });
+      }
       set((s) => ({
         sessions: s.sessions.map((sess) =>
           sess.id === sessionId ? { ...sess, status: "connected" as const, everConnected: true } : sess,
@@ -1174,7 +1188,7 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     const remaining = state.sessions.filter((s) => s.id !== sessionId);
     // Duplicates share a connectionId: only the last session may drop the ephemeral connection.
     if (closing && !remaining.some((s) => s.connectionId === closing.connectionId)) {
-      ephemeralConnections.delete(closing.connectionId);
+      dropEphemeralConnection(closing.connectionId);
     }
     connectOverrides.delete(sessionId);
     set({

--- a/tests/ephemeralCredentials.test.ts
+++ b/tests/ephemeralCredentials.test.ts
@@ -1,0 +1,58 @@
+import { test, expect, afterEach } from "vitest";
+import {
+  setEphemeralCredentials,
+  clearEphemeralCredentials,
+  withEphemeralCredentials,
+} from "../src/services/ephemeralCredentials.ts";
+
+afterEach(() => {
+  clearEphemeralCredentials("e1");
+  clearEphemeralCredentials("c1");
+});
+
+test("no cached auth: resolution passes through untouched", () => {
+  const resolved = { username: "alice", password: undefined, privateKey: undefined, passphrase: undefined };
+  expect(withEphemeralCredentials("e1", resolved)).toEqual(resolved);
+});
+
+test("quick-connect password survives for a second session on the same ephemeral id", () => {
+  setEphemeralCredentials("e1", { username: "voltius", password: "not-a-real-password" });
+  // What the vault returns for an unsaved host: nothing but the record's username.
+  const resolved = { username: "voltius", password: undefined, privateKey: undefined, passphrase: undefined };
+  expect(withEphemeralCredentials("e1", resolved)).toEqual({
+    username: "voltius",
+    password: "not-a-real-password",
+    privateKey: undefined,
+    passphrase: undefined,
+  });
+});
+
+test("caches key and passphrase too", () => {
+  setEphemeralCredentials("e1", { username: "alice", privateKey: "not-a-real-private-key", passphrase: "not-a-real-passphrase" });
+  const resolved = { username: "alice", password: undefined, privateKey: undefined, passphrase: undefined };
+  expect(withEphemeralCredentials("e1", resolved)).toEqual({
+    username: "alice",
+    password: undefined,
+    privateKey: "not-a-real-private-key",
+    passphrase: "not-a-real-passphrase",
+  });
+});
+
+test("overlay username wins over the stale ephemeral record username", () => {
+  setEphemeralCredentials("e1", { username: "typed-user", password: "not-a-real-password" });
+  const resolved = { username: "record-user", password: undefined, privateKey: undefined, passphrase: undefined };
+  expect(withEphemeralCredentials("e1", resolved).username).toBe("typed-user");
+});
+
+test("stored vault secret wins over a cached one for a saved host", () => {
+  setEphemeralCredentials("c1", { username: "alice", password: "not-a-real-stale-password" });
+  const resolved = { username: "alice", password: "from-vault", privateKey: undefined, passphrase: undefined };
+  expect(withEphemeralCredentials("c1", resolved).password).toBe("from-vault");
+});
+
+test("clearing drops the cached auth", () => {
+  setEphemeralCredentials("e1", { username: "voltius", password: "not-a-real-password" });
+  clearEphemeralCredentials("e1");
+  const resolved = { username: "voltius", password: undefined, privateKey: undefined, passphrase: undefined };
+  expect(withEphemeralCredentials("e1", resolved).password).toBeUndefined();
+});


### PR DESCRIPTION
Duplicating (Ctrl+Shift+D) an unsaved quick-connect session failed to authenticate. The same gap affected reconnect and the auto-reconnect backoff.

## Root cause

Quick-connect builds an ephemeral `Connection` that is never written to the vault. The password typed into the connect overlay lives only in `connectOverrides` — a map keyed by **session** id — and that entry is deleted as soon as the first connect succeeds.

Nothing was ever stored against the ephemeral **connection** id, so every path that re-resolves credentials by connection id resolved nothing and dialled the host with no password:

- `beginConnection` (what duplicate goes through)
- `connectConnection`
- `reconnect` / `reconnectAttempt` (the auto-reconnect backoff)
- `reconnectWithPassphrase`

The ephemeral record itself was fine — `removeSession` already holds it until the last session on that connection id closes. Only the secret was missing.

## Fix

New `src/services/ephemeralCredentials.ts`: a module-level map keyed by ephemeral connection id, **in memory only** — never the keychain, never disk.

- `resolveConnectionCredentials` layers the cache *under* whatever the vault resolved, so stored secrets always win and saved hosts are unaffected.
- Written on a successful `retryConnect`, and only while the id is still ephemeral.
- Dropped by a new `dropEphemeralConnection()` — which folds together the record delete and the cache clear at both call sites — when the last session on that id closes, or when the host is materialized into a real saved connection.

An overlay-entered **username** was being lost the same way; it is now carried too.

`duplicateSession` stays synchronous — nothing new is awaited on the duplicate path.

## Verification

- 6 new unit tests in `tests/ephemeralCredentials.test.ts`; `tsc --noEmit` clean.
- Live in the headless stack: quick-connect `ssh voltius@ssh-host-1:2222` → "Connect" (not "Connect & Save") → Ctrl+Shift+D → the duplicate reaches a live `ssh-host-1:~$` prompt, both tabs green.
- Negative control: with the one-line cache read disabled, the identical script reproducibly lands the duplicate on "AUTHENTICATION REQUIRED"; restored, it connects.

The reconnect half is covered by the shared code path (`resolveConnectionCredentials`, exercised by the duplicate run) and unit tests rather than a separate live drop-and-reconnect: a non-persistent session that is dropped has its tab removed outright, so there is no reconnect button to click.

## Note

Branched off `dev` at 8cc2a73. Touches `sessionStore.ts` and `duplicateSession.ts`'s neighbourhood but not the same lines as #109 — no textual conflict expected.
