### PR TITLE
fix: prevent window from closing if reopened during shutdown sync

### DIFF
--- a/src/plugins/runtime.quitHandler.test.ts
+++ b/src/plugins/runtime.quitHandler.test.ts
@@ -4,15 +4,17 @@ import type { PluginAPI, PluginManifest } from "./api";
 
 type CloseHandler = (event: { preventDefault: () => void }) => unknown;
 
-const { closeHandlers, hide, invoke } = vi.hoisted(() => ({
+const { closeHandlers, hide, invoke, isVisible } = vi.hoisted(() => ({
   closeHandlers: [] as CloseHandler[],
   hide: vi.fn(() => Promise.resolve()),
   invoke: vi.fn(() => Promise.resolve()),
+  isVisible: vi.fn(() => Promise.resolve(false)),
 }));
 
 vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: () => ({
     hide,
+    isVisible,
     onCloseRequested: (cb: CloseHandler) => {
       closeHandlers.push(cb);
       return Promise.resolve(() => {});
@@ -47,6 +49,7 @@ beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   hide.mockClear();
   invoke.mockClear();
+  isVisible.mockClear();
 });
 
 afterEach(() => {

--- a/src/plugins/runtime.quitHandler.test.ts
+++ b/src/plugins/runtime.quitHandler.test.ts
@@ -48,8 +48,10 @@ async function registerQuitHook(cb: () => void | Promise<void>): Promise<() => v
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   hide.mockClear();
+  hide.mockImplementation(() => Promise.resolve());
   invoke.mockClear();
   isVisible.mockClear();
+  isVisible.mockImplementation(() => Promise.resolve(false));
 });
 
 afterEach(() => {
@@ -99,6 +101,62 @@ describe("the close handler", () => {
     // The fallback exit must have been disarmed by the normal path.
     await vi.advanceTimersByTimeAsync(5000);
     expect(invoke).toHaveBeenCalledTimes(1);
+    off();
+  });
+
+  test("cancels the exit when the window was reopened during the wait", async () => {
+    isVisible.mockImplementation(() => Promise.resolve(true));
+    const off = await registerQuitHook(() => {});
+
+    await fireClose();
+
+    expect(invoke).not.toHaveBeenCalled();
+    off();
+  });
+
+  test("exits when the visibility check rejects", async () => {
+    isVisible.mockImplementation(() => Promise.reject(new Error("no window")));
+    const off = await registerQuitHook(() => {});
+
+    await fireClose();
+
+    expect(invoke).toHaveBeenCalledWith("force_quit");
+    off();
+  });
+
+  test("exits when the visibility check never settles", async () => {
+    isVisible.mockImplementation(() => new Promise<boolean>(() => {}));
+    const off = await registerQuitHook(() => {});
+
+    const closed = fireClose();
+    await vi.advanceTimersByTimeAsync(1000);
+    await closed;
+
+    expect(invoke).toHaveBeenCalledWith("force_quit");
+    off();
+  });
+
+  test("exits when the hide failed, without trusting the visibility check", async () => {
+    hide.mockImplementation(() => Promise.reject(new Error("no window")));
+    isVisible.mockImplementation(() => Promise.resolve(true));
+    const off = await registerQuitHook(() => {});
+
+    await fireClose();
+
+    expect(isVisible).not.toHaveBeenCalled();
+    expect(invoke).toHaveBeenCalledWith("force_quit");
+    off();
+  });
+
+  test("exits on the fallback when the hide never settles", async () => {
+    hide.mockImplementation(() => new Promise<void>(() => {}));
+    const off = await registerQuitHook(() => {});
+
+    const closed = fireClose();
+    await vi.advanceTimersByTimeAsync(1000);
+    await closed;
+
+    expect(invoke).toHaveBeenCalledWith("force_quit");
     off();
   });
 });

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -312,14 +312,20 @@ async function ensureQuitHandler() {
     // A hidden window over a live process is worse than a slow close, so the
     // exit is armed up front: it survives a throw or an invoke that never lands.
     const fallback = setTimeout(quit, 6000);
+    let shouldQuit = true;
     try {
       await Promise.race([
         Promise.allSettled(callbacks.map(async (cb) => cb())),
         new Promise<void>((r) => setTimeout(r, 5000)),
       ]);
+      if (await win.isVisible().catch(() => false)) {
+        shouldQuit = false;
+      }
     } finally {
       clearTimeout(fallback);
-      quit();
+      if (shouldQuit) {
+        quit();
+      }
     }
   });
 }

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -290,6 +290,14 @@ function ensureLifecycleSetup() {
   });
 }
 
+/** Resolves with `p`, or with `orElse` if `p` rejects or outlasts `ms`. */
+function settleWithin<T>(p: Promise<T>, ms: number, orElse: T): Promise<T> {
+  return Promise.race([
+    p.catch(() => orElse),
+    new Promise<T>((r) => setTimeout(() => r(orElse), ms)),
+  ]);
+}
+
 async function ensureQuitHandler() {
   if (_quitHandlerRegistered) return;
   _quitHandlerRegistered = true;
@@ -306,26 +314,25 @@ async function ensureQuitHandler() {
       quit();
       return;
     }
-    // Without this the window stays up for the whole wait, which reads as a
-    // hang when a quit hook does network work (gist-sync pushes on exit).
-    win.hide().catch(() => {});
     // A hidden window over a live process is worse than a slow close, so the
     // exit is armed up front: it survives a throw or an invoke that never lands.
     const fallback = setTimeout(quit, 6000);
-    let shouldQuit = true;
+    // Without this the window stays up for the whole wait, which reads as a
+    // hang when a quit hook does network work (gist-sync pushes on exit).
+    // Awaited, because a window the user reopened is only distinguishable from
+    // a hide that failed once the hide itself has landed.
+    const hidden = await settleWithin(win.hide().then(() => true), 1000, false);
     try {
       await Promise.race([
         Promise.allSettled(callbacks.map(async (cb) => cb())),
         new Promise<void>((r) => setTimeout(r, 5000)),
       ]);
-      if (await win.isVisible().catch(() => false)) {
-        shouldQuit = false;
-      }
     } finally {
       clearTimeout(fallback);
-      if (shouldQuit) {
-        quit();
-      }
+      // Single-instance raises the window when the user relaunches Voltius
+      // mid-wait. Exiting then would close an app the user just reopened.
+      const reopened = hidden && (await settleWithin(win.isVisible(), 1000, false));
+      if (!reopened) quit();
     }
   });
 }


### PR DESCRIPTION
The problem:
[https://youtu.be/MN6DXxceRuI](https://youtu.be/MN6DXxceRuI)

When I close the app, the window hides and the sync runs in the background.
However, if you reopen the app before the sync is finished, the window closes once it completes.

This PR fixes this bug; the app will no longer close if the window is shown.