### PR TITLE
fix(mcp): close the P6 pane follow-ups

### DIFF
--- a/src/components/filetransfer/TransferQueue.tsx
+++ b/src/components/filetransfer/TransferQueue.tsx
@@ -136,6 +136,8 @@ export function TransferQueue({ transfers, onClear, onCancel, onCancelAll, onRet
                   title={mcpOwnerTitle(tr.owner, t, {
                     known: "fileTransfer.queue.mcpTooltip",
                     unknown: "fileTransfer.queue.mcpTooltipUnknown",
+                    // Transfers show "started by" regardless of connection state (out of scope here).
+                    disconnected: "fileTransfer.queue.mcpTooltip",
                   })}
                 >
                   {tr.owner && <McpMark variant="rail" testId={`mcp-bar-${tr.id}`} busy={tr.status === "running"} />}

--- a/src/components/layout/TitleBar.tsx
+++ b/src/components/layout/TitleBar.tsx
@@ -198,17 +198,24 @@ export default function TitleBar() {
   };
 
   const renderMcpBar = (key: string, sessionIds: string[]) => {
-    const owned = sessionIds.some((id) => id in mcpOwners);
+    const owners = sessionIds.map((id) => mcpOwners[id]).filter((o) => o !== undefined);
     const busy = sessionIds.some((id) => (mcpBusy[id] ?? 0) > 0);
-    if (!owned && !busy) return null;
-    return <McpMark variant="rail" testId={`mcp-bar-${key}`} busy={busy} />;
+    if (owners.length === 0 && !busy) return null;
+    // Orphaned only if every owned session in this tab lost its client; an unowned,
+    // merely-busy session (a live call against a user-opened session) is not an orphan.
+    const disconnected = owners.length > 0 && owners.every((o) => o.clientId === null);
+    return <McpMark variant="rail" testId={`mcp-bar-${key}`} busy={busy} disconnected={disconnected} />;
   };
 
   const mcpTooltip = (sessionIds: string[]): string | undefined =>
     mcpOwnerTitle(
       sessionIds.map((id) => mcpOwners[id]).find((o) => o !== undefined),
       t,
-      { known: "panes.header.mcpTooltip", unknown: "panes.header.mcpTooltipUnknown" },
+      {
+        known: "panes.header.mcpTooltip",
+        unknown: "panes.header.mcpTooltipUnknown",
+        disconnected: "panes.header.mcpTooltipDisconnected",
+      },
     );
 
   const renderTitlebarDropCue = (itemKey: string | null, placement: "before" | "after") => {

--- a/src/components/panes/PaneHeader.tsx
+++ b/src/components/panes/PaneHeader.tsx
@@ -345,9 +345,11 @@ export function PaneHeader({ paneId, session, active }: { paneId: string; sessio
         {mcpOwner && (
           <McpMark
             variant="chip"
+            disconnected={mcpOwner.clientId === null}
             title={mcpOwnerTitle(mcpOwner, t, {
               known: "panes.header.mcpTooltip",
               unknown: "panes.header.mcpTooltipUnknown",
+              disconnected: "panes.header.mcpTooltipDisconnected",
             })}
             label={t("panes.header.mcpBadge")}
           />

--- a/src/components/shared/McpMark.test.tsx
+++ b/src/components/shared/McpMark.test.tsx
@@ -8,7 +8,11 @@ afterEach(() => cleanup());
 
 const t = ((key: string, opts?: Record<string, unknown>) =>
   opts?.client ? `${key}:${String(opts.client)}` : key) as never;
-const keys = { known: "panes.header.mcpTooltip", unknown: "panes.header.mcpTooltipUnknown" };
+const keys = {
+  known: "panes.header.mcpTooltip",
+  unknown: "panes.header.mcpTooltipUnknown",
+  disconnected: "panes.header.mcpTooltipDisconnected",
+};
 
 describe("mcpOwnerTitle", () => {
   it("is undefined with no owner", () => {
@@ -24,6 +28,16 @@ describe("mcpOwnerTitle", () => {
     expect(mcpOwnerTitle({ clientId: "c", clientName: "", since: 0 }, t, keys))
       .toBe("panes.header.mcpTooltipUnknown");
   });
+
+  it("picks the disconnected wording for an orphan", () => {
+    expect(mcpOwnerTitle({ clientId: null, clientName: "Claude Code", since: 0 }, t, keys))
+      .toBe("panes.header.mcpTooltipDisconnected:Claude Code");
+  });
+
+  it("falls back to the unknown wording when an orphan has no name", () => {
+    expect(mcpOwnerTitle({ clientId: null, clientName: "", since: 0 }, t, keys))
+      .toBe("panes.header.mcpTooltipUnknown");
+  });
 });
 
 describe("McpMark rail", () => {
@@ -36,6 +50,11 @@ describe("McpMark rail", () => {
   it("pulses while busy", () => {
     render(<McpMark variant="rail" testId="mcp-bar-tab-1" busy />);
     expect(screen.getByTestId("mcp-bar-tab-1").className).toContain("mcp-pulse");
+  });
+
+  it("never pulses while disconnected, even if busy", () => {
+    render(<McpMark variant="rail" testId="mcp-bar-tab-1" busy disconnected />);
+    expect(screen.getByTestId("mcp-bar-tab-1").className).not.toContain("mcp-pulse");
   });
 });
 

--- a/src/components/shared/McpMark.tsx
+++ b/src/components/shared/McpMark.tsx
@@ -2,15 +2,17 @@ import { Icon } from "@iconify/react";
 import type { TFunction } from "i18next";
 import type { McpOwner } from "@/stores/mcpOwnershipStore";
 
-/** The tooltip for an MCP-owned surface. Each site passes its own key pair:
- *  a tab is "opened by", a transfer is "started by". */
+/** The tooltip for an MCP-owned surface. Each site passes its own key set:
+ *  a tab is "opened by", a transfer is "started by". A `null` clientId means
+ *  the owning client disconnected, leaving the surface an orphan. */
 export function mcpOwnerTitle(
   owner: McpOwner | undefined,
   t: TFunction,
-  keys: { known: string; unknown: string },
+  keys: { known: string; unknown: string; disconnected: string },
 ): string | undefined {
   if (!owner) return undefined;
-  return owner.clientName ? t(keys.known, { client: owner.clientName }) : t(keys.unknown);
+  if (!owner.clientName) return t(keys.unknown);
+  return t(owner.clientId === null ? keys.disconnected : keys.known, { client: owner.clientName });
 }
 
 /** Background for a surface an MCP client owns. */
@@ -19,16 +21,16 @@ export function mcpTint(base: string): string {
 }
 
 type Props =
-  | { variant: "rail"; testId: string; busy: boolean }
-  | { variant: "chip"; title: string | undefined; label: string };
+  | { variant: "rail"; testId: string; busy: boolean; disconnected?: boolean }
+  | { variant: "chip"; title: string | undefined; label: string; disconnected?: boolean };
 
 export function McpMark(props: Props) {
   if (props.variant === "rail") {
     return (
       <span
         data-testid={props.testId}
-        className={`absolute left-0 top-0 bottom-0 w-[3px] ${props.busy ? "mcp-pulse" : ""}`}
-        style={{ background: "var(--t-mcp)" }}
+        className={`absolute left-0 top-0 bottom-0 w-[3px] ${props.busy && !props.disconnected ? "mcp-pulse" : ""}`}
+        style={{ background: "var(--t-mcp)", opacity: props.disconnected ? 0.4 : 1 }}
       />
     );
   }
@@ -36,7 +38,11 @@ export function McpMark(props: Props) {
     <span
       data-testid="mcp-chip"
       className="flex items-center gap-1 px-1.5 py-0.5 rounded-sm text-[10px] font-semibold"
-      style={{ background: "color-mix(in srgb, var(--t-mcp) 22%, transparent)", color: "var(--t-mcp)" }}
+      style={{
+        background: `color-mix(in srgb, var(--t-mcp) ${props.disconnected ? 10 : 22}%, transparent)`,
+        color: "var(--t-mcp)",
+        opacity: props.disconnected ? 0.6 : 1,
+      }}
       title={props.title}
     >
       <Icon icon="lucide:bot" width={11} />

--- a/src/i18n/locales/en/panes.json
+++ b/src/i18n/locales/en/panes.json
@@ -14,6 +14,7 @@
       "mcpBadge": "MCP",
       "mcpTooltip": "Opened by {{client}}",
       "mcpTooltipUnknown": "Opened by an MCP client",
+      "mcpTooltipDisconnected": "Opened by {{client}} (disconnected)",
       "disableBroadcast": "Disable broadcast",
       "broadcastInput": "Broadcast input",
       "detachPane": "Detach pane",

--- a/src/i18n/locales/fr/panes.json
+++ b/src/i18n/locales/fr/panes.json
@@ -14,6 +14,7 @@
       "mcpBadge": "MCP",
       "mcpTooltip": "Ouvert par {{client}}",
       "mcpTooltipUnknown": "Ouvert par un client MCP",
+      "mcpTooltipDisconnected": "Ouvert par {{client}} (déconnecté)",
       "disableBroadcast": "Désactiver la diffusion",
       "broadcastInput": "Diffuser la saisie",
       "detachPane": "Détacher le panneau",

--- a/src/i18n/locales/ru/panes.json
+++ b/src/i18n/locales/ru/panes.json
@@ -14,6 +14,7 @@
       "mcpBadge": "MCP",
       "mcpTooltip": "Открыто клиентом {{client}}",
       "mcpTooltipUnknown": "Открыто MCP-клиентом",
+      "mcpTooltipDisconnected": "Открыто клиентом {{client}} (соединение закрыто)",
       "disableBroadcast": "Отключить трансляцию",
       "broadcastInput": "Транслировать ввод",
       "detachPane": "Отсоединить панель",

--- a/src/i18n/locales/zh/panes.json
+++ b/src/i18n/locales/zh/panes.json
@@ -14,6 +14,7 @@
       "mcpBadge": "MCP",
       "mcpTooltip": "由 {{client}} 打开",
       "mcpTooltipUnknown": "由 MCP 客户端打开",
+      "mcpTooltipDisconnected": "由 {{client}} 打开（已断开）",
       "disableBroadcast": "禁用广播",
       "broadcastInput": "广播输入",
       "detachPane": "分离面板",

--- a/src/mcp/register.ownership.test.ts
+++ b/src/mcp/register.ownership.test.ts
@@ -5,11 +5,19 @@ vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn(async () => {}) }));
 
 const execute = vi.fn(async () => ({ ok: true }));
 vi.mock("./consumer", () => ({
-  buildMcpTools: (_api: unknown, owned: Set<string>) => [
+  buildMcpTools: (_api: unknown, owned: {
+    has: (id: string) => boolean;
+    add: (id: string) => void;
+    acquire?: (id: string) => boolean;
+  }) => [
     { name: "open_session", schema: { safeParse: (a: unknown) => ({ success: true, data: a }) },
       execute: async () => { owned.add("s1"); return { sessionId: "s1" }; } },
     { name: "run_command", schema: { safeParse: (a: unknown) => ({ success: true, data: a }) },
       execute },
+    { name: "claim_probe", schema: { safeParse: (a: unknown) => ({ success: true, data: a }) },
+      execute: async (a: { sessionId: string }) => ({ acquired: owned.acquire!(a.sessionId) }) },
+    { name: "list_probe", schema: { safeParse: (a: unknown) => ({ success: true, data: a }) },
+      execute: async (a: { sessionId: string }) => ({ owned: owned.has(a.sessionId) }) },
   ],
   listToolDescriptors: (tools: { name: string }[]) => tools.map((t) => ({ name: t.name })),
   callTool: async (tools: { name: string; execute: (a: unknown) => Promise<unknown> }[], name: string, args: unknown) => {
@@ -86,5 +94,43 @@ describe("bridge ownership", () => {
     await vi.runAllTimersAsync();
     expect(useMcpOwnershipStore.getState().busy).toEqual({});
     vi.useRealTimers();
+  });
+
+  it("a different client adopts an orphaned session on a write", async () => {
+    await handleBridgePayload({ op: "tools/call", name: "open_session", args: {}, clientId: "c1" });
+    await handleBridgePayload({ op: "client_closed", clientId: "c1" });
+    await handleBridgePayload({
+      op: "tools/call", name: "claim_probe", args: { sessionId: "s1" },
+      clientId: "c2", clientName: "Second",
+    });
+    expect(useMcpOwnershipStore.getState().owners.s1).toMatchObject({
+      clientId: "c2", clientName: "Second",
+    });
+  });
+
+  it("a live client cannot take another live client's session", async () => {
+    await handleBridgePayload({ op: "tools/call", name: "open_session", args: {}, clientId: "c1" });
+    const result = await handleBridgePayload({
+      op: "tools/call", name: "claim_probe", args: { sessionId: "s1" }, clientId: "c2",
+    });
+    expect(result).toMatchObject({ result: { acquired: false } });
+    expect(useMcpOwnershipStore.getState().owners.s1).toMatchObject({ clientId: "c1" });
+  });
+
+  it("a session with no owner row is never adoptable", async () => {
+    const result = await handleBridgePayload({
+      op: "tools/call", name: "claim_probe", args: { sessionId: "user-session" }, clientId: "c2",
+    });
+    expect(result).toMatchObject({ result: { acquired: false } });
+    expect(useMcpOwnershipStore.getState().owners["user-session"]).toBeUndefined();
+  });
+
+  it("a listing does not adopt an orphan", async () => {
+    await handleBridgePayload({ op: "tools/call", name: "open_session", args: {}, clientId: "c1" });
+    await handleBridgePayload({ op: "client_closed", clientId: "c1" });
+    await handleBridgePayload({
+      op: "tools/call", name: "list_probe", args: { sessionId: "s1" }, clientId: "c2",
+    });
+    expect(useMcpOwnershipStore.getState().owners.s1).toMatchObject({ clientId: null });
   });
 });

--- a/src/mcp/register.ownership.test.ts
+++ b/src/mcp/register.ownership.test.ts
@@ -47,10 +47,10 @@ describe("bridge ownership", () => {
     expect(useMcpOwnershipStore.getState().owners.s1.clientName).toBe("");
   });
 
-  it("client_closed clears that client's claims", async () => {
+  it("client_closed orphans that client's claims rather than dropping them", async () => {
     await handleBridgePayload({ op: "tools/call", name: "open_session", args: {}, clientId: "c1" });
     await handleBridgePayload({ op: "client_closed", clientId: "c1" });
-    expect(useMcpOwnershipStore.getState().owners.s1).toBeUndefined();
+    expect(useMcpOwnershipStore.getState().owners.s1).toMatchObject({ clientId: null });
   });
 
   it("marks the session busy for the duration of a call and clears it after", async () => {

--- a/src/mcp/register.ts
+++ b/src/mcp/register.ts
@@ -28,6 +28,17 @@ function ownedSessionsFor(clientId: string, name: () => string): OwnedSessions {
   const store = () => useMcpOwnershipStore.getState();
   return {
     has: (id) => store().owners[id]?.clientId === clientId,
+    // An orphan — a session this or another MCP client opened, whose client has
+    // since disconnected — is adopted by the first client that writes to it. A
+    // session with no row at all is one the user opened, and stays unclaimable.
+    acquire: (id) => {
+      const owner = store().owners[id];
+      if (!owner) return false;
+      if (owner.clientId === clientId) return true;
+      if (owner.clientId !== null) return false;
+      store().claim(id, { clientId, clientName: name() });
+      return true;
+    },
     add: (id) => store().claim(id, { clientId, clientName: name() }),
     delete: (id) => {
       const had = store().owners[id]?.clientId === clientId;

--- a/src/plugins/domains/panes.test.ts
+++ b/src/plugins/domains/panes.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import type { PanePorts } from "./panes";
 import { detach, focus, listTabs, moveToPane, PANE_ERRORS, splitWith } from "./panes";
-import type { SplitTab } from "@/stores/layoutStore";
+import type { SplitTab, SplitPosition } from "@/stores/layoutStore";
+import { splitGeometry } from "@/stores/layoutStore";
 
 export const splitTab = (over: Partial<SplitTab> = {}): SplitTab => ({
   id: "tab-1",
@@ -387,6 +388,31 @@ describe("focus", () => {
       }),
     });
     expect(focus(ports, "sess-b")).toEqual({ ok: false, error: PANE_ERRORS.unchanged });
+  });
+});
+
+describe("splitGeometry", () => {
+  it("maps each position to a direction and an order", () => {
+    expect(splitGeometry("left")).toEqual({ direction: "h", incomingFirst: true });
+    expect(splitGeometry("right")).toEqual({ direction: "h", incomingFirst: false });
+    expect(splitGeometry("top")).toEqual({ direction: "v", incomingFirst: true });
+    expect(splitGeometry("bottom")).toEqual({ direction: "v", incomingFirst: false });
+  });
+
+  it("verifies a same-tab move against the geometry the position implies", () => {
+    const positions: SplitPosition[] = ["left", "right", "top", "bottom"];
+    for (const position of positions) {
+      const { direction, incomingFirst } = splitGeometry(position);
+      const first = { type: "leaf" as const, id: "p-1", sessionId: incomingFirst ? "sess-c" : "sess-a" };
+      const second = { type: "leaf" as const, id: "p-2", sessionId: incomingFirst ? "sess-a" : "sess-c" };
+      const ports = makePorts({
+        splitTabs: vi.fn(() => [splitTab({
+          root: { type: "split", id: "s-1", direction, ratio: 0.5, first, second },
+        })]),
+      });
+      const result = moveToPane(ports, { sessionId: "sess-c", targetSessionId: "sess-a", position });
+      expect(result.ok).toBe(true);
+    }
   });
 });
 

--- a/src/plugins/domains/panes.test.ts
+++ b/src/plugins/domains/panes.test.ts
@@ -265,8 +265,52 @@ describe("moveToPane", () => {
   it("refuses when the target's tab has broadcast typing enabled", () => {
     const ports = makePorts({ splitTabs: vi.fn(() => [splitTab({ broadcastActive: true })]) });
     const result = moveToPane(ports, { sessionId: "sess-a", targetSessionId: "sess-b", position: "top" });
-    expect(result).toEqual({ ok: false, error: PANE_ERRORS.broadcastActive });
+    expect(result).toEqual({ ok: false, error: PANE_ERRORS.broadcastActiveSameTab });
     expect(ports.movePane).not.toHaveBeenCalled();
+  });
+});
+
+describe("broadcast refusals name the right action", () => {
+  const broadcasting = () =>
+    makePorts({ splitTabs: vi.fn(() => [splitTab({ broadcastActive: true })]) });
+
+  it("a move inside a broadcasting tab talks about moving, not placing", () => {
+    const result = moveToPane(broadcasting(), {
+      sessionId: "sess-a", targetSessionId: "sess-b", position: "right",
+    });
+    expect(result).toEqual({ ok: false, error: PANE_ERRORS.broadcastActiveSameTab });
+  });
+
+  it("a split into a broadcasting tab keeps the placement wording", () => {
+    const result = splitWith(broadcasting(), {
+      sessionId: "sess-c", targetSessionId: "sess-a", position: "right",
+    });
+    expect(result).toEqual({ ok: false, error: PANE_ERRORS.broadcastActive });
+  });
+
+  it("a cross-tab move into a broadcasting tab keeps the placement wording", () => {
+    const source = splitTab({
+      id: "tab-2",
+      root: {
+        type: "split", id: "s-2", direction: "h", ratio: 0.5,
+        first: { type: "leaf", id: "p-3", sessionId: "sess-c" },
+        second: { type: "leaf", id: "p-4", sessionId: "sess-d" },
+      },
+      broadcastActive: false,
+    });
+    const ports = makePorts({
+      splitTabs: vi.fn(() => [splitTab({ broadcastActive: true }), source]),
+      sessions: vi.fn(() => [
+        { id: "sess-a", connectionName: "web-01" },
+        { id: "sess-b", connectionName: "db-01" },
+        { id: "sess-c", connectionName: "lonely" },
+        { id: "sess-d", connectionName: "other" },
+      ]),
+    });
+    const result = moveToPane(ports, {
+      sessionId: "sess-c", targetSessionId: "sess-a", position: "right",
+    });
+    expect(result).toEqual({ ok: false, error: PANE_ERRORS.broadcastActive });
   });
 });
 

--- a/src/plugins/domains/panes.ts
+++ b/src/plugins/domains/panes.ts
@@ -48,6 +48,7 @@ export const PANE_ERRORS = {
   alreadySplit: "that session is already in a split tab; use session_move_to_pane",
   notSplit: "that session is not in a split tab; use pane_split first",
   broadcastActive: "the target tab has broadcast typing enabled; turn broadcast off before placing a pane there",
+  broadcastActiveSameTab: "that tab has broadcast typing enabled; turn broadcast off before moving panes inside it",
   noPaneToMaximize: "that session is not in a split tab; there is no pane to maximize",
   // Every layout store method returns {} rather than throwing when it cannot
   // find its target, so a write is only known to have happened by re-reading.
@@ -144,8 +145,8 @@ function preflight(ports: PanePorts, input: PairInput): PaneResult | null {
  *  membership test is presence in the tab. Placing an owned pane into a
  *  broadcasting tab would hand the user's keystrokes, passwords included, to
  *  the agent's PTY. */
-function refuseBroadcastingTarget(tab: SplitTab | null): PaneResult | null {
-  return tab?.broadcastActive ? { ok: false, error: PANE_ERRORS.broadcastActive } : null;
+function refuseBroadcastingTarget(tab: SplitTab | null, error: string = PANE_ERRORS.broadcastActive): PaneResult | null {
+  return tab?.broadcastActive ? { ok: false, error } : null;
 }
 
 /** `createSplitTab` (`layoutStore.ts:285`) inherits `state.broadcastActive`
@@ -243,10 +244,14 @@ export function moveToPane(ports: PanePorts, input: PairInput): PaneResult {
   if (!source) return { ok: false, error: PANE_ERRORS.notSplit };
 
   const target = locate(ports, input.targetSessionId);
-  const broadcastRefusal = refuseBroadcastingTarget(target?.tab ?? null);
+  const sameTab = target !== null && target.tab.id === source.tab.id;
+  const broadcastRefusal = refuseBroadcastingTarget(
+    target?.tab ?? null,
+    sameTab ? PANE_ERRORS.broadcastActiveSameTab : PANE_ERRORS.broadcastActive,
+  );
   if (broadcastRefusal) return broadcastRefusal;
 
-  if (target && target.tab.id === source.tab.id) {
+  if (sameTab && target) {
     ports.activateSplitTab(source.tab.id);
     ports.movePane(source.leaf.id, target.leaf.id, input.position);
     return verifySameTabMove(ports, input);

--- a/src/plugins/domains/panes.ts
+++ b/src/plugins/domains/panes.ts
@@ -1,9 +1,9 @@
 import {
   findLeafBySession,
   getPaneSessionIds,
+  splitGeometry,
   type LeafNode,
   type PaneNode,
-  type SplitDirection,
   type SplitNode,
   type SplitPosition,
   type SplitTab,
@@ -192,7 +192,7 @@ function findParentSplit(root: PaneNode, leafId: string): SplitNode | null {
 /**
  * Re-read the layout and confirm the postcondition a same-tab move implies:
  * the two leaves are siblings under one split node, with the direction and
- * first/second order `position` implies (`splitLeaf`, `layoutStore.ts:111`).
+ * first/second order `position` implies (`splitGeometry`, `layoutStore.ts`).
  * Checking only "both sessions share a tab" (`verifyTogether`) proves nothing
  * here — that is already true before the move runs, so a silent store no-op
  * would still read as success.
@@ -201,8 +201,7 @@ function verifySameTabMove(ports: PanePorts, input: PairInput): PaneResult {
   const placed = locate(ports, input.sessionId);
   if (!placed) return { ok: false, error: PANE_ERRORS.unchanged };
   const parent = findParentSplit(placed.tab.root, placed.leaf.id);
-  const direction: SplitDirection = input.position === "left" || input.position === "right" ? "h" : "v";
-  const incomingFirst = input.position === "left" || input.position === "top";
+  const { direction, incomingFirst } = splitGeometry(input.position);
   const [expectedFirst, expectedSecond] = incomingFirst
     ? [input.sessionId, input.targetSessionId]
     : [input.targetSessionId, input.sessionId];

--- a/src/plugins/toolSurface/tools/helpers.ts
+++ b/src/plugins/toolSurface/tools/helpers.ts
@@ -186,3 +186,8 @@ export function objectOp(ports: ToolSurfacePorts, gate: ReturnType<typeof makeGa
     }
   };
 }
+
+/** The ownership check every MCP write gate uses. */
+export function mayAct(ports: ToolSurfacePorts, sessionId: string): boolean {
+  return ports.owned.acquire?.(sessionId) ?? ports.owned.has(sessionId);
+}

--- a/src/plugins/toolSurface/tools/panes.test.ts
+++ b/src/plugins/toolSurface/tools/panes.test.ts
@@ -110,4 +110,10 @@ describe("pane tools", () => {
     const result = await tool(ports, "pane_detach").execute({ sessionId: "sess-b" });
     expect(result).toMatchObject({ refused: true, error: "not yours" });
   });
+
+  it("pane_focus documents that maximize needs a split tab", () => {
+    const { ports } = makePorts();
+    expect(tool(ports, "pane_focus").description).toContain("maximize");
+    expect(tool(ports, "pane_focus").description).toMatch(/not in a split tab/);
+  });
 });

--- a/src/plugins/toolSurface/tools/panes.test.ts
+++ b/src/plugins/toolSurface/tools/panes.test.ts
@@ -116,4 +116,21 @@ describe("pane tools", () => {
     expect(tool(ports, "pane_focus").description).toContain("maximize");
     expect(tool(ports, "pane_focus").description).toMatch(/not in a split tab/);
   });
+
+  it("a pane write adopts through acquire when the double provides one", async () => {
+    const acquire = vi.fn(() => true);
+    const { ports, panes } = makePorts();
+    const withAcquire = { ...ports, owned: { ...ports.owned, acquire } } as ToolSurfacePorts;
+    await tool(withAcquire, "pane_detach").execute({ sessionId: "orphan" });
+    expect(acquire).toHaveBeenCalledWith("orphan");
+    expect(panes.detach).toHaveBeenCalledWith("orphan");
+  });
+
+  it("pane_list never adopts", async () => {
+    const acquire = vi.fn(() => true);
+    const { ports } = makePorts();
+    const withAcquire = { ...ports, owned: { ...ports.owned, acquire } } as ToolSurfacePorts;
+    await tool(withAcquire, "pane_list").execute({});
+    expect(acquire).not.toHaveBeenCalled();
+  });
 });

--- a/src/plugins/toolSurface/tools/panes.ts
+++ b/src/plugins/toolSurface/tools/panes.ts
@@ -97,7 +97,9 @@ export function buildPaneTools(ports: ToolSurfacePorts): Tool[] {
       name: "pane_focus",
       description:
         "Bring a session's pane to the front so the user sees it, optionally maximizing it within "
-        + "its tab. Works on any open session, changes only what is visible. Prompts the user.",
+        + "its tab. Works on any open session, changes only what is visible. `maximize: true` is "
+        + "refused for a session that is not in a split tab, because there is no pane to maximize. "
+        + "Prompts the user.",
       risk: "prompt",
       schema: z.object({ sessionId: z.string(), maximize: z.boolean().optional() }),
       execute: async (raw) =>

--- a/src/plugins/toolSurface/tools/panes.ts
+++ b/src/plugins/toolSurface/tools/panes.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { PluginPanePosition, PluginPaneResult } from "@/plugins/api";
 import type { Tool } from "../types";
 import type { ToolSurfacePorts } from "../coreTools";
-import { makeGate } from "./helpers";
+import { makeGate, mayAct } from "./helpers";
 import { refusal } from "../refusal";
 
 export const PANE_PERMISSIONS = ["panes:read", "panes:write"] as const;
@@ -38,10 +38,10 @@ export function buildPaneTools(ports: ToolSurfacePorts): Tool[] {
     run: (args: Record<string, unknown>) => PluginPaneResult,
     requireOwned = true,
   ): Promise<unknown> => {
-    if (requireOwned && !ports.owned.has(String(raw.sessionId))) return notOwned();
+    if (requireOwned && !mayAct(ports, String(raw.sessionId))) return notOwned();
     const g = await gate(tool, raw);
     if (!g.ok) return g.result;
-    if (requireOwned && !ports.owned.has(String(g.args.sessionId))) return notOwned();
+    if (requireOwned && !mayAct(ports, String(g.args.sessionId))) return notOwned();
     const result = run(g.args);
     return result.ok ? { ok: true, result: result.tab } : refusal(result.error);
   };

--- a/src/plugins/toolSurface/tools/sessions.ts
+++ b/src/plugins/toolSurface/tools/sessions.ts
@@ -4,7 +4,7 @@ import type { ToolSurfacePorts } from "../coreTools";
 import { captureCommand, sendKeysToSession, sendSerialCommand } from "../capture";
 import { tokensToBytes } from "../keyTokens";
 import { guardConnectionId } from "../connectionGuard";
-import { makeGate, sessionAuditMeta, sessionGate } from "./helpers";
+import { makeGate, mayAct, sessionAuditMeta, sessionGate } from "./helpers";
 import { refusal } from "../refusal";
 
 export const SESSION_PERMISSIONS = [
@@ -169,13 +169,13 @@ export function buildSessionTools(ports: ToolSurfacePorts): Tool[] {
       risk: "prompt",
       schema: z.object({ sessionId: z.string() }),
       execute: async (raw) => {
-        if (!ports.owned.has(String(raw.sessionId))) {
+        if (!mayAct(ports, String(raw.sessionId))) {
           return notOwned(ports);
         }
         const g = await gate("close_session", raw);
         if (!g.ok) return g.result;
         const sessionId = String(g.args.sessionId);
-        if (!ports.owned.has(sessionId)) {
+        if (!mayAct(ports, sessionId)) {
           return notOwned(ports);
         }
         await ports.api.sessions.close(sessionId);

--- a/src/plugins/toolSurface/types.ts
+++ b/src/plugins/toolSurface/types.ts
@@ -23,7 +23,12 @@ export type ToolDecision =
  *  consumer back it with something other than a plain Set — the MCP bridge
  *  backs it with a reactive store so the UI can see provenance. */
 export interface OwnedSessions {
+  /** Pure: does this caller already own the session. Used by listings. */
   has(sessionId: string): boolean;
+  /** May this caller act on the session, adopting an orphan if it is one.
+   *  Optional so a bare Set still satisfies the interface in tests; `mayAct`
+   *  falls back to `has`. */
+  acquire?(sessionId: string): boolean;
   add(sessionId: string): void;
   delete(sessionId: string): boolean;
 }

--- a/src/stores/layoutStore.ts
+++ b/src/stores/layoutStore.ts
@@ -108,9 +108,19 @@ function replaceLeaf(root: PaneNode, targetPaneId: string, replacement: PaneNode
   };
 }
 
+/** Where a split places the incoming leaf: which axis, and which side. */
+export function splitGeometry(position: SplitPosition): {
+  direction: SplitDirection;
+  incomingFirst: boolean;
+} {
+  return {
+    direction: position === "left" || position === "right" ? "h" : "v",
+    incomingFirst: position === "left" || position === "top",
+  };
+}
+
 function splitLeaf(target: LeafNode, leaf: LeafNode, position: SplitPosition): SplitNode {
-  const direction: SplitDirection = position === "left" || position === "right" ? "h" : "v";
-  const incomingFirst = position === "left" || position === "top";
+  const { direction, incomingFirst } = splitGeometry(position);
   return {
     type: "split",
     id: newSplitId(),

--- a/src/stores/mcpOwnershipStore.test.ts
+++ b/src/stores/mcpOwnershipStore.test.ts
@@ -15,11 +15,26 @@ describe("mcpOwnershipStore", () => {
     expect(store().owners.s1).toBeUndefined();
   });
 
-  it("clearClient drops only that client's sessions", () => {
+  it("clearClient orphans only that client's sessions and keeps the rows", () => {
     store().claim("s1", { clientId: "c1", clientName: "A" });
     store().claim("s2", { clientId: "c2", clientName: "B" });
     store().clearClient("c1");
-    expect(Object.keys(store().owners)).toEqual(["s2"]);
+    expect(store().owners.s1).toMatchObject({ clientId: null, clientName: "A" });
+    expect(store().owners.s2).toMatchObject({ clientId: "c2" });
+  });
+
+  it("clearClient leaves the state object untouched when it owns nothing", () => {
+    store().claim("s1", { clientId: "c1", clientName: "A" });
+    const before = store().owners;
+    store().clearClient("c2");
+    expect(store().owners).toBe(before);
+  });
+
+  it("keepOnly still drops orphan rows for sessions that are gone", () => {
+    store().claim("s1", { clientId: "c1", clientName: "A" });
+    store().clearClient("c1");
+    store().keepOnly([]);
+    expect(store().owners).toEqual({});
   });
 
   it("keepOnly prunes owners and busy counters for sessions that are gone", () => {

--- a/src/stores/mcpOwnershipStore.ts
+++ b/src/stores/mcpOwnershipStore.ts
@@ -1,7 +1,9 @@
 import { create } from "zustand";
 
 export interface McpOwner {
-  clientId: string;
+  /** null once the client that opened this session disconnected: the session is
+   *  an orphan, adoptable by the next MCP client that writes to it. */
+  clientId: string | null;
   clientName: string;
   since: number;
 }
@@ -45,10 +47,14 @@ export const useMcpOwnershipStore = create<McpOwnershipStore>((set) => ({
 
   clearClient: (clientId) =>
     set((s) => {
+      const hit = Object.values(s.owners).some((o) => o.clientId === clientId);
+      if (!hit) return s;
       const owners = Object.fromEntries(
-        Object.entries(s.owners).filter(([, o]) => o.clientId !== clientId),
+        Object.entries(s.owners).map(([id, o]) =>
+          [id, o.clientId === clientId ? { ...o, clientId: null } : o],
+        ),
       );
-      return Object.keys(owners).length === Object.keys(s.owners).length ? s : { owners };
+      return { owners };
     }),
 
   keepOnly: (sessionIds) =>


### PR DESCRIPTION
Closes the four follow-ups deliberately deferred when the MCP panes phase (#111) shipped.

## The real bug

MCP session ownership was scoped to the client **connection**, not the client or the session. The client id is a fresh UUID per accepted socket, and on disconnect `clearClient` deleted every ownership row that client held. The sessions stayed open, but nothing could ever claim them again — `close_session` and every pane write refused permanently, and the violet MCP mark vanished from a tab still holding an agent shell. Pre-existing since the first MCP phase.

Now `clearClient` **marks** each row `clientId: null` — an orphan — instead of deleting it, and the first *write* by any MCP client adopts an orphan (`acquire` in `src/mcp/register.ts`, reached through `mayAct`). Three properties hold:

- A session the **user** opened by hand has no ownership row at all, so it stays permanently unclaimable — an agent can never adopt what it did not open.
- A row belonging to a **live** client is never adoptable, so two concurrent clients keep full isolation.
- **Listings never adopt.** `pane_list`, `list_sessions` and `sessionAuditMeta` keep the pure `has`; only write gates call `mayAct`. An adopting `has` would have claimed every orphan in sight just by listing them.

An orphaned tab now renders with a dimmed, non-pulsing rail and an "Opened by {client} (disconnected)" tooltip, so a disconnected agent stops reading as a live one.

## The other three

- **`splitGeometry`**, exported from `layoutStore.ts` and shared by `splitLeaf` (the mutation) and `verifySameTabMove` (the postcondition check). They had duplicated the position → direction/order mapping; a change to one would have made every same-tab `session_move_to_pane` report failure after actually succeeding, with no test catching it.
- A `session_move_to_pane` refused because the tab it is **already in** has broadcast typing on now says "before moving panes inside it" rather than "before placing a pane there". Wording only — the guard and the exfiltration property behind it are untouched.
- `pane_focus`'s description documents that `maximize: true` is refused for a session that is not in a split tab.

Verb count stays 64: no new tool, no new permission, no new audit action.

## Verification

Full suite: 371 files / 2829 tests passing.

Live gate — 7/7 against a real running app with two real `voltius mcp` stdio clients, in a private container:

1. Client A opens a session, splits it, violet rail appears.
2. Client A killed → rail dims to 0.4 opacity, stops pulsing, tooltip reads "(disconnected)", both sessions stay connected.
3. New `voltius mcp` process (new client id): `pane_list` and `pane_focus` do **not** adopt; `session_move_to_pane` does — `ownedByCaller` flips true, rail returns to full opacity.
4. Client B closes an orphan it never opened — the exact operation that was impossible before.
5. `close_session` on a session the user opened by hand is still refused.
6. Same-tab broadcast refusal shows the new wording.
7. `pane_focus` with `maximize: true` outside a split tab refuses.

## Known, deliberately deferred

- A write the user **denies** at the approval card still adopts the orphan, because the ownership check runs before the gate (so a doomed call does not raise a card). Effect is a relabelled tab, no isolation loss.
- A tab holding one orphaned and one live session shows a full-opacity rail with a "(disconnected)" tooltip — the rail is conservative (`every`), the tooltip takes the first owner. Per-pane chips are correct.
- An orphan whose client reported no name shows "Opened by an MCP client" with no disconnect note.
- The **ru and zh** strings for the new i18n key have not had a fluent human read; only fr did.
