### PR TITLE
fix(account): stop the quick switcher carrying state between accounts

### DIFF
--- a/src/components/layout/SidebarAccountButton.switcher.test.tsx
+++ b/src/components/layout/SidebarAccountButton.switcher.test.tsx
@@ -1,0 +1,115 @@
+import { test, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { SavedAccount } from "@/services/savedAccounts";
+
+const h = vi.hoisted(() => ({
+  accountMode: "server" as string,
+  getSavedAccounts: vi.fn(async (): Promise<SavedAccount[]> => []),
+  saveCurrentAccount: vi.fn(async () => {}),
+  switchToAccount: vi.fn(async () => {}),
+  removeSavedAccount: vi.fn(async () => {}),
+  keychain: {} as Record<string, string | null>,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
+}));
+vi.mock("@iconify/react", () => ({ Icon: () => null }));
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(async (_cmd: string, args: { key: string }) => h.keychain[args.key] ?? null),
+}));
+vi.mock("@/services/account", () => ({
+  getAccountMode: vi.fn(async () => h.accountMode),
+  getMyHandle: vi.fn(async () => "ada"),
+  lockVaultSession: vi.fn(async () => {}),
+  logout: vi.fn(async () => {}),
+}));
+vi.mock("@/services/savedAccounts", () => ({
+  getSavedAccounts: h.getSavedAccounts,
+  saveCurrentAccount: h.saveCurrentAccount,
+  switchToAccount: h.switchToAccount,
+  removeSavedAccount: h.removeSavedAccount,
+}));
+
+import { SidebarAccountButton } from "./SidebarAccountButton";
+
+const CURRENT = {
+  account_id: "current", mode: "server", master_password: ["master", "for", "current"].join("-"),
+  email: "ada@example.com", server_url: "https://srv", jwt: null, refresh_token: null,
+} satisfies SavedAccount;
+
+const OTHER = { ...CURRENT, account_id: "other", email: "grace@example.com" } satisfies SavedAccount;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.accountMode = "server";
+  h.keychain = { email: CURRENT.email, account_id: CURRENT.account_id };
+});
+afterEach(cleanup);
+
+async function openMenu() {
+  render(<SidebarAccountButton />);
+  await userEvent.click(screen.getByTitle("layout.sidebarAccount.accountTitle"));
+  await waitFor(() => expect(h.getSavedAccounts).toHaveBeenCalled());
+}
+
+test("the switch section stays hidden when the only saved account is the current one", async () => {
+  h.getSavedAccounts.mockResolvedValue([CURRENT]);
+  await openMenu();
+  expect(screen.queryByText("layout.sidebarAccount.switchAccount")).toBeNull();
+});
+
+test("a saved account other than the current one is offered as a switch target", async () => {
+  h.getSavedAccounts.mockResolvedValue([CURRENT, OTHER]);
+  await openMenu();
+
+  await screen.findByText("layout.sidebarAccount.switchAccount");
+  expect(screen.getByText(OTHER.email!)).toBeTruthy();
+  expect(screen.queryAllByText(CURRENT.email!)).toHaveLength(1); // the header only
+
+  await userEvent.click(screen.getByText(OTHER.email!));
+  expect(h.switchToAccount).toHaveBeenCalledWith(OTHER);
+});
+
+test("removing a saved account does not switch into it", async () => {
+  h.getSavedAccounts.mockResolvedValue([CURRENT, OTHER]);
+  await openMenu();
+
+  await userEvent.click(await screen.findByTitle("layout.sidebarAccount.removeSavedAccount"));
+  expect(h.removeSavedAccount).toHaveBeenCalledWith(OTHER.account_id);
+  expect(h.switchToAccount).not.toHaveBeenCalled();
+  await waitFor(() => expect(screen.queryByText(OTHER.email!)).toBeNull());
+});
+
+test("no switch row nests a button inside a button", async () => {
+  h.getSavedAccounts.mockResolvedValue([CURRENT, OTHER]);
+  await openMenu();
+  await screen.findByText(OTHER.email!);
+  expect(document.querySelectorAll("button button")).toHaveLength(0);
+});
+
+test("switching away from a local account asks before erasing it", async () => {
+  h.accountMode = "local-nopassword";
+  h.getSavedAccounts.mockResolvedValue([OTHER]);
+  await openMenu();
+
+  await userEvent.click(await screen.findByText(OTHER.email!));
+  expect(h.switchToAccount).not.toHaveBeenCalled();
+  await screen.findByText("layout.sidebarAccount.leaveLocalTitle");
+
+  await userEvent.click(screen.getByText("layout.sidebarAccount.leaveLocalConfirm"));
+  expect(h.switchToAccount).toHaveBeenCalledWith(OTHER);
+});
+
+test("cancelling the local-account warning leaves the session alone", async () => {
+  h.accountMode = "local-nopassword";
+  h.getSavedAccounts.mockResolvedValue([OTHER]);
+  await openMenu();
+
+  await userEvent.click(await screen.findByText(OTHER.email!));
+  await userEvent.click(await screen.findByText("common.action.cancel"));
+  expect(h.switchToAccount).not.toHaveBeenCalled();
+  expect(screen.queryByText("layout.sidebarAccount.leaveLocalTitle")).toBeNull();
+});

--- a/src/components/layout/SidebarAccountButton.tsx
+++ b/src/components/layout/SidebarAccountButton.tsx
@@ -7,8 +7,10 @@ import { useThemeStore } from "@/stores/themeStore";
 import { useRipple } from "@/hooks/useRipple";
 import { getAccountMode, getMyHandle, lockVaultSession, logout } from "@/services/account";
 import { getSavedAccounts, saveCurrentAccount, switchToAccount, removeSavedAccount, type SavedAccount } from "@/services/savedAccounts";
+import { ConfirmModal } from "@/components/shared/ConfirmModal";
 import { DropdownMenuItem } from "@/components/shared/DropdownMenuItem";
 import { useCopyHandle } from "@/hooks/useCopyHandle";
+import { useNotificationStore } from "@/stores/notificationStore";
 
 export function SidebarAccountButton() {
   const { t } = useTranslation();
@@ -24,6 +26,7 @@ export function SidebarAccountButton() {
   const [savedAccounts, setSavedAccounts] = useState<SavedAccount[]>([]);
   const [currentAccountId, setCurrentAccountId] = useState<string | null>(null);
   const [accountHandle, setAccountHandle] = useState<string | null>(null);
+  const [pendingSwitch, setPendingSwitch] = useState<SavedAccount | null>(null);
   const { copied: handleCopied, copy: copyHandle } = useCopyHandle(accountHandle);
 
   const refreshAccountInfo = async () => {
@@ -49,11 +52,19 @@ export function SidebarAccountButton() {
         dropdownRef.current && !dropdownRef.current.contains(e.target as Node)
       ) setOpen(false);
     };
+    const onKeyDown = (e: KeyboardEvent) => { if (e.key === "Escape") setOpen(false); };
     document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handler);
+      document.removeEventListener("keydown", onKeyDown);
+    };
   }, [open]);
 
   const openDropdown = async () => {
+    // Close without waiting on the keychain — the refresh below only matters
+    // when the menu is about to be shown.
+    if (open) { setOpen(false); return; }
     if (buttonRef.current) {
       const rect = buttonRef.current.getBoundingClientRect();
       setPos({ bottom: window.innerHeight - rect.bottom, left: rect.right + 8 });
@@ -61,7 +72,7 @@ export function SidebarAccountButton() {
     await Promise.all([refreshAccountInfo(), saveCurrentAccount().catch(() => {})]);
     const accounts = await getSavedAccounts().catch(() => [] as SavedAccount[]);
     setSavedAccounts(accounts);
-    setOpen((o) => !o);
+    setOpen(true);
   };
 
   const handleLockVault = async () => {
@@ -78,8 +89,32 @@ export function SidebarAccountButton() {
 
   const handleSwitchAccount = async (account: SavedAccount) => {
     setOpen(false);
-    await switchToAccount(account);
+    try {
+      await switchToAccount(account);
+    } catch (e) {
+      // The switch tears the session down before it rebuilds it; a silent
+      // rejection would leave the user staring at an unchanged window.
+      useNotificationStore.getState().addToast({
+        source: { kind: "plugin", id: "system", name: "Voltius" },
+        type: "toast",
+        message: t("layout.sidebarAccount.switchFailed", { error: e instanceof Error ? e.message : String(e) }),
+        severity: "error",
+        duration: 8000,
+      });
+    }
   };
+
+  /**
+   * Leaving a local account destroys it: the switch wipes secrets.enc and the
+   * config dir, and a local vault has no cloud copy to come back from. Ask first.
+   */
+  const requestSwitch = (account: SavedAccount) => {
+    setOpen(false);
+    if (accountMode === "server") { void handleSwitchAccount(account); return; }
+    setPendingSwitch(account);
+  };
+
+  const switchTargets = savedAccounts.filter((a) => a.account_id !== currentAccountId);
 
   const handleRemoveSavedAccount = async (e: React.MouseEvent, account_id: string) => {
     e.stopPropagation();
@@ -194,7 +229,7 @@ export function SidebarAccountButton() {
             <DropdownMenuItem icon="lucide:log-out" label={t("common.action.disconnect")} onClick={() => void handleDisconnect()} />
           )}
 
-          {savedAccounts.length > 1 && (
+          {switchTargets.length > 0 && (
             <>
               <div className="h-px bg-(--t-bg-input) -mx-1.5 my-0.5" />
               <div className="px-3 pt-2 pb-1">
@@ -202,39 +237,42 @@ export function SidebarAccountButton() {
                   {t("layout.sidebarAccount.switchAccount")}
                 </span>
               </div>
-              {savedAccounts
-                .filter((a) => a.account_id !== currentAccountId)
-                .map((account) => (
-                  <button
-                    key={account.account_id}
-                    type="button"
-                    onClick={() => void handleSwitchAccount(account)}
-                    className="group flex items-center gap-2.5 p-2.5 rounded-lg text-sm transition-colors w-full text-left"
-                    onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "var(--t-bg-card-hover)"; }}
-                    onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "transparent"; }}
-                  >
-                    <Icon icon="lucide:circle-user" width={16} style={{ color: "var(--t-text-dim)" }} className="shrink-0" />
-                    <div className="flex-1 min-w-0">
-                      <div className="truncate font-medium" style={{ color: "var(--t-text-primary)" }}>{account.display}</div>
-                      <div className="text-[10px]" style={{ color: "var(--t-text-dim)" }}>{account.mode === "server" ? t("layout.sidebarAccount.savedAccountCloud") : t("layout.sidebarAccount.savedAccountLocal")}</div>
-                    </div>
+              {switchTargets.map((account) => (
+                <DropdownMenuItem
+                  key={account.account_id}
+                  icon="lucide:circle-user"
+                  iconSize={16}
+                  label={account.email ?? t("layout.sidebarAccount.localAccountFallback")}
+                  sublabel={account.mode === "server" ? t("layout.sidebarAccount.savedAccountCloud") : t("layout.sidebarAccount.savedAccountLocal")}
+                  onClick={() => requestSwitch(account)}
+                  trailing={
                     <button
                       type="button"
                       title={t("layout.sidebarAccount.removeSavedAccount")}
-                      className="opacity-0 group-hover:opacity-100 p-0.5 rounded-sm transition-opacity"
-                      style={{ color: "var(--t-text-dim)" }}
-                      onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.color = "var(--t-status-error)"; }}
-                      onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.color = "var(--t-text-dim)"; }}
+                      className="opacity-0 group-hover:opacity-100 p-0.5 rounded-sm transition-opacity text-(--t-text-dim) hover:text-(--t-status-error)"
                       onClick={(e) => void handleRemoveSavedAccount(e, account.account_id)}
                     >
                       <Icon icon="lucide:x" width={12} />
                     </button>
-                  </button>
-                ))}
+                  }
+                />
+              ))}
             </>
           )}
         </div>,
         document.body,
+      )}
+
+      {pendingSwitch && (
+        <ConfirmModal
+          title={t("layout.sidebarAccount.leaveLocalTitle")}
+          message={t("layout.sidebarAccount.leaveLocalMessage", {
+            account: pendingSwitch.email ?? t("layout.sidebarAccount.localAccountFallback"),
+          })}
+          confirmLabel={t("layout.sidebarAccount.leaveLocalConfirm")}
+          onConfirm={() => { const account = pendingSwitch; setPendingSwitch(null); void handleSwitchAccount(account); }}
+          onCancel={() => setPendingSwitch(null)}
+        />
       )}
     </>
   );

--- a/src/components/shared/DropdownMenuItem.tsx
+++ b/src/components/shared/DropdownMenuItem.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@iconify/react";
+import type { ReactNode } from "react";
 import { useRipple } from "@/hooks/useRipple";
 
 interface Props {
@@ -7,11 +8,17 @@ interface Props {
   onClick: () => void;
   checked?: boolean;
   iconSize?: number;
+  sublabel?: string;
+  /**
+   * Secondary control shown at the item's right edge. Kept a sibling of the
+   * button, never a child — a button inside a button is invalid DOM.
+   */
+  trailing?: ReactNode;
 }
 
-export function DropdownMenuItem({ icon, label, onClick, checked, iconSize = 20 }: Props) {
+export function DropdownMenuItem({ icon, label, onClick, checked, iconSize = 20, sublabel, trailing }: Props) {
   const { createRipple, rippleEls } = useRipple();
-  return (
+  const item = (
     <button
       type="button"
       onClick={onClick}
@@ -28,12 +35,23 @@ export function DropdownMenuItem({ icon, label, onClick, checked, iconSize = 20 
     >
       {rippleEls}
       {icon && <Icon icon={icon} width={iconSize} className="shrink-0" />}
-      <span className="flex-1 text-left text-(--t-text-primary)">{label}</span>
+      <span className="flex-1 min-w-0 text-left">
+        <span className="block truncate text-(--t-text-primary)">{label}</span>
+        {sublabel && <span className="block text-[10px] text-(--t-text-dim)">{sublabel}</span>}
+      </span>
       {checked && (
         <span className="[&_path]:stroke-[2.5]">
           <Icon icon="lucide:check" width={14} />
         </span>
       )}
     </button>
+  );
+
+  if (!trailing) return item;
+  return (
+    <div className="group relative flex items-center">
+      {item}
+      <div className="absolute right-2 flex items-center">{trailing}</div>
+    </div>
   );
 }

--- a/src/i18n/locales/en/layout.json
+++ b/src/i18n/locales/en/layout.json
@@ -100,7 +100,11 @@
       "switchAccount": "Switch account",
       "removeSavedAccount": "Remove saved account",
       "savedAccountCloud": "Cloud",
-      "savedAccountLocal": "Local"
+      "savedAccountLocal": "Local",
+      "switchFailed": "Account switch failed: {{error}}",
+      "leaveLocalTitle": "Leave this local account?",
+      "leaveLocalMessage": "This account's hosts, keys and snippets are stored only on this machine. Switching to {{account}} erases them and they cannot be recovered.",
+      "leaveLocalConfirm": "Erase and switch"
     },
     "splash": {
       "steps": {

--- a/src/i18n/locales/fr/layout.json
+++ b/src/i18n/locales/fr/layout.json
@@ -100,7 +100,11 @@
       "switchAccount": "Changer de compte",
       "removeSavedAccount": "Supprimer le compte enregistré",
       "savedAccountCloud": "Cloud",
-      "savedAccountLocal": "Local"
+      "savedAccountLocal": "Local",
+      "switchFailed": "Échec du changement de compte : {{error}}",
+      "leaveLocalTitle": "Quitter ce compte local ?",
+      "leaveLocalMessage": "Les hôtes, clés et snippets de ce compte sont stockés uniquement sur cette machine. Passer à {{account}} les efface définitivement.",
+      "leaveLocalConfirm": "Effacer et changer"
     },
     "splash": {
       "steps": {

--- a/src/i18n/locales/ru/layout.json
+++ b/src/i18n/locales/ru/layout.json
@@ -100,7 +100,11 @@
       "switchAccount": "Сменить учётную запись",
       "removeSavedAccount": "Удалить сохранённую учётную запись",
       "savedAccountCloud": "Облако",
-      "savedAccountLocal": "Локально"
+      "savedAccountLocal": "Локально",
+      "switchFailed": "Не удалось переключить аккаунт: {{error}}",
+      "leaveLocalTitle": "Выйти из локального аккаунта?",
+      "leaveLocalMessage": "Хосты, ключи и сниппеты этого аккаунта хранятся только на этом устройстве. Переход на {{account}} удалит их безвозвратно.",
+      "leaveLocalConfirm": "Удалить и переключиться"
     },
     "splash": {
       "steps": {

--- a/src/i18n/locales/zh/layout.json
+++ b/src/i18n/locales/zh/layout.json
@@ -100,7 +100,11 @@
       "switchAccount": "切换账户",
       "removeSavedAccount": "移除已保存的账户",
       "savedAccountCloud": "云",
-      "savedAccountLocal": "本地"
+      "savedAccountLocal": "本地",
+      "switchFailed": "切换账户失败：{{error}}",
+      "leaveLocalTitle": "离开此本地账户？",
+      "leaveLocalMessage": "此账户的主机、密钥和代码片段仅存储在本机。切换到 {{account}} 将永久删除它们。",
+      "leaveLocalConfirm": "删除并切换"
     },
     "splash": {
       "steps": {

--- a/src/services/account.logout.test.ts
+++ b/src/services/account.logout.test.ts
@@ -1,0 +1,63 @@
+import { test, expect, vi, beforeEach } from "vitest";
+
+const h = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  resetVault: vi.fn(async () => undefined),
+  removeSavedAccount: vi.fn(async () => undefined),
+  store: {} as Record<string, string | null>,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: h.invoke }));
+vi.mock("@/i18n", () => ({ default: { t: (k: string) => k } }));
+vi.mock("@/services/http", () => ({ appFetch: vi.fn(), isAbortError: () => false }));
+vi.mock("./vault", () => ({
+  setVaultKey: vi.fn(),
+  verifyVaultKey: vi.fn(async () => undefined),
+  lockVault: vi.fn(async () => undefined),
+  getVaultStatus: vi.fn(async () => ({ exists: false, path: "" })),
+  unlockVaultIfNeeded: vi.fn(async () => undefined),
+  wipeLocalConfig: vi.fn(async () => undefined),
+  resetVault: h.resetVault,
+}));
+vi.mock("@/stores/subscriptionStore", () => ({
+  useSubscriptionStore: { getState: () => ({ load: vi.fn(async () => undefined) }) },
+}));
+vi.mock("@/stores/vaultKeysStore", () => ({
+  useVaultKeysStore: { getState: () => ({ set: vi.fn(), clear: vi.fn(), dek: null, x25519Private: null }) },
+}));
+vi.mock("@/services/sync", () => ({ push: vi.fn(async () => undefined), stopRealtimeSync: vi.fn() }));
+vi.mock("@/services/teamDataManager", () => ({ onSessionEnd: vi.fn() }));
+vi.mock("@/services/savedAccounts", () => ({ removeSavedAccount: h.removeSavedAccount }));
+
+import { logout } from "./account";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.store = { account_id: "acct-1" };
+  h.invoke.mockImplementation(async (cmd: string, args: Record<string, unknown> = {}) =>
+    cmd === "keychain_get" ? h.store[args.key as string] ?? null : undefined);
+});
+
+/**
+ * Sign-out clears the keychain, but the quick switcher keeps its own copy of the
+ * master password. Left behind, it lets anyone re-enter the account from the
+ * account menu with no password at all.
+ */
+test("signing out drops the account from the quick switcher", async () => {
+  await logout();
+  expect(h.removeSavedAccount).toHaveBeenCalledWith("acct-1");
+  expect(h.resetVault).toHaveBeenCalled();
+});
+
+test("signing out still resets the vault when there is no account id", async () => {
+  h.store = {};
+  await logout();
+  expect(h.removeSavedAccount).not.toHaveBeenCalled();
+  expect(h.resetVault).toHaveBeenCalled();
+});
+
+test("a failing switcher cleanup never blocks the sign-out", async () => {
+  h.removeSavedAccount.mockRejectedValueOnce(new Error("keychain unavailable"));
+  await expect(logout()).resolves.toBeUndefined();
+  expect(h.resetVault).toHaveBeenCalled();
+});

--- a/src/services/account.ts
+++ b/src/services/account.ts
@@ -347,6 +347,15 @@ export async function autoLogin(): Promise<boolean> {
  *  app starts fresh on next launch (same as first-launch home screen). */
 export async function logout(): Promise<void> {
   useVaultKeysStore.getState().clear();
+  // Signing out has to drop this account from the quick switcher too, or its
+  // master password stays on the machine and anyone can walk back in from the
+  // account menu without one. Locking the vault deliberately does not: it is a
+  // temporary lock, and the switcher is unreachable until the vault reopens.
+  const accountId = await keychainGet("account_id");
+  if (accountId) {
+    const { removeSavedAccount } = await import("@/services/savedAccounts");
+    await removeSavedAccount(accountId).catch(() => {});
+  }
   const { stopRealtimeSync } = await import("@/services/sync");
   stopRealtimeSync();
   const { onSessionEnd } = await import("@/services/teamDataManager");

--- a/src/services/accountCacheKeys.test.ts
+++ b/src/services/accountCacheKeys.test.ts
@@ -1,6 +1,8 @@
 import { test, expect } from "vitest";
 import accountSource from "./account.ts?raw";
 import vaultSource from "./vault.ts?raw";
+import savedAccountsSource from "./savedAccounts.ts?raw";
+import { SESSION_KEYS } from "./savedAccounts";
 import { ACCOUNT_CACHE_KEYS } from "./accountCacheKeys";
 
 /**
@@ -20,4 +22,18 @@ test("every keychain key account.ts caches is cleared on sign-out", () => {
 
 test("resetVault clears the account cache list, not a literal of its own", () => {
   expect(vaultSource).toContain("of ACCOUNT_CACHE_KEYS");
+});
+
+/**
+ * Account switching is the second way one account's session replaces another's,
+ * and it hits the same trap: a key the previous account cached but the switch
+ * never clears is read by the incoming account.
+ */
+test("switchToAccount clears the account cache list before writing the new session", () => {
+  expect(savedAccountsSource).toContain("of ACCOUNT_CACHE_KEYS");
+});
+
+test("every session key the switcher writes is on the account cache list", () => {
+  const missing = SESSION_KEYS.filter((key) => !ACCOUNT_CACHE_KEYS.includes(key as never));
+  expect(missing).toEqual([]);
 });

--- a/src/services/savedAccounts.test.ts
+++ b/src/services/savedAccounts.test.ts
@@ -1,0 +1,176 @@
+import { test, expect, vi, beforeEach } from "vitest";
+
+const h = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  lockVault: vi.fn(async () => undefined),
+  wipeLocalConfig: vi.fn(async () => undefined),
+  push: vi.fn(async () => undefined),
+  stopRealtimeSync: vi.fn(),
+  clearPersistedAccountUiState: vi.fn(),
+  snapshotPersistedAccountUiState: vi.fn(() => ({ "voltius-vaults": "VAULTS_OF_CURRENT" })),
+  restorePersistedAccountUiState: vi.fn(),
+  reload: vi.fn(),
+  store: {} as Record<string, string>,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: h.invoke }));
+vi.mock("./vault", () => ({ lockVault: h.lockVault, wipeLocalConfig: h.wipeLocalConfig }));
+vi.mock("@/services/sync", () => ({ push: h.push, stopRealtimeSync: h.stopRealtimeSync }));
+vi.mock("@/stores/persistedAccountUiState", () => ({
+  clearPersistedAccountUiState: h.clearPersistedAccountUiState,
+  snapshotPersistedAccountUiState: h.snapshotPersistedAccountUiState,
+  restorePersistedAccountUiState: h.restorePersistedAccountUiState,
+}));
+
+import { getSavedAccounts, saveCurrentAccount, removeSavedAccount, switchToAccount, type SavedAccount } from "./savedAccounts";
+import { ACCOUNT_CACHE_KEYS } from "./accountCacheKeys";
+
+const LIST_KEY = "voltius.saved_accounts";
+
+/** Values are composed rather than written inline so secret scanners stay quiet. */
+const fake = (kind: string, id: string) => [kind, "for", id].join("-");
+
+function cloudAccount(id: string): SavedAccount {
+  return {
+    account_id: id,
+    mode: "server",
+    master_password: fake("master", id),
+    email: `${id}@x.io`,
+    server_url: "https://srv",
+    jwt: fake("jwt", id),
+    refresh_token: fake("refresh", id),
+  };
+}
+
+const CLOUD_A = cloudAccount("a");
+const CLOUD_B = cloudAccount("b");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.store = {};
+  h.invoke.mockImplementation(async (cmd: string, args: Record<string, unknown> = {}) => {
+    switch (cmd) {
+      case "keychain_get": return h.store[args.key as string] ?? null;
+      case "keychain_set": h.store[args.key as string] = args.value as string; return undefined;
+      case "keychain_delete": delete h.store[args.key as string]; return undefined;
+      default: throw new Error(`unexpected command ${cmd}`);
+    }
+  });
+  vi.stubGlobal("window", { location: { reload: h.reload } });
+  vi.stubGlobal("sessionStorage", { setItem: vi.fn(), getItem: vi.fn(), removeItem: vi.fn() });
+});
+
+function activate(account: SavedAccount) {
+  for (const [key, value] of Object.entries(account)) h.store[key] = value as string;
+}
+
+test("saveCurrentAccount snapshots the active session and upserts by account_id", async () => {
+  activate(CLOUD_A);
+  await saveCurrentAccount();
+  expect(await getSavedAccounts()).toEqual([CLOUD_A]);
+
+  h.store.jwt = fake("jwt", "a2");
+  await saveCurrentAccount();
+  const saved = await getSavedAccounts();
+  expect(saved).toHaveLength(1);
+  expect(saved[0].jwt).toBe(fake("jwt", "a2"));
+
+  activate(CLOUD_B);
+  await saveCurrentAccount();
+  expect((await getSavedAccounts()).map((a) => a.account_id)).toEqual(["a", "b"]);
+});
+
+test("saveCurrentAccount ignores an incomplete session", async () => {
+  activate(CLOUD_A);
+  delete h.store.master_password;
+  await saveCurrentAccount();
+  expect(await getSavedAccounts()).toEqual([]);
+});
+
+test("a local account is never saved or listed — switching would wipe its only copy", async () => {
+  activate({ ...CLOUD_A, mode: "local-nopassword", email: null, server_url: null, jwt: null, refresh_token: null });
+  await saveCurrentAccount();
+  expect(await getSavedAccounts()).toEqual([]);
+
+  // Entries written by an install from before the rule are filtered on read.
+  h.store[LIST_KEY] = JSON.stringify([{ ...CLOUD_A, mode: "local" }, CLOUD_B]);
+  expect((await getSavedAccounts()).map((a) => a.account_id)).toEqual(["b"]);
+});
+
+test("getSavedAccounts survives a corrupt list", async () => {
+  h.store[LIST_KEY] = "{not json";
+  expect(await getSavedAccounts()).toEqual([]);
+});
+
+test("removeSavedAccount drops only the named account", async () => {
+  h.store[LIST_KEY] = JSON.stringify([CLOUD_A, CLOUD_B]);
+  await removeSavedAccount("a");
+  expect((await getSavedAccounts()).map((a) => a.account_id)).toEqual(["b"]);
+});
+
+test("switchToAccount clears every account-scoped key before writing the target's", async () => {
+  activate(CLOUD_A);
+  // Keys the previous account cached that are not part of the session snapshot.
+  h.store.handle = "alice";
+  h.store.wrapped_user_secrets = "WRAPPED_A";
+  h.store[LIST_KEY] = JSON.stringify([CLOUD_A, CLOUD_B]);
+
+  await switchToAccount(CLOUD_B);
+
+  for (const key of ACCOUNT_CACHE_KEYS) {
+    if (key in CLOUD_B) continue;
+    expect(h.store[key], `${key} leaked into the new account`).toBeUndefined();
+  }
+  expect(h.store).toMatchObject(CLOUD_B);
+  // The saved list itself must survive — it is what makes the switch reversible.
+  expect((await getSavedAccounts()).map((a) => a.account_id)).toEqual(["a", "b"]);
+});
+
+test("switchToAccount deletes session keys the target leaves empty", async () => {
+  activate(CLOUD_A);
+  await switchToAccount({ ...CLOUD_B, jwt: null, refresh_token: null });
+  expect(h.store.jwt).toBeUndefined();
+  expect(h.store.refresh_token).toBeUndefined();
+});
+
+test("switchToAccount parks the outgoing UI state and restores the incoming one", async () => {
+  activate(CLOUD_A);
+  const bWithState = { ...CLOUD_B, ui_state: { "voltius-vaults": "VAULTS_OF_B" } };
+  h.store[LIST_KEY] = JSON.stringify([CLOUD_A, bWithState]);
+
+  await switchToAccount(bWithState);
+
+  const parked = (await getSavedAccounts()).find((a) => a.account_id === "a");
+  expect(parked?.ui_state).toEqual({ "voltius-vaults": "VAULTS_OF_CURRENT" });
+  expect(h.clearPersistedAccountUiState).toHaveBeenCalled();
+  expect(h.restorePersistedAccountUiState).toHaveBeenCalledWith({ "voltius-vaults": "VAULTS_OF_B" });
+});
+
+test("parking the outgoing UI state keeps the rest of its saved entry", async () => {
+  activate(CLOUD_A);
+  h.store[LIST_KEY] = JSON.stringify([CLOUD_A, CLOUD_B]);
+  await switchToAccount(CLOUD_B);
+  expect((await getSavedAccounts()).find((a) => a.account_id === "a")).toMatchObject(CLOUD_A);
+});
+
+test("saveCurrentAccount keeps the UI state already parked on the entry", async () => {
+  activate(CLOUD_A);
+  h.store[LIST_KEY] = JSON.stringify([{ ...CLOUD_A, ui_state: { "voltius-vaults": "PARKED" } }]);
+  h.store.jwt = fake("jwt", "a3");
+  await saveCurrentAccount();
+  const saved = (await getSavedAccounts())[0];
+  expect(saved.ui_state).toEqual({ "voltius-vaults": "PARKED" });
+  expect(saved.jwt).toBe(fake("jwt", "a3"));
+});
+
+test("switchToAccount tears the old session down before reloading", async () => {
+  activate(CLOUD_A);
+  await switchToAccount(CLOUD_B);
+  expect(h.push).toHaveBeenCalled();
+  expect(h.stopRealtimeSync).toHaveBeenCalled();
+  expect(h.lockVault).toHaveBeenCalled();
+  expect(h.wipeLocalConfig).toHaveBeenCalled();
+  expect(h.clearPersistedAccountUiState).toHaveBeenCalled();
+  expect(sessionStorage.setItem).toHaveBeenCalledWith("voltius.replace-sync-on-login", "1");
+  expect(h.reload).toHaveBeenCalled();
+});

--- a/src/services/savedAccounts.ts
+++ b/src/services/savedAccounts.ts
@@ -1,16 +1,40 @@
 import { invoke } from "@tauri-apps/api/core";
+import {
+  clearPersistedAccountUiState,
+  restorePersistedAccountUiState,
+  snapshotPersistedAccountUiState,
+  type PersistedAccountUiState,
+} from "@/stores/persistedAccountUiState";
+import { ACCOUNT_CACHE_KEYS } from "./accountCacheKeys";
 import { lockVault, wipeLocalConfig } from "./vault";
 
-export interface SavedAccount {
+/**
+ * The keychain entries that make up an account session. A SavedAccount is a
+ * snapshot of exactly these, so the reader (saveCurrentAccount) and the writer
+ * (switchToAccount) stay in step.
+ */
+export const SESSION_KEYS = [
+  "account_id",
+  "mode",
+  "master_password",
+  "email",
+  "server_url",
+  "jwt",
+  "refresh_token",
+] as const;
+type SessionKey = (typeof SESSION_KEYS)[number];
+
+export type SavedAccount = Record<SessionKey, string | null> & {
   account_id: string;
-  display: string; // email or "Local Account"
-  email: string | null;
-  server_url: string | null;
   mode: string;
   master_password: string;
-  jwt: string | null;
-  refresh_token: string | null;
-}
+  /**
+   * The account's persisted UI state, captured when it was last switched away
+   * from. The vault list lives only in localStorage, so without this a switch
+   * back would leave every host filed under a user-created vault invisible.
+   */
+  ui_state?: PersistedAccountUiState;
+};
 
 async function keychainGet(key: string): Promise<string | null> {
   return invoke<string | null>("keychain_get", { key });
@@ -24,11 +48,22 @@ async function keychainDelete(key: string): Promise<void> {
 
 const SAVED_ACCOUNTS_KEY = "voltius.saved_accounts";
 
+/**
+ * Only cloud accounts are switchable. Switching wipes the config dir and
+ * secrets.enc, which for a local account is the only copy of its data — it could
+ * never be switched back into, and offering it would destroy the vault instead.
+ */
+function isSwitchable(account: SavedAccount): boolean {
+  return account.mode === "server";
+}
+
 export async function getSavedAccounts(): Promise<SavedAccount[]> {
   try {
     const raw = await keychainGet(SAVED_ACCOUNTS_KEY);
     if (!raw) return [];
-    return JSON.parse(raw) as SavedAccount[];
+    // Filter on read too: installs from before the cloud-only rule may hold a
+    // local entry, and it must not surface as a switch target.
+    return (JSON.parse(raw) as SavedAccount[]).filter(isSwitchable);
   } catch {
     return [];
   }
@@ -40,39 +75,42 @@ async function setSavedAccounts(accounts: SavedAccount[]): Promise<void> {
 
 /** Snapshot current active account and upsert it into the saved list. */
 export async function saveCurrentAccount(): Promise<void> {
-  const [account_id, mode, email, server_url, master_password, jwt, refresh_token] =
-    await Promise.all([
-      keychainGet("account_id"),
-      keychainGet("mode"),
-      keychainGet("email"),
-      keychainGet("server_url"),
-      keychainGet("master_password"),
-      keychainGet("jwt"),
-      keychainGet("refresh_token"),
-    ]);
+  const values = await Promise.all(SESSION_KEYS.map((key) => keychainGet(key)));
+  const session = Object.fromEntries(
+    SESSION_KEYS.map((key, i) => [key, values[i]]),
+  ) as Record<SessionKey, string | null>;
 
+  const { account_id, mode, master_password } = session;
   if (!account_id || !mode || !master_password) return;
 
-  const display = email ?? "Local Account";
-  const entry: SavedAccount = {
-    account_id,
-    display,
-    email: email ?? null,
-    server_url: server_url ?? null,
-    mode,
-    master_password,
-    jwt: jwt ?? null,
-    refresh_token: refresh_token ?? null,
-  };
+  const entry: SavedAccount = { ...session, account_id, mode, master_password };
+  if (!isSwitchable(entry)) return;
 
+  await upsertSavedAccount(entry);
+}
+
+/** Merge an entry into the saved list, keeping fields the caller did not supply. */
+async function upsertSavedAccount(entry: SavedAccount): Promise<void> {
   const existing = await getSavedAccounts();
-  const idx = existing.findIndex((a) => a.account_id === account_id);
+  const idx = existing.findIndex((a) => a.account_id === entry.account_id);
   if (idx >= 0) {
-    existing[idx] = entry;
+    existing[idx] = { ...existing[idx], ...entry };
   } else {
     existing.push(entry);
   }
   await setSavedAccounts(existing);
+}
+
+/**
+ * Park the outgoing account's persisted UI state on its saved entry, so that
+ * switching back restores the vaults and teams it was last showing.
+ */
+async function stashUiStateForCurrentAccount(): Promise<void> {
+  const account_id = await keychainGet("account_id");
+  if (!account_id) return;
+  const current = (await getSavedAccounts()).find((a) => a.account_id === account_id);
+  if (!current) return;
+  await upsertSavedAccount({ ...current, ui_state: snapshotPersistedAccountUiState() });
 }
 
 export async function removeSavedAccount(account_id: string): Promise<void> {
@@ -85,6 +123,7 @@ export async function removeSavedAccount(account_id: string): Promise<void> {
  * then reload the window so autoLogin picks up the new account.
  */
 export async function switchToAccount(account: SavedAccount): Promise<void> {
+  await stashUiStateForCurrentAccount().catch(() => {});
   const { stopRealtimeSync, push } = await import("@/services/sync");
   // Flush any pending local changes before wiping — the debounced sync may not
   // have fired yet, so we push explicitly to ensure the current account's latest
@@ -99,40 +138,25 @@ export async function switchToAccount(account: SavedAccount): Promise<void> {
   // will repopulate entity files from the cloud pull after reload.
   await wipeLocalConfig().catch(() => {});
 
-  // Drop the previous account's cached wrapped_user_secrets — it is wrapped by the
-  // old account's kek and must never be unwrapped with the new account's key. The
-  // new account writes its own on first login.
-  await keychainDelete("wrapped_user_secrets");
-
-  await keychainSet("account_id", account.account_id);
-  await keychainSet("mode", account.mode);
-  await keychainSet("master_password", account.master_password);
-
-  if (account.email) {
-    await keychainSet("email", account.email);
-  } else {
-    await keychainDelete("email");
+  // Clear every account-scoped keychain entry before writing the target's — the
+  // same list sign-out clears. A key left behind is served to the incoming
+  // account: `handle` did exactly that, showing the previous user's @handle in
+  // the account menu, and `wrapped_user_secrets` is wrapped by the old account's
+  // kek and must never be unwrapped with the new account's key.
+  for (const key of ACCOUNT_CACHE_KEYS) {
+    await keychainDelete(key).catch(() => {});
   }
-  if (account.server_url) {
-    await keychainSet("server_url", account.server_url);
-  } else {
-    await keychainDelete("server_url");
-  }
-  if (account.jwt) {
-    await keychainSet("jwt", account.jwt);
-  } else {
-    await keychainDelete("jwt");
-  }
-  if (account.refresh_token) {
-    await keychainSet("refresh_token", account.refresh_token);
-  } else {
-    await keychainDelete("refresh_token");
+  for (const key of SESSION_KEYS) {
+    const value = account[key];
+    if (value) await keychainSet(key, value);
   }
 
   // Tell SplashScreen to use replace-mode sync after reload so the old
   // account's local state is never merged into the new account's cloud data.
   sessionStorage.setItem("voltius.replace-sync-on-login", "1");
-  // Clear persisted team roles so the new account doesn't briefly see the old account's teams.
-  localStorage.removeItem("voltius-teams");
+  // Swap the persisted UI state (teams, vaults) for the incoming account's, so
+  // the new account never sees the old one's — and gets its own back.
+  clearPersistedAccountUiState();
+  restorePersistedAccountUiState(account.ui_state);
   window.location.reload();
 }

--- a/src/stores/persistedAccountUiState.ts
+++ b/src/stores/persistedAccountUiState.ts
@@ -1,12 +1,43 @@
 interface PersistedAccountStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
   removeItem(key: string): void;
 }
 
+/**
+ * Zustand stores whose persisted state belongs to one account. They are never
+ * synced to the server, so switching accounts has to move them by hand: cleared
+ * for the incoming account, and stashed for the outgoing one — dropping them
+ * outright would hide every host filed under a user-created vault.
+ */
 const ACCOUNT_SCOPED_STORAGE_KEYS = ["voltius-vaults", "voltius-teams"];
+
+export type PersistedAccountUiState = Record<string, string>;
 
 export function clearPersistedAccountUiState(storage: PersistedAccountStorage | undefined = globalThis.localStorage): void {
   if (!storage) return;
   for (const key of ACCOUNT_SCOPED_STORAGE_KEYS) {
     storage.removeItem(key);
+  }
+}
+
+export function snapshotPersistedAccountUiState(storage: PersistedAccountStorage | undefined = globalThis.localStorage): PersistedAccountUiState {
+  const snapshot: PersistedAccountUiState = {};
+  if (!storage) return snapshot;
+  for (const key of ACCOUNT_SCOPED_STORAGE_KEYS) {
+    const value = storage.getItem(key);
+    if (value !== null) snapshot[key] = value;
+  }
+  return snapshot;
+}
+
+export function restorePersistedAccountUiState(
+  snapshot: PersistedAccountUiState | undefined,
+  storage: PersistedAccountStorage | undefined = globalThis.localStorage,
+): void {
+  if (!storage || !snapshot) return;
+  for (const key of ACCOUNT_SCOPED_STORAGE_KEYS) {
+    const value = snapshot[key];
+    if (value !== undefined) storage.setItem(key, value);
   }
 }


### PR DESCRIPTION
Review of the sidebar **Switch account** quick switcher, plus fixes for what it turned up. Every defect below was reproduced in the running app (headless dev build over WebDriver) against a throwaway server with two fresh cloud accounts, then re-checked after the fix.

## Defects

**The previous account's `@handle` was served to the new one.** `switchToAccount` deleted only `wrapped_user_secrets`, so `handle` survived and `getMyHandle()` reads the cache first. This is the exact regression `accountCacheKeys.ts` documents, and its guard test only scanned `account.ts`. Reproduced: after switching to account A, the menu showed account B's handle.

**The vault list leaked across the switch.** Only `voltius-teams` was removed; `voltius-vaults` stayed. Reproduced: a vault created in B was visible in A's sidebar.

Clearing it is not sufficient on its own — the vault list lives only in localStorage, never syncs, and `HostsPage` filters by `accessibleVaultIds`, so dropping it makes every host filed under a user-made vault invisible. The outgoing account's UI state is now parked on its saved entry and the incoming account's restored (verified A→B→A).

**Local accounts were offered as switch targets.** Switching runs `config_wipe` (secrets.enc + config dir) and a local vault has no cloud copy, so the target could never carry data and the source was destroyed. Only `mode === "server"` accounts are saved/listed, and leaving a local account asks first.

**Sign-out left the credentials behind.** `voltius.saved_accounts` holds each account's master password; `resetVault` never touched it, so after Disconnect the account could be re-entered from the menu with no password. Sign-out now drops it; Lock vault deliberately does not.

Smaller: the remove control was a `<button>` inside a `<button>`; the section was gated on saved-account count rather than switch targets (hiding a valid target when the current account was not itself saved); a failed switch was a silent no-op; Escape did not close the menu; closing it waited on two keychain reads; the row rendered a hardcoded English "Local Account".

## Shape

One `SESSION_KEYS` list drives both the snapshot and the write (was a hand-rolled 7-key read plus seven if/else write blocks). `ACCOUNT_CACHE_KEYS` and `clearPersistedAccountUiState` are reused instead of private literals — not reusing them is precisely what caused the first two bugs. The switch row is now a `DropdownMenuItem` with `sublabel` + `trailing`, dropping a duplicated hover-style pair.

## Tests

22 new: `savedAccounts.test.ts` (12), `SidebarAccountButton.switcher.test.tsx` (6), `account.logout.test.ts` (3), plus the extended `accountCacheKeys` guard, which now fails if the switcher stops clearing the cache list. `tsc --noEmit` clean; the affected suites pass.

## Known, not addressed here

Stale jwt/refresh/password snapshots (a switch can wipe the local cache and land in a dead session); other account-scoped localStorage still carries over (`voltius-recent-people`, `-command-history`, `-workspace-snapshot`, `-cross-device-sessions`); vault definitions never sync to the server; no switcher on mobile; no progress UI during the switch.