### PR TITLE
feat(share): make People rows read as clickable and let Recent be pruned

### DIFF
--- a/src/components/terminal/PeopleTab.test.tsx
+++ b/src/components/terminal/PeopleTab.test.tsx
@@ -84,6 +84,43 @@ test("Recent's own empty state stands alone even while Your teams has results", 
   expect(screen.getByText("terminal.share.recentEmpty")).toBeTruthy();
 });
 
+test("a recent row can be forgotten from the row itself", async () => {
+  useRecentPeopleStore.setState({ recent: [{ user_id: "r1", handle: "kevin-p-6620", last_invited_at: "" }], recentUpdatedAt: "" });
+  render(<PeopleTab {...base} />);
+  await userEvent.click(await screen.findByRole("button", { name: "terminal.share.forgetPerson" }));
+  expect(useRecentPeopleStore.getState().recent).toHaveLength(0);
+  expect(screen.queryByRole("button", { name: /kevin-p-6620/i })).toBeNull();
+});
+
+test("forgetting does not invite: the forget control is its own target", async () => {
+  useRecentPeopleStore.setState({ recent: [{ user_id: "r1", handle: "kevin-p-6620", last_invited_at: "" }], recentUpdatedAt: "" });
+  const onInvite = vi.fn();
+  render(<PeopleTab {...base} onInvite={onInvite} />);
+  await userEvent.click(await screen.findByRole("button", { name: "terminal.share.forgetPerson" }));
+  expect(onInvite).not.toHaveBeenCalled();
+});
+
+// Nothing to forget on a teammate or a search hit — the row is derived from the
+// roster/server, not from local Recent, so an X there would promise a deletion
+// the store cannot make.
+test("only recent rows offer forget", async () => {
+  h.allTeammates.mockResolvedValue(roster);
+  h.searchUsers.mockResolvedValue([{ user_id: "s1", handle: "sam-q", is_teammate: false }]);
+  render(<PeopleTab {...base} />);
+  await userEvent.type(screen.getByRole("textbox"), "sam-q");
+  await screen.findByRole("button", { name: /sam-q/i });
+  expect(screen.queryByRole("button", { name: "terminal.share.forgetPerson" })).toBeNull();
+});
+
+test("an invitable row reads as clickable and a blocked one does not", async () => {
+  h.allTeammates.mockResolvedValue(roster);
+  render(<PeopleTab {...base} session={{ vaultIds: ["t1"], participantIds: [], invitedIds: [] }} />);
+  const covered = await screen.findByRole("button", { name: /amber-lynx-4410/i });
+  const open = await screen.findByRole("button", { name: /brisk-otter-8823/i });
+  expect(open.className).toContain("cursor-pointer");
+  expect(covered.className).not.toContain("cursor-pointer");
+});
+
 // ─── Moved from InvitePeopleSection.test.tsx (that component was deleted; PeopleTab
 // replaced it as ShareMenu's only invite surface) ───────────────────────────────
 

--- a/src/components/terminal/PeopleTab.tsx
+++ b/src/components/terminal/PeopleTab.tsx
@@ -41,8 +41,17 @@ interface RowEntry {
   isStranger: boolean;
   /** Only teammates carry live presence; undefined omits the dot entirely. */
   isOnline?: boolean;
+  /** Only Recent rows: the roster and search hits aren't ours to delete. */
+  canForget?: boolean;
   onContextMenu?: (e: React.MouseEvent) => void;
 }
+
+/**
+ * Row controls stay out of the way until the row is aimed at. Coarse pointers
+ * have no hover to reveal them with, so there they're simply always visible.
+ */
+const REVEAL =
+  "opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100";
 
 function ErrorBanner({ children }: { children: React.ReactNode }) {
   return (
@@ -67,6 +76,7 @@ function PersonRow({
   capBlocked,
   onInvite,
   onUninvite,
+  onForget,
   t,
 }: {
   entry: RowEntry;
@@ -77,15 +87,18 @@ function PersonRow({
   onInvite: () => void;
   /** Offered only on a standing invite: the seat it holds is the one A6 exists to free. */
   onUninvite?: () => void;
+  /** Drops the person from Recent. Absent on rows that aren't ours to delete. */
+  onForget?: () => void;
   t: (key: string, opts?: Record<string, unknown>) => string;
 }) {
   const { target, isStranger, isOnline, onContextMenu } = entry;
+  const actionable = !hasAccess && !inFlight && !invited && !capBlocked;
   return (
-    <div className="flex items-center gap-1">
+    <div className={`group flex items-center gap-1 rounded-md transition-colors ${actionable ? "hover:bg-(--t-bg-elevated)" : ""}`}>
       <button
-        className="flex-1 min-w-0 flex items-center gap-2 px-2 py-1.5 rounded-md text-left disabled:cursor-default transition-colors"
+        className={`flex-1 min-w-0 flex items-center gap-2 px-2 py-1.5 rounded-md text-left transition-colors focus-visible:outline-1 focus-visible:outline-(--t-accent) ${actionable ? "cursor-pointer" : "cursor-default"}`}
         style={{ color: "var(--t-text-primary)", background: "transparent" }}
-        disabled={hasAccess || inFlight || invited || capBlocked}
+        disabled={!actionable}
         onClick={onInvite}
         onContextMenu={onContextMenu}
       >
@@ -120,16 +133,32 @@ function PersonRow({
           <span className="text-[10px] shrink-0" style={{ color: "var(--t-text-dim)" }}>
             {t("terminal.share.inviteCapReached")}
           </span>
-        ) : null}
+        ) : (
+          // Names the action rather than only hinting the row is live: an
+          // untouched row is otherwise indistinguishable from static text.
+          <Icon icon="lucide:user-plus" width={12} className={`shrink-0 ${REVEAL}`} style={{ color: "var(--t-text-dim)" }} />
+        )}
       </button>
       {invited && onUninvite && (
         <button
-          className="text-[10px] px-1.5 py-1 rounded-md shrink-0 transition-colors"
+          className="text-[10px] px-1.5 py-1 rounded-md shrink-0 transition-colors cursor-pointer"
           style={{ color: "var(--t-text-dim)" }}
           title={t("terminal.share.withdrawInvite")}
           onClick={onUninvite}
         >
           {t("terminal.share.withdrawInvite")}
+        </button>
+      )}
+      {onForget && (
+        <button
+          // Colour lives in classes, not `style`: an inline colour outranks the
+          // hover variant and the red-on-hover never lands.
+          className={`p-1 mr-1 rounded-md shrink-0 cursor-pointer text-(--t-text-dim) hover:text-(--t-status-error) ${REVEAL}`}
+          title={t("terminal.share.forgetPerson")}
+          aria-label={t("terminal.share.forgetPerson")}
+          onClick={onForget}
+        >
+          <Icon icon="lucide:x" width={12} />
         </button>
       )}
     </div>
@@ -221,6 +250,7 @@ export function PeopleTab({ session, invitedThisSession, guestCap, tier, onUpgra
       },
       teamIds: teammate?.teamIds ?? [],
       isStranger: false,
+      canForget: true,
       onContextMenu: (e: React.MouseEvent) => {
         e.preventDefault();
         setMenu({ userId: p.user_id, pos: { x: e.clientX, y: e.clientY } });
@@ -262,6 +292,7 @@ export function PeopleTab({ session, invitedThisSession, guestCap, tier, onUpgra
         capBlocked={capBlocked}
         onInvite={() => handleInvite(entry.target)}
         onUninvite={onUninvite ? () => handleUninvite(entry.target.user_id) : undefined}
+        onForget={entry.canForget ? () => forget(entry.target.user_id) : undefined}
         t={t}
       />
     );


### PR DESCRIPTION
## Problem

Two things reported on ShareMenu's People tab:

1. Forgetting a Recent person existed only behind a right-click context menu — invisible on a mouse, unreachable on touch.
2. Rows had no hover state, no pointer cursor and no focus ring. Tailwind v4's preflight pins buttons to `cursor: default`, so an invitable row was visually indistinguishable from static text. The same applied to teammate rows and search results.

## Change

All in `PersonRow`, so Recent, Your teams and search hits are fixed by one edit:

- `actionable` is derived once and drives both the `disabled` state and the styling (replaces the inline `hasAccess || inFlight || invited || capBlocked` expression).
- Actionable rows tint on hover (`hover:bg-(--t-bg-elevated)`, matching `PortRow`), take `cursor-pointer`, and show a focus ring so keyboard users see what mouse users see.
- The empty branch of the status slot now renders a dim `lucide:user-plus`, revealed with the row — it names the action instead of only hinting the row is live. It can never collide with `Has access` / `Invited` / the cap notice, which render only when the row is *not* actionable.
- Recent rows gain a reveal-on-hover forget button calling `forget(user_id)`. No confirmation — the entry is re-earned on the next invite and the removal already syncs like any other write to the store.
- Coarse pointers have no hover to reveal controls with, so under `@media (hover: none)` both reveals are simply always visible.
- The right-click menu stays as the power path; it is no longer the only path.

`canForget` is set only on Recent rows: a teammate or search hit is derived from the roster/server, so an X there would promise a deletion the store cannot make.

No store changes, no new i18n keys (the button reuses `terminal.share.forgetPerson`).

## Verification

- `PeopleTab`, `ShareMenu`, `ShareMenu.invitePeople`: 39/39 pass, including 4 new tests — forget drops the row from the store and the list, forget does not fire an invite, only Recent rows offer it, and a blocked row does not read as clickable.
- `tsc --noEmit` clean.
- Compiled this component's Tailwind in isolation to confirm every new variant actually generates, including the arbitrary `[@media(hover:none)]:opacity-100` and `focus-visible:outline-(--t-accent)`.

Not verified in the live app: the headless container bind-mounts the primary checkout, so a worktree branch does not hot-reload there. Happy to stand up a stack against this branch if a visual pass is wanted before merge.
