### PR TITLE
refactor(mcp): setting_set reports coerced, not changed

### DIFF
--- a/src/plugins/api.ts
+++ b/src/plugins/api.ts
@@ -1067,9 +1067,12 @@ export interface PluginAPI {
      *  does). Read-only — requires "settings:read". */
     consequenceOf(key: string, value: unknown): string | undefined;
     /** Writes, then RE-READS: a store setter may clamp or normalise, so
-     *  `effective` is the value that actually landed, not the one asked for. */
+     *  `effective` is the value that actually landed, not the one asked for,
+     *  and `coerced` says whether the two differ. Neither reports whether the
+     *  setting's value moved — writing the value it already held is a
+     *  successful write with `coerced: false`. */
     set(key: string, value: unknown): DomainResult<{
-      key: string; requested: unknown; effective: unknown; changed: boolean;
+      key: string; requested: unknown; effective: unknown; coerced: boolean;
     }>;
   };
 

--- a/src/plugins/domains/settings.test.ts
+++ b/src/plugins/domains/settings.test.ts
@@ -41,7 +41,7 @@ describe("domaine settings", () => {
     const res = setSetting("toggles.scroll-minimap", false);
     expect(res).toEqual({
       ok: true,
-      result: { key: "toggles.scroll-minimap", requested: false, effective: false, changed: false },
+      result: { key: "toggles.scroll-minimap", requested: false, effective: false, coerced: false },
     });
     expect(getSetting("toggles.scroll-minimap")!.value).toBe(false);
   });
@@ -58,7 +58,7 @@ describe("domaine settings", () => {
     expect(res.result.requested).toBe(50_000.6);
     expect(res.result.effective).toBe(50_001);
     expect(res.result.effective).not.toBe(50_000.6);
-    expect(res.result.changed).toBe(true);
+    expect(res.result.coerced).toBe(true);
   });
 
   test("set refuse une valeur hors bornes sans écrire", () => {

--- a/src/plugins/domains/settings.ts
+++ b/src/plugins/domains/settings.ts
@@ -88,7 +88,7 @@ function validate(def: SettingDef, value: unknown): string | undefined {
 export function setSetting(
   key: string,
   value: unknown,
-): DomainResult<{ key: string; requested: unknown; effective: unknown; changed: boolean }> {
+): DomainResult<{ key: string; requested: unknown; effective: unknown; coerced: boolean }> {
   const def = settingDef(key);
   if (!def) return { ok: false, error: unknownSetting(key) };
   if (!def.writable || !def.set) {
@@ -110,6 +110,6 @@ export function setSetting(
   const effective = settingDef(key)?.get();
   return {
     ok: true,
-    result: { key, requested: value, effective, changed: effective !== value },
+    result: { key, requested: value, effective, coerced: effective !== value },
   };
 }

--- a/src/plugins/toolSurface/tools/settings.test.ts
+++ b/src/plugins/toolSurface/tools/settings.test.ts
@@ -24,7 +24,7 @@ const ports = (over: Partial<Record<string, unknown>> = {}) => ({
         key === "toggles.plugin-install-review" && value === false
           ? "Turns off the consent screen."
           : undefined),
-      set: vi.fn(() => ({ ok: true, result: { key: "k", requested: 1, effective: 1, changed: false } })),
+      set: vi.fn(() => ({ ok: true, result: { key: "k", requested: 1, effective: 1, coerced: false } })),
       ...(over.settings as object ?? {}),
     },
   },


### PR DESCRIPTION
`setting_set` returned a field named `changed` that never reported whether the setting changed. It reports whether the store normalised or clamped what you sent: writing the value a key already holds is a successful write that comes back `changed: false`, which reads as "nothing happened".

Renamed to `coerced`, which is what it measures, and the doc comment now says plainly that neither `effective` nor `coerced` tells you whether the stored value moved.

This is a public shape on the MCP surface, so it is renamed now rather than after a release freezes it. P8 introduced it and P8 has not shipped — the last release, 0.25.0, carried 74 verbs and no settings verbs at all — so no published client can be relying on the old name.

Touches `src/plugins/domains/settings.ts`, its `PluginAPI` declaration, and the two tests asserting the field.

`src/plugins` + `src/mcp`: 138 files / 1236 tests green, `tsc --noEmit` clean.
