### PR TITLE
fix(account): move the rest of an account's local state with the account

### DIFF
--- a/src/components/layout/SidebarAccountButton.switcher.test.tsx
+++ b/src/components/layout/SidebarAccountButton.switcher.test.tsx
@@ -8,6 +8,7 @@ const h = vi.hoisted(() => ({
   getSavedAccounts: vi.fn(async (): Promise<SavedAccount[]> => []),
   saveCurrentAccount: vi.fn(async () => {}),
   switchToAccount: vi.fn(async () => {}),
+  signOutToAddAccount: vi.fn(async () => {}),
   removeSavedAccount: vi.fn(async () => {}),
   keychain: {} as Record<string, string | null>,
 }));
@@ -30,6 +31,7 @@ vi.mock("@/services/savedAccounts", () => ({
   getSavedAccounts: h.getSavedAccounts,
   saveCurrentAccount: h.saveCurrentAccount,
   switchToAccount: h.switchToAccount,
+  signOutToAddAccount: h.signOutToAddAccount,
   removeSavedAccount: h.removeSavedAccount,
 }));
 
@@ -139,4 +141,16 @@ test("the auto-lock row opens the account settings section", async () => {
   await userEvent.click(await screen.findByText("layout.sidebarAccount.autoLock"));
   expect(useUIStore.getState().settingsOpen).toBe(true);
   expect(useUIStore.getState().settingsSection).toBe("account");
+});
+
+test("a cloud account can add another one without signing out", async () => {
+  await openMenu();
+  await userEvent.click(await screen.findByText("layout.sidebarAccount.addAccount"));
+  expect(h.signOutToAddAccount).toHaveBeenCalled();
+});
+
+test("a local account is not offered the add-account route", async () => {
+  h.accountMode = "local";
+  await openMenu();
+  expect(screen.queryByText("layout.sidebarAccount.addAccount")).toBeNull();
 });

--- a/src/components/layout/SidebarAccountButton.tsx
+++ b/src/components/layout/SidebarAccountButton.tsx
@@ -6,7 +6,7 @@ import { useUIStore } from "@/stores/uiStore";
 import { useThemeStore } from "@/stores/themeStore";
 import { useRipple } from "@/hooks/useRipple";
 import { getAccountMode, getMyHandle, lockVaultSession, logout } from "@/services/account";
-import { getSavedAccounts, saveCurrentAccount, switchToAccount, removeSavedAccount, type SavedAccount } from "@/services/savedAccounts";
+import { getSavedAccounts, saveCurrentAccount, signOutToAddAccount, switchToAccount, removeSavedAccount, type SavedAccount } from "@/services/savedAccounts";
 import { ConfirmModal } from "@/components/shared/ConfirmModal";
 import { DropdownMenuItem } from "@/components/shared/DropdownMenuItem";
 import { useCopyHandle } from "@/hooks/useCopyHandle";
@@ -89,6 +89,11 @@ export function SidebarAccountButton() {
     setOpen(false);
     await logout();
     window.location.reload();
+  };
+
+  const handleAddAccount = async () => {
+    setOpen(false);
+    await signOutToAddAccount();
   };
 
   const handleSwitchAccount = async (account: SavedAccount) => {
@@ -246,6 +251,14 @@ export function SidebarAccountButton() {
               icon="lucide:log-in"
               label={t("layout.sidebarAccount.signInSignUp")}
               onClick={() => { openCloudAuth("signin"); setOpen(false); }}
+            />
+          )}
+
+          {accountMode === "server" && (
+            <DropdownMenuItem
+              icon="lucide:user-plus"
+              label={t("layout.sidebarAccount.addAccount")}
+              onClick={() => void handleAddAccount()}
             />
           )}
 

--- a/src/i18n/locales/en/layout.json
+++ b/src/i18n/locales/en/layout.json
@@ -107,7 +107,8 @@
       "leaveLocalConfirm": "Erase and switch",
       "autoLock": "Auto-lock settings…",
       "autoLockOff": "Auto-lock off",
-      "autoLockAfter": "Auto-locks after {{duration}}"
+      "autoLockAfter": "Auto-locks after {{duration}}",
+      "addAccount": "Add another account…"
     },
     "splash": {
       "steps": {

--- a/src/i18n/locales/fr/layout.json
+++ b/src/i18n/locales/fr/layout.json
@@ -107,7 +107,8 @@
       "leaveLocalConfirm": "Effacer et changer",
       "autoLock": "Réglages du verrouillage auto…",
       "autoLockOff": "Verrouillage auto désactivé",
-      "autoLockAfter": "Verrouillage auto après {{duration}}"
+      "autoLockAfter": "Verrouillage auto après {{duration}}",
+      "addAccount": "Ajouter un autre compte…"
     },
     "splash": {
       "steps": {

--- a/src/i18n/locales/ru/layout.json
+++ b/src/i18n/locales/ru/layout.json
@@ -107,7 +107,8 @@
       "leaveLocalConfirm": "Удалить и переключиться",
       "autoLock": "Настройки автоблокировки…",
       "autoLockOff": "Автоблокировка выключена",
-      "autoLockAfter": "Автоблокировка через {{duration}}"
+      "autoLockAfter": "Автоблокировка через {{duration}}",
+      "addAccount": "Добавить другой аккаунт…"
     },
     "splash": {
       "steps": {

--- a/src/i18n/locales/zh/layout.json
+++ b/src/i18n/locales/zh/layout.json
@@ -107,7 +107,8 @@
       "leaveLocalConfirm": "删除并切换",
       "autoLock": "自动锁定设置…",
       "autoLockOff": "自动锁定已关闭",
-      "autoLockAfter": "{{duration}}后自动锁定"
+      "autoLockAfter": "{{duration}}后自动锁定",
+      "addAccount": "添加其他账户…"
     },
     "splash": {
       "steps": {

--- a/src/services/savedAccounts.test.ts
+++ b/src/services/savedAccounts.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/stores/persistedAccountUiState", () => ({
   restorePersistedAccountUiState: h.restorePersistedAccountUiState,
 }));
 
-import { getSavedAccounts, saveCurrentAccount, removeSavedAccount, switchToAccount, type SavedAccount } from "./savedAccounts";
+import { getSavedAccounts, saveCurrentAccount, removeSavedAccount, signOutToAddAccount, switchToAccount, type SavedAccount } from "./savedAccounts";
 import { ACCOUNT_CACHE_KEYS } from "./accountCacheKeys";
 
 const LIST_KEY = "voltius.saved_accounts";
@@ -173,4 +173,30 @@ test("switchToAccount tears the old session down before reloading", async () => 
   expect(h.clearPersistedAccountUiState).toHaveBeenCalled();
   expect(sessionStorage.setItem).toHaveBeenCalledWith("voltius.replace-sync-on-login", "1");
   expect(h.reload).toHaveBeenCalled();
+});
+
+/**
+ * Sign-out forgets the account by design, and it is otherwise the only way to
+ * reach the auth screen — so without this the switcher could never hold a
+ * second account.
+ */
+test("adding another account keeps the current one in the switcher", async () => {
+  activate(CLOUD_A);
+  h.store.handle = "alice";
+
+  await signOutToAddAccount();
+
+  expect((await getSavedAccounts()).map((a) => a.account_id)).toEqual(["a"]);
+  expect(h.store.master_password).toBeUndefined();
+  expect(h.store.handle).toBeUndefined();
+  expect(h.wipeLocalConfig).toHaveBeenCalled();
+  expect(h.clearPersistedAccountUiState).toHaveBeenCalled();
+  expect(h.reload).toHaveBeenCalled();
+});
+
+test("adding another account parks the outgoing account's UI state", async () => {
+  activate(CLOUD_A);
+  await signOutToAddAccount();
+  const parked = (await getSavedAccounts()).find((a) => a.account_id === "a");
+  expect(parked?.ui_state).toEqual({ "voltius-vaults": "VAULTS_OF_CURRENT" });
 });

--- a/src/services/savedAccounts.ts
+++ b/src/services/savedAccounts.ts
@@ -119,10 +119,12 @@ export async function removeSavedAccount(account_id: string): Promise<void> {
 }
 
 /**
- * Switch to a saved account: lock vault, overwrite active keychain entries,
- * then reload the window so autoLogin picks up the new account.
+ * End the current account's session without touching the saved list: flush its
+ * work to the server, park its UI state, and leave the machine with no active
+ * account. Shared by the switch and by "add another account", which differ only
+ * in what they put back afterwards.
  */
-export async function switchToAccount(account: SavedAccount): Promise<void> {
+async function tearDownSession(): Promise<void> {
   await stashUiStateForCurrentAccount().catch(() => {});
   const { stopRealtimeSync, push } = await import("@/services/sync");
   // Flush any pending local changes before wiping — the debounced sync may not
@@ -146,17 +148,37 @@ export async function switchToAccount(account: SavedAccount): Promise<void> {
   for (const key of ACCOUNT_CACHE_KEYS) {
     await keychainDelete(key).catch(() => {});
   }
+
+  // Tell SplashScreen to use replace-mode sync after reload so the old
+  // account's local state is never merged into the next account's cloud data.
+  sessionStorage.setItem("voltius.replace-sync-on-login", "1");
+  clearPersistedAccountUiState();
+}
+
+/**
+ * Switch to a saved account: end the current session, write the target's
+ * keychain entries and UI state, then reload so autoLogin picks it up.
+ */
+export async function switchToAccount(account: SavedAccount): Promise<void> {
+  await tearDownSession();
   for (const key of SESSION_KEYS) {
     const value = account[key];
     if (value) await keychainSet(key, value);
   }
-
-  // Tell SplashScreen to use replace-mode sync after reload so the old
-  // account's local state is never merged into the new account's cloud data.
-  sessionStorage.setItem("voltius.replace-sync-on-login", "1");
-  // Swap the persisted UI state (teams, vaults) for the incoming account's, so
-  // the new account never sees the old one's — and gets its own back.
-  clearPersistedAccountUiState();
   restorePersistedAccountUiState(account.ui_state);
+  window.location.reload();
+}
+
+/**
+ * Leave the current account signed in to the switcher and land on the auth
+ * screen, so a second account can be added.
+ *
+ * Sign-out cannot do this job: it forgets the account on the way out, by
+ * design. Without this the switcher could never hold more than one account,
+ * because signing out is otherwise the only way to reach the auth screen.
+ */
+export async function signOutToAddAccount(): Promise<void> {
+  await saveCurrentAccount();
+  await tearDownSession();
   window.location.reload();
 }

--- a/src/stores/persistedAccountUiState.test.ts
+++ b/src/stores/persistedAccountUiState.test.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "vitest";
+import {
+  ACCOUNT_SCOPED_STORAGE_KEYS,
+  ACCOUNT_SCOPED_RESET_KEYS,
+  DEVICE_SCOPED_STORAGE_KEYS,
+  clearPersistedAccountUiState,
+  snapshotPersistedAccountUiState,
+  restorePersistedAccountUiState,
+} from "./persistedAccountUiState";
+
+const storeSources = import.meta.glob("./*.ts", { query: "?raw", import: "default", eager: true }) as Record<string, string>;
+
+function fakeStorage(initial: Record<string, string> = {}) {
+  const data = { ...initial };
+  return {
+    data,
+    getItem: (key: string) => data[key] ?? null,
+    setItem: (key: string, value: string) => { data[key] = value; },
+    removeItem: (key: string) => { delete data[key]; },
+  };
+}
+
+const ACCOUNT_STATE = Object.fromEntries(ACCOUNT_SCOPED_STORAGE_KEYS.map((key) => [key, `state of ${key}`]));
+const DEVICE_STATE = Object.fromEntries(DEVICE_SCOPED_STORAGE_KEYS.map((key) => [key, `state of ${key}`]));
+const RESET_STATE = Object.fromEntries(ACCOUNT_SCOPED_RESET_KEYS.map((key) => [key, `state of ${key}`]));
+
+test("clearing takes the account's state and leaves the machine's", () => {
+  const storage = fakeStorage({ ...ACCOUNT_STATE, ...DEVICE_STATE, ...RESET_STATE });
+
+  clearPersistedAccountUiState(storage);
+
+  expect(Object.keys(storage.data).sort()).toEqual([...DEVICE_SCOPED_STORAGE_KEYS].sort());
+});
+
+test("a snapshot carries the account's state but never the reset keys", () => {
+  const storage = fakeStorage({ ...ACCOUNT_STATE, ...DEVICE_STATE, ...RESET_STATE });
+
+  const snapshot = snapshotPersistedAccountUiState(storage);
+
+  expect(snapshot).toEqual(ACCOUNT_STATE);
+});
+
+test("restoring writes the snapshot back and leaves absent keys absent", () => {
+  const storage = fakeStorage(DEVICE_STATE);
+
+  restorePersistedAccountUiState({ "voltius-vaults": "the vaults" }, storage);
+
+  expect(storage.data["voltius-vaults"]).toBe("the vaults");
+  expect(storage.data["voltius-teams"]).toBeUndefined();
+});
+
+test("a switch hands the incoming account its own state, not the outgoing one's", () => {
+  const storage = fakeStorage({ ...ACCOUNT_STATE, ...DEVICE_STATE, ...RESET_STATE });
+
+  const outgoing = snapshotPersistedAccountUiState(storage);
+  clearPersistedAccountUiState(storage);
+  restorePersistedAccountUiState({ "voltius-teams": "the other account's teams" }, storage);
+
+  expect(storage.data["voltius-teams"]).toBe("the other account's teams");
+  expect(storage.data["voltius-command-history"]).toBeUndefined();
+  expect(storage.data["voltius-app-settings-ts"]).toBeUndefined();
+
+  // …and switching back returns what the first account had.
+  clearPersistedAccountUiState(storage);
+  restorePersistedAccountUiState(outgoing, storage);
+  expect(storage.data).toMatchObject(ACCOUNT_STATE);
+});
+
+/**
+ * The whole bug class here is a store nobody classified: it keeps its previous
+ * account's contents and shows them to the next one. A new persisted store has
+ * to land in one of the three lists or this fails.
+ */
+test("every persisted store is classified as the account's or the machine's", () => {
+  const persisted = Object.values(storeSources)
+    .flatMap((source) => [...source.matchAll(/name: "(voltius-[a-z0-9-]+)"/g)].map((m) => m[1]));
+
+  expect(persisted.length).toBeGreaterThan(15);
+
+  const classified = new Set([
+    ...ACCOUNT_SCOPED_STORAGE_KEYS,
+    ...ACCOUNT_SCOPED_RESET_KEYS,
+    ...DEVICE_SCOPED_STORAGE_KEYS,
+  ]);
+  expect([...new Set(persisted)].filter((key) => !classified.has(key))).toEqual([]);
+});
+
+test("no key is classified twice", () => {
+  const all = [...ACCOUNT_SCOPED_STORAGE_KEYS, ...ACCOUNT_SCOPED_RESET_KEYS, ...DEVICE_SCOPED_STORAGE_KEYS];
+  expect(all).toHaveLength(new Set(all).size);
+});

--- a/src/stores/persistedAccountUiState.ts
+++ b/src/stores/persistedAccountUiState.ts
@@ -9,14 +9,73 @@ interface PersistedAccountStorage {
  * synced to the server, so switching accounts has to move them by hand: cleared
  * for the incoming account, and stashed for the outgoing one — dropping them
  * outright would hide every host filed under a user-created vault.
+ *
+ * A store belongs here when its contents name the account's own things — its
+ * vaults, teams, hosts, teammates, sessions. Device preferences (UI scale,
+ * theme, poll intervals, which plugins are exposed to MCP) do not: they follow
+ * the machine, not the person signed in on it.
  */
-const ACCOUNT_SCOPED_STORAGE_KEYS = ["voltius-vaults", "voltius-teams"];
+export const ACCOUNT_SCOPED_STORAGE_KEYS = [
+  "voltius-vaults",
+  "voltius-teams",
+  // Teammates this account invited, by handle.
+  "voltius-recent-people",
+  // Commands typed into this account's sessions, and their unsent input buffers.
+  "voltius-command-history",
+  // Open tabs, which name this account's connections and sessions.
+  "voltius-workspace-snapshot",
+  // Session manifests published by this account's other devices.
+  "voltius-cross-device-sessions",
+  // Recent snippet runs, keyed by connection.
+  "voltius-snippet-recent",
+  // Snippet variable values remembered per connection — often credentials.
+  "voltius-host-command-vars",
+];
+
+/**
+ * The local clock for the app-settings sync payload. Unlike the keys above it is
+ * cleared without ever being restored: it exists only to win or lose a
+ * last-write-wins merge, and one account's newer stamp would make the incoming
+ * account's own settings look stale and never apply.
+ */
+export const ACCOUNT_SCOPED_RESET_KEYS = ["voltius-app-settings-ts"];
+
+/**
+ * Knowingly left out: `voltius-local-audit-logs`. It is account data, but it is
+ * read strictly by vault id — ids the next account cannot hold — so it is
+ * residue rather than a leak, and it runs to ~1 MB per vault, which is far too
+ * much to park inside a keychain entry (the Linux keyring's default per-user
+ * quota is 20 KB in total). It wants per-account namespacing instead.
+ */
+
+/**
+ * Persisted state that deliberately stays put across a sign-out or a switch: it
+ * describes the machine and how this person likes it set up, not the account.
+ * Listed rather than assumed so the guard test can insist that every persisted
+ * store is classified one way or the other.
+ */
+export const DEVICE_SCOPED_STORAGE_KEYS = [
+  "voltius-ui",
+  "voltius-theme",
+  "voltius-locale",
+  "voltius-security",
+  "voltius-shortcuts",
+  "voltius-sftp-settings",
+  "voltius-terminal-settings",
+  "voltius-toggle-settings",
+  "voltius-connectivity-settings",
+  "voltius-mcp-contributions",
+  // Persists poll intervals only — the statuses it holds stay in memory.
+  "voltius-host-ping",
+  // Persists nothing (`partialize: () => ({})`); the key is an empty husk.
+  "voltius-connection-presence",
+];
 
 export type PersistedAccountUiState = Record<string, string>;
 
 export function clearPersistedAccountUiState(storage: PersistedAccountStorage | undefined = globalThis.localStorage): void {
   if (!storage) return;
-  for (const key of ACCOUNT_SCOPED_STORAGE_KEYS) {
+  for (const key of [...ACCOUNT_SCOPED_STORAGE_KEYS, ...ACCOUNT_SCOPED_RESET_KEYS]) {
     storage.removeItem(key);
   }
 }


### PR DESCRIPTION
Follow-up to #127. That PR moved `voltius-vaults` and `voltius-teams` with the account and left every other account-scoped store behind.

## What was leaking

The incoming account inherited the outgoing one's **command history and unsent input buffers**, the **teammates it had invited**, its **open tabs**, the **sessions its other devices published**, its **recent snippet runs**, and the **snippet variable values remembered per connection** — which are often credentials. Sign-out left all of it behind too.

They are parked on the account's saved entry and restored on the way back, exactly as vaults and teams already were.

**`voltius-app-settings-ts` is cleared rather than parked.** It is the local clock for the app-settings sync payload; the outgoing account's newer stamp made the incoming account's own settings lose the last-write-wins merge and never apply. Restoring it would recreate that, so it is reset and the incoming account's settings always win.

**Deliberately excluded, with the reasoning in the source:** `voltius-local-audit-logs` (account data, but read strictly by vault id — ids the next account cannot hold — and ~1 MB per vault against a 20 KB Linux keyring quota; it wants per-account namespacing), and the device preferences: UI scale, theme, locale, shortcuts, terminal/SFTP/connectivity settings, MCP exposure, ping intervals.

The classification is the durable part: every persisted store is now listed as the account's or the machine's, and a test fails on any store that is neither.

## A regression from #127, fixed here

Sign-out drops the account from the switcher — right on its own, but it was also the **only** way to reach the auth screen. So after #127 a second account could never be added: sign out of A, sign in as B, switcher empty. Reproduced in the app before fixing.

**"Add another account…"** (cloud accounts only) ends the session the way a switch does — flush, park, lock, wipe the config dir, clear the keychain cache — and lands on the auth screen with the account still saved. Disconnect keeps forgetting it.

## Verified in the running app

Two accounts on a throwaway server:

- "Add another account" from B → auth screen, B's keys cleared from localStorage, B still saved.
- Signed in as A → B is a switch target again (the regression path).
- Seeded A with `secret-of-A` in history, `friend-of-A` in recent people, `A-secret-var` in snippet vars → switched to B: B saw **its own** `secret-of-B` / `friend-of-B`, no snippet vars, no settings stamp; `voltius-ui` untouched.
- Switched back to A: all three of A's values returned, settings stamp still clear.
- Disconnect: only device preferences, `device_id` and the team-key migration flag remain.

11 new tests (6 on the classification, 2 on add-account in the service, 2 in the menu, plus the switch round trip); `tsc --noEmit` clean. `TitleBar.syncState` times out locally under load with these changes stashed as well — unrelated.