### PR TITLE
fix(test): complete the Team fixture that broke the typecheck

### DIFF
--- a/src/components/terminal/ShareMenu.invitePeople.test.tsx
+++ b/src/components/terminal/ShareMenu.invitePeople.test.tsx
@@ -143,7 +143,7 @@ test("hides the invite section in the active view when no session key is retaine
 });
 
 test("hides the invite section in setup view for free tier", async () => {
-  teamState.teams = [{ id: "vault-1", name: "Vault", owner_tier: "teams" }];
+  teamState.teams = [{ id: "vault-1", name: "Vault", owner_id: "u0", owner_tier: "teams", created_at: "", role_ids: [] }];
   const anchorRef = createRef<HTMLButtonElement>();
   render(
     <ShareMenu


### PR DESCRIPTION
`dev` is red at d630d21 and so is every PR built against it.

```
src/components/terminal/ShareMenu.invitePeople.test.tsx(146,22): error TS2739:
Type '{ id: string; name: string; owner_tier: string; }' is missing the following
properties from type 'Team': owner_id, created_at, role_ids
```

The free-tier test in `ShareMenu.invitePeople.test.tsx` built a `Team` with three of its six fields. Completed it to match the shape every other Team fixture in the repo uses (`teamInbox.test.ts`, `domains/team.test.ts`).

`tsc --noEmit` clean; the file's 5 tests pass.