### PR TITLE
fix(share): relay a local shell to its guests, and route their input back

### DIFF
--- a/src/components/terminal/SessionView.tsx
+++ b/src/components/terminal/SessionView.tsx
@@ -28,7 +28,7 @@ export function HostAwareTerminalView({
   /** Split panes carry no status bar of their own. */
   statusBar?: boolean;
 }) {
-  useMultiplayerHostBroadcast(session.id);
+  useMultiplayerHostBroadcast(session.id, session.type);
   const mpState = useTeamSessionStore((s) => s.connections[session.id]);
   const isSharing = !!mpState;
 

--- a/src/hooks/useMultiplayerHostBroadcast.test.tsx
+++ b/src/hooks/useMultiplayerHostBroadcast.test.tsx
@@ -2,33 +2,34 @@ import { test, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, cleanup, act } from "@testing-library/react";
 
 const h = vi.hoisted(() => ({
-  onSshOutput: vi.fn(),
+  onSessionOutput: vi.fn(),
   append: vi.fn(),
   drain: vi.fn(),
 }));
-vi.mock("@/services/ssh", () => ({ onSshOutput: h.onSshOutput }));
+vi.mock("@/services/sessionInput", () => ({ onSessionOutput: h.onSessionOutput }));
 vi.mock("@/services/multiplayerService", () => ({
-  appendSshOutputBuffer: h.append,
-  drainSshOutputBuffer: h.drain,
+  appendSessionOutputBuffer: h.append,
+  drainSessionOutputBuffer: h.drain,
 }));
 
 import { useMultiplayerHostBroadcast } from "./useMultiplayerHostBroadcast";
 import { useTeamSessionStore } from "@/stores/teamSessionStore";
+import type { TerminalSession } from "@/types";
 
 const ID = "local1";
-function Harness({ id = ID }: { id?: string }) {
-  useMultiplayerHostBroadcast(id);
+function Harness({ id = ID, type = "ssh" as TerminalSession["type"] }: { id?: string; type?: TerminalSession["type"] }) {
+  useMultiplayerHostBroadcast(id, type);
   return null;
 }
 
-// installs onSshOutput mock: captures the callback, hands back an unlisten spy,
-// resolves `ready` once onSshOutput has been called (so tests can await it before emitting).
+// installs the onSessionOutput mock: captures the callback, hands back an unlisten spy,
+// resolves `ready` once onSessionOutput has been called (so tests can await it before emitting).
 function installListener() {
   const unlisten = vi.fn();
   let cb: ((d: Uint8Array) => void) | null = null;
   let resolveListen!: () => void;
   const ready = new Promise<void>((r) => (resolveListen = r));
-  h.onSshOutput.mockImplementation((_id, fn) => {
+  h.onSessionOutput.mockImplementation((_id, _type, fn) => {
     cb = fn;
     resolveListen();
     return Promise.resolve(unlisten);
@@ -37,17 +38,17 @@ function installListener() {
 }
 
 beforeEach(() => {
-  h.onSshOutput.mockReset();
+  h.onSessionOutput.mockReset();
   h.append.mockReset();
   h.drain.mockReset();
   useTeamSessionStore.setState({ connections: {} } as never);
 });
 afterEach(() => cleanup());
 
-test("subscribes to onSshOutput for the given session id", () => {
+test("subscribes to the session's own transport, not always ssh", () => {
   installListener();
-  render(<Harness />);
-  expect(h.onSshOutput).toHaveBeenCalledWith(ID, expect.any(Function));
+  render(<Harness type="local" />);
+  expect(h.onSessionOutput).toHaveBeenCalledWith(ID, "local", expect.any(Function));
 });
 
 test("host role forwards output via connection.sendOutput, does not buffer", async () => {
@@ -66,7 +67,22 @@ test("host role forwards output via connection.sendOutput, does not buffer", asy
   expect(h.append).not.toHaveBeenCalled();
 });
 
-test("non-host (guest) buffers via appendSshOutputBuffer, does not send", async () => {
+test("a shared local shell forwards its PTY output to the relay", async () => {
+  const lst = installListener();
+  const sendOutput = vi.fn(async () => {});
+  useTeamSessionStore.setState({
+    connections: { [ID]: { role: "host", connection: { sendOutput } } },
+  } as never);
+  render(<Harness type="local" />);
+  await lst.ready;
+
+  const data = new Uint8Array([9, 9]);
+  act(() => lst.emit(data));
+
+  expect(sendOutput).toHaveBeenCalledWith(data);
+});
+
+test("non-host (guest) buffers via appendSessionOutputBuffer, does not send", async () => {
   const lst = installListener();
   const sendOutput = vi.fn(async () => {});
   useTeamSessionStore.setState({
@@ -127,13 +143,13 @@ test("cleanup on unmount calls unlisten and drains the buffer", async () => {
   expect(h.drain).toHaveBeenCalledWith(ID);
 });
 
-test("unmount before onSshOutput resolves disposes the late listener", async () => {
+test("unmount before the subscription resolves disposes the late listener", async () => {
   const unlisten = vi.fn();
-  let resolveOnSshOutput!: (fn: () => void) => void;
-  h.onSshOutput.mockImplementation(
+  let resolveSubscribe!: (fn: () => void) => void;
+  h.onSessionOutput.mockImplementation(
     () =>
       new Promise<() => void>((resolve) => {
-        resolveOnSshOutput = resolve;
+        resolveSubscribe = resolve;
       }),
   );
 
@@ -142,7 +158,7 @@ test("unmount before onSshOutput resolves disposes the late listener", async () 
 
   expect(unlisten).not.toHaveBeenCalled();
   await act(async () => {
-    resolveOnSshOutput(unlisten);
+    resolveSubscribe(unlisten);
     await Promise.resolve();
   });
 

--- a/src/hooks/useMultiplayerHostBroadcast.ts
+++ b/src/hooks/useMultiplayerHostBroadcast.ts
@@ -1,26 +1,27 @@
 import { useEffect } from "react";
-import { onSshOutput } from "@/services/ssh";
+import { onSessionOutput } from "@/services/sessionInput";
 import { useTeamSessionStore } from "@/stores/teamSessionStore";
-import { appendSshOutputBuffer, drainSshOutputBuffer } from "@/services/multiplayerService";
+import { appendSessionOutputBuffer, drainSessionOutputBuffer } from "@/services/multiplayerService";
+import type { TerminalSession } from "@/types";
 
 /**
- * Subscribes to SSH output events for a session.
+ * Subscribes to a session's output events, whatever its transport.
  * - Always buffers output so it can be used as a snapshot when sharing starts.
  * - Forwards live output to the multiplayer WebSocket while actively sharing as host.
  */
-export function useMultiplayerHostBroadcast(localSessionId: string) {
+export function useMultiplayerHostBroadcast(localSessionId: string, sessionType: TerminalSession["type"]) {
   useEffect(() => {
     let cancelled = false;
     let unlisten: (() => void) | null = null;
 
-    onSshOutput(localSessionId, (data) => {
+    onSessionOutput(localSessionId, sessionType, (data) => {
       const conn = useTeamSessionStore.getState().connections[localSessionId];
       if (conn?.role === "host") {
         // Sharing is active — forward live output to the relay.
         conn.connection.sendOutput(data).catch(() => {});
       } else {
         // Not sharing yet — buffer for use as initial snapshot when sharing starts.
-        appendSshOutputBuffer(localSessionId, data);
+        appendSessionOutputBuffer(localSessionId, data);
       }
     }).then((fn) => {
       if (cancelled) {
@@ -34,7 +35,7 @@ export function useMultiplayerHostBroadcast(localSessionId: string) {
       cancelled = true;
       unlisten?.();
       // Drop the buffer if the terminal closes without ever sharing.
-      drainSshOutputBuffer(localSessionId);
+      drainSessionOutputBuffer(localSessionId);
     };
-  }, [localSessionId]);
+  }, [localSessionId, sessionType]);
 }

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -9,10 +9,8 @@ import i18n from "@/i18n";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useIdentityStore } from "@/stores/identityStore";
 import { useKeyStore } from "@/stores/keyStore";
-import { onSshOutput } from "@/services/ssh";
-import { onLocalOutput, localConnect, localSendInput } from "@/services/local";
-import { onSerialOutput } from "@/services/serial";
-import { sendSessionInput } from "@/services/sessionInput";
+import { localConnect, localSendInput } from "@/services/local";
+import { onSessionOutput, sendSessionInput } from "@/services/sessionInput";
 import { readTerminalSnapshot, readTerminalSelection, getAppCursorMode } from "@/hooks/useTerminal";
 import { usePluginStore } from "@/stores/pluginStore";
 import { useUIStore, type NavItem } from "@/stores/uiStore";
@@ -1956,10 +1954,7 @@ function createPluginAPI(manifest: PluginManifest): PluginAPI {
         const session = useSessionStore.getState().sessions.find((s) => s.id === sessionId);
         if (!session) throw new Error(`Session "${sessionId}" not found`);
         const decoder = new TextDecoder();
-        const handler = (data: Uint8Array) => cb(decoder.decode(data, { stream: true }));
-        if (session.type === "local") return onLocalOutput(sessionId, handler);
-        if (session.type === "serial") return onSerialOutput(sessionId, handler);
-        return onSshOutput(sessionId, handler);
+        return onSessionOutput(sessionId, session.type, (data) => cb(decoder.decode(data, { stream: true })));
       },
     },
 

--- a/src/services/multiplayerService.ts
+++ b/src/services/multiplayerService.ts
@@ -364,16 +364,16 @@ export async function endMultiplayerSession(sessionId: string): Promise<void> {
 
 // ─── WebSocket connection ─────────────────────────────────────────────────────
 
-// ─── Per-session SSH output buffer (pre-share scrollback) ────────────────────
+// ─── Per-session output buffer (pre-share scrollback, any transport) ─────────
 
 const MAX_BUFFER_BYTES = 64 * 1024; // 64 KB per session
 
 interface OutputBuffer { chunks: Uint8Array[]; totalBytes: number; }
-const sshOutputBuffers = new Map<string, OutputBuffer>();
+const sessionOutputBuffers = new Map<string, OutputBuffer>();
 
-export function appendSshOutputBuffer(sessionId: string, data: Uint8Array): void {
-  let buf = sshOutputBuffers.get(sessionId);
-  if (!buf) { buf = { chunks: [], totalBytes: 0 }; sshOutputBuffers.set(sessionId, buf); }
+export function appendSessionOutputBuffer(sessionId: string, data: Uint8Array): void {
+  let buf = sessionOutputBuffers.get(sessionId);
+  if (!buf) { buf = { chunks: [], totalBytes: 0 }; sessionOutputBuffers.set(sessionId, buf); }
   buf.chunks.push(data);
   buf.totalBytes += data.length;
   while (buf.totalBytes > MAX_BUFFER_BYTES && buf.chunks.length > 0) {
@@ -381,9 +381,9 @@ export function appendSshOutputBuffer(sessionId: string, data: Uint8Array): void
   }
 }
 
-export function drainSshOutputBuffer(sessionId: string): Uint8Array | null {
-  const buf = sshOutputBuffers.get(sessionId);
-  sshOutputBuffers.delete(sessionId);
+export function drainSessionOutputBuffer(sessionId: string): Uint8Array | null {
+  const buf = sessionOutputBuffers.get(sessionId);
+  sessionOutputBuffers.delete(sessionId);
   if (!buf || buf.chunks.length === 0) return null;
   const out = new Uint8Array(buf.totalBytes);
   let offset = 0;

--- a/src/services/multiplayerService.ws.test.ts
+++ b/src/services/multiplayerService.ws.test.ts
@@ -4,8 +4,8 @@ vi.mock("@/i18n", () => ({ default: { t: (k: string) => k } }));
 
 import {
   openWebSocket,
-  appendSshOutputBuffer,
-  drainSshOutputBuffer,
+  appendSessionOutputBuffer,
+  drainSessionOutputBuffer,
   encryptData,
   importSessionKey,
 } from "./multiplayerService";
@@ -135,14 +135,14 @@ test("initial snapshot is encrypted and sent on open", async () => {
 });
 
 test("output buffer evicts oldest chunks past 64KB and drains in order", () => {
-  appendSshOutputBuffer("s1", new Uint8Array([1, 2]));
-  appendSshOutputBuffer("s1", new Uint8Array([3]));
+  appendSessionOutputBuffer("s1", new Uint8Array([1, 2]));
+  appendSessionOutputBuffer("s1", new Uint8Array([3]));
   // toEqual on Uint8Array breaks cross-realm under jsdom; compare byte arrays.
-  expect(Array.from(drainSshOutputBuffer("s1")!)).toEqual([1, 2, 3]);
-  expect(drainSshOutputBuffer("s1")).toBeNull(); // cleared after drain
+  expect(Array.from(drainSessionOutputBuffer("s1")!)).toEqual([1, 2, 3]);
+  expect(drainSessionOutputBuffer("s1")).toBeNull(); // cleared after drain
 
-  appendSshOutputBuffer("s2", new Uint8Array(40 * 1024).fill(9));
-  appendSshOutputBuffer("s2", new Uint8Array(40 * 1024).fill(8)); // pushes total > 64KB, evicts first
-  const drained = drainSshOutputBuffer("s2")!;
+  appendSessionOutputBuffer("s2", new Uint8Array(40 * 1024).fill(9));
+  appendSessionOutputBuffer("s2", new Uint8Array(40 * 1024).fill(8)); // pushes total > 64KB, evicts first
+  const drained = drainSessionOutputBuffer("s2")!;
   expect(drained.length).toBeLessThanOrEqual(64 * 1024);
 });

--- a/src/services/sessionInput.test.ts
+++ b/src/services/sessionInput.test.ts
@@ -1,13 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.mock("@/services/local", () => ({ localSendInput: vi.fn(async () => {}), localResize: vi.fn(async () => {}) }));
-vi.mock("@/services/serial", () => ({ serialWrite: vi.fn(async () => {}) }));
-vi.mock("@/services/ssh", () => ({ sshSendInput: vi.fn(async () => {}), sshResize: vi.fn(async () => {}) }));
+const unlisten = () => {};
+vi.mock("@/services/local", () => ({
+  localSendInput: vi.fn(async () => {}),
+  localResize: vi.fn(async () => {}),
+  onLocalOutput: vi.fn(async () => unlisten),
+}));
+vi.mock("@/services/serial", () => ({
+  serialWrite: vi.fn(async () => {}),
+  onSerialOutput: vi.fn(async () => unlisten),
+}));
+vi.mock("@/services/ssh", () => ({
+  sshSendInput: vi.fn(async () => {}),
+  sshResize: vi.fn(async () => {}),
+  onSshOutput: vi.fn(async () => unlisten),
+}));
 
-import { sendSessionInput, sendSessionResize } from "./sessionInput";
-import { localSendInput, localResize } from "@/services/local";
-import { serialWrite } from "@/services/serial";
-import { sshSendInput, sshResize } from "@/services/ssh";
+import { sendSessionInput, sendSessionResize, onSessionOutput } from "./sessionInput";
+import { localSendInput, localResize, onLocalOutput } from "@/services/local";
+import { serialWrite, onSerialOutput } from "@/services/serial";
+import { sshSendInput, sshResize, onSshOutput } from "@/services/ssh";
 
 const bytes = new TextEncoder().encode("hi");
 
@@ -35,6 +47,36 @@ describe("sendSessionInput", () => {
   it("rejects when the transport rejects, rather than swallowing", async () => {
     vi.mocked(sshSendInput).mockRejectedValueOnce(new Error("channel closed"));
     await expect(sendSessionInput("s3", "ssh", bytes)).rejects.toThrow("channel closed");
+  });
+});
+
+describe("onSessionOutput", () => {
+  beforeEach(() => vi.clearAllMocks());
+  const cb = () => {};
+
+  it("subscribes a local session to local-output", async () => {
+    await onSessionOutput("s1", "local", cb);
+    expect(onLocalOutput).toHaveBeenCalledWith("s1", cb);
+    expect(onSshOutput).not.toHaveBeenCalled();
+  });
+
+  it("subscribes a serial session to serial-output", async () => {
+    await onSessionOutput("s2", "serial", cb);
+    expect(onSerialOutput).toHaveBeenCalledWith("s2", cb);
+    expect(onSshOutput).not.toHaveBeenCalled();
+  });
+
+  it("subscribes an ssh session to ssh-output", async () => {
+    await onSessionOutput("s3", "ssh", cb);
+    expect(onSshOutput).toHaveBeenCalledWith("s3", cb);
+  });
+
+  it("subscribes nothing for a multiplayer tab, which has no local transport", async () => {
+    const stop = await onSessionOutput("s4", "multiplayer", cb);
+    expect(onSshOutput).not.toHaveBeenCalled();
+    expect(onLocalOutput).not.toHaveBeenCalled();
+    expect(onSerialOutput).not.toHaveBeenCalled();
+    expect(() => stop()).not.toThrow();
   });
 });
 

--- a/src/services/sessionInput.ts
+++ b/src/services/sessionInput.ts
@@ -1,6 +1,8 @@
-import { localResize, localSendInput } from "@/services/local";
-import { serialWrite } from "@/services/serial";
-import { sshResize, sshSendInput } from "@/services/ssh";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import { localResize, localSendInput, onLocalOutput } from "@/services/local";
+import { onSerialOutput, serialWrite } from "@/services/serial";
+import { onSshOutput, sshResize, sshSendInput } from "@/services/ssh";
+import type { TerminalSession } from "@/types";
 
 /**
  * Write raw bytes to a session's transport. The single fan-out: the terminal's
@@ -10,15 +12,41 @@ import { sshResize, sshSendInput } from "@/services/ssh";
  * Rejects on transport failure. Callers that must not fail on a dropped
  * keystroke (the interactive terminal) swallow it at their own call site — a
  * swallow inside here would hide a failed MCP write.
+ *
+ * A `multiplayer` tab holds no transport of its own — its keystrokes travel the
+ * relay — so it is a no-op here rather than a misrouted SSH write.
  */
 export async function sendSessionInput(
   sessionId: string,
-  sessionType: "ssh" | "local" | "serial",
+  sessionType: TerminalSession["type"],
   data: Uint8Array,
 ): Promise<void> {
   if (sessionType === "local") return localSendInput(sessionId, data);
   if (sessionType === "serial") return serialWrite(sessionId, data);
+  if (sessionType === "multiplayer") return;
   return sshSendInput(sessionId, data);
+}
+
+/**
+ * Subscribe to a session's output events. The read-side twin of
+ * `sendSessionInput`: the multiplayer host broadcast and PluginAPI's
+ * `terminal.onOutput` both come through here, so a transport is wired for
+ * every consumer at once rather than per call site — a shared local shell
+ * relayed nothing to its guests because one such site listened only for
+ * `ssh-output`.
+ *
+ * A `multiplayer` tab is a guest's view of someone else's session: it has no
+ * local transport to listen to, so it resolves to a no-op unsubscribe.
+ */
+export async function onSessionOutput(
+  sessionId: string,
+  sessionType: TerminalSession["type"],
+  callback: (data: Uint8Array) => void,
+): Promise<UnlistenFn> {
+  if (sessionType === "local") return onLocalOutput(sessionId, callback);
+  if (sessionType === "serial") return onSerialOutput(sessionId, callback);
+  if (sessionType === "multiplayer") return () => {};
+  return onSshOutput(sessionId, callback);
 }
 
 /**
@@ -31,7 +59,7 @@ export async function sendSessionInput(
  */
 export async function sendSessionResize(
   sessionId: string,
-  sessionType: "ssh" | "local" | "serial",
+  sessionType: TerminalSession["type"],
   cols: number,
   rows: number,
 ): Promise<void> {

--- a/src/stores/sessionStore.ts
+++ b/src/stores/sessionStore.ts
@@ -1203,3 +1203,12 @@ export const useSessionStore = create<SessionStore>((set, get) => ({
     usePanelSftpStore.getState().closeSession(sessionId);
   },
 }));
+
+/**
+ * The transport a session's bytes travel over, for callers holding only an id —
+ * the multiplayer relay's guest-input path. An unknown id resolves to "ssh",
+ * matching the transport default everywhere else.
+ */
+export function getSessionTransportType(sessionId: string): TerminalSession["type"] {
+  return useSessionStore.getState().sessions.find((s) => s.id === sessionId)?.type ?? "ssh";
+}

--- a/src/stores/teamSessionStore.directInvite.test.ts
+++ b/src/stores/teamSessionStore.directInvite.test.ts
@@ -4,7 +4,7 @@ import type { TeamMember } from "@/services/teamService";
 const mp = vi.hoisted(() => ({
   listActiveSessions: vi.fn(async () => []),
   openWebSocket: vi.fn(() => ({ close: vi.fn(), requestControl: vi.fn(), grantControl: vi.fn(), revokeControl: vi.fn() })),
-  drainSshOutputBuffer: vi.fn(() => undefined),
+  drainSessionOutputBuffer: vi.fn(() => undefined),
   createDirectSession: vi.fn(async () => ({ sessionId: "sess-1", sessionKey: new Uint8Array(), sessionKeyBytes: new Uint8Array(32) })),
   inviteUserToSession: vi.fn(async () => {}),
 }));

--- a/src/stores/teamSessionStore.test.ts
+++ b/src/stores/teamSessionStore.test.ts
@@ -5,15 +5,20 @@ const mp = vi.hoisted(() => ({
   getMySessionKey: vi.fn(async () => ({ sessionKey: new Uint8Array() })),
   openWebSocket: vi.fn(),
   endMultiplayerSession: vi.fn(async () => {}),
-  createVaultSession: vi.fn(), createInviteLinkSession: vi.fn(), drainSshOutputBuffer: vi.fn(() => undefined),
+  createVaultSession: vi.fn(), createInviteLinkSession: vi.fn(), drainSessionOutputBuffer: vi.fn(() => undefined),
 }));
 const svc = vi.hoisted(() => ({
   getServerUrlValue: vi.fn(async () => "https://s"),
   getJwtToken: vi.fn(async () => "jwt"),
   getMyUserId: vi.fn(async () => "u1"),
 }));
+const io = vi.hoisted(() => ({
+  sendSessionInput: vi.fn(async () => {}),
+  getSessionTransportType: vi.fn(() => "ssh"),
+}));
 vi.mock("@/services/multiplayerService", () => mp);
-vi.mock("@/services/ssh", () => ({ sshSendInput: vi.fn(async () => {}) }));
+vi.mock("@/services/sessionInput", () => ({ sendSessionInput: io.sendSessionInput }));
+vi.mock("@/stores/sessionStore", () => ({ getSessionTransportType: io.getSessionTransportType }));
 vi.mock("@/services/teamService", () => svc);
 vi.mock("@/i18n", () => ({ default: { t: (k: string) => k } }));
 
@@ -41,6 +46,8 @@ function assertOpenWebSocketArgsCarryNoIdentity(args: unknown[], expectedStrings
 
 beforeEach(() => {
   Object.values(mp).forEach((f) => f.mockClear());
+  io.sendSessionInput.mockClear();
+  io.getSessionTransportType.mockReset().mockReturnValue("ssh");
   useTeamSessionStore.setState({ activeSessions: [], connections: {} });
 });
 
@@ -92,6 +99,30 @@ test("joinSession wires callbacks that drive the participant/control state machi
 
   cb.onSessionEnded(); // guest → marked ended, not removed
   expect(get().connections[localId].ended).toBe(true);
+});
+
+// Regression guard: a host's callbacks used to write a guest's keystrokes with
+// sshSendInput unconditionally, so control handed to a guest on a shared local
+// shell or serial session went nowhere.
+test.each([
+  ["local", "local-1"],
+  ["serial", "serial-1"],
+  ["ssh", "ssh-1"],
+] as const)("a guest's input reaches a %s host session's own transport", async (type, localId) => {
+  io.getSessionTransportType.mockReturnValue(type);
+  let cb: any;
+  mp.openWebSocket.mockImplementation((...args: any[]) => {
+    cb = args.find((a) => a && typeof a === "object" && "onParticipantList" in a);
+    return connStub();
+  });
+  mp.createVaultSession.mockResolvedValueOnce({ sessionId: "m1", sessionKey: new Uint8Array([1]), sessionKeyBytes: new Uint8Array(32) });
+
+  await get().startSharing(localId, ["v1"], [], "conn", []);
+
+  const data = new Uint8Array([0x6c, 0x73]);
+  cb.onInput(data);
+
+  expect(io.sendSessionInput).toHaveBeenCalledWith(localId, type, data);
 });
 
 // Regression guard: attachAsHost (the host-side path shared by startSharing,

--- a/src/stores/teamSessionStore.ts
+++ b/src/stores/teamSessionStore.ts
@@ -2,7 +2,8 @@ import { create, type StoreApi } from "zustand";
 import i18n from "@/i18n";
 import * as mp from "@/services/multiplayerService";
 import type { ActiveSession, Participant, MultiplayerConnection, SessionKey } from "@/services/multiplayerService";
-import { sshSendInput } from "@/services/ssh";
+import { sendSessionInput } from "@/services/sessionInput";
+import { getSessionTransportType } from "@/stores/sessionStore";
 import type { TeamMember } from "@/services/teamService";
 import type { InviteTarget } from "@/services/teamSharing";
 export type { ActiveSession, Participant };
@@ -87,7 +88,11 @@ export interface MultiplayerSessionState {
 function makeCallbacks(localSessionId: string, set: any, _get: any) {
   return {
     onOutput: () => {},
-    onInput: (data: Uint8Array) => { sshSendInput(localSessionId, data).catch(() => {}); },
+    // A guest with control types into whatever the host is running — a local
+    // shell and a serial port as much as an SSH channel.
+    onInput: (data: Uint8Array) => {
+      sendSessionInput(localSessionId, getSessionTransportType(localSessionId), data).catch(() => {});
+    },
     onControlUpdate: (holderId: string, requesterId: string | null) => {
       set((s: TeamSessionStore) => ({
         connections: { ...s.connections, [localSessionId]: { ...s.connections[localSessionId]!, controlHolder: holderId, controlRequester: requesterId } },
@@ -144,7 +149,7 @@ async function attachAsHost(
   if (!serverUrl || !jwt) throw new Error(i18n.t("common.error.notConnectedToServer"));
 
   const myUserId = await import("@/services/teamService").then((m) => m.getMyUserId()).then((id) => id ?? "");
-  const initialSnapshot = mp.drainSshOutputBuffer(localSessionId) ?? undefined;
+  const initialSnapshot = mp.drainSessionOutputBuffer(localSessionId) ?? undefined;
 
   const conn = mp.openWebSocket(serverUrl, sessionId, jwt, sessionKey, {
     ...makeCallbacks(localSessionId, set, get),


### PR DESCRIPTION
Sharing a **local shell** relayed nothing to the guest: the join itself worked — tab opened, WebSocket admitted, presence updated — and the guest then watched a permanently blank terminal. Sharing SSH was unaffected. Found during the unified-invite-flow live gate; pre-existing, not caused by it.

## Root cause

Three call sites assumed SSH. It is one bug wearing three hats:

| Call site | Assumed | Consequence |
|---|---|---|
| `useMultiplayerHostBroadcast` | `onSshOutput` unconditionally | a local shell emits `local-output-<id>`, so nothing fed the relay and the pre-share snapshot buffer stayed empty — **the blank terminal** |
| `teamSessionStore` `onInput` | `sshSendInput` only | a guest granted control on a local shell typed into nothing |
| both of the above | — | serial sessions carried the same two defects |

The second one was never reported because nobody got past the blank screen to try typing.

## Fix

- `onSessionOutput(sessionId, type, cb)` in `services/sessionInput.ts` — the read-side twin of the existing `sendSessionInput` fan-out, so a transport is wired for every consumer at once instead of per call site. PluginAPI's `terminal.onOutput`, which carried its own copy of the three-way dispatch, now routes through it.
- Guest input goes through `sendSessionInput` with the transport resolved by a new `getSessionTransportType(sessionId)`.
- A `multiplayer` tab holds no transport of its own, so it is an explicit no-op in both fan-outs rather than a misrouted SSH write.
- `append/drainSshOutputBuffer` → `…SessionOutputBuffer`: the buffer was never SSH-specific.

## Verification

- **Unit:** 454 files / 3420 tests pass; `tsc --noEmit` clean. New tests cover the transport matrix for `onSessionOutput`, a local shell's PTY output reaching the relay, and guest input routing per transport.
- **Live, two real accounts against a live server:** the guest received the pre-share scrollback *and* live output, and a guest with control had its keystrokes execute in the host's local PTY.

```
"root@<host-container>:~# echo SNAPSHOT_MARKER_AAA",   <- pre-share scrollback
"SNAPSHOT_MARKER_AAA",
"root@<host-container>:~# echo VOLTIUSPROOF123",       <- live relay
"VOLTIUSPROOF123",
"root@<host-container>:~# echo GUEST_TYPED_XYZ",       <- guest typed it
"GUEST_TYPED_XYZ",
```

- **Negative control:** reverting the hook to its ssh-only form, then a fresh share and fresh join, reproduced the empty guest buffer exactly (`{"rows":43,"lines":[]}`). Restoring the fix brought the output back.

## Note for anyone testing this by hand

A guest tab renders `MultiplayerTerminalView`, which has no terminal search, and the canvas renderer leaves no text in the DOM — screenshots and `innerText` both prove nothing. The buffer is readable by walking the React fiber tree up from the `.xterm` element to a hook state exposing `buffer.active.getLine`.
