### PR TITLE
Sync the vault list, and stop hiding objects whose vault is unknown

### DIFF
--- a/src/components/layout/VaultSidebar.tsx
+++ b/src/components/layout/VaultSidebar.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useVaultStore } from "@/stores/vaultStore";
 import { useTeamStore } from "@/stores/teamStore";
+import { useOrphanVaultIds } from "@/hooks/useAccessibleVaultIds";
+import { unknownVaultLabel } from "@/hooks/accessibleVaults";
 import { useTeamVaultStateStore } from "@/stores/teamVaultStateStore";
 import { onVaultSelect } from "@/services/teamDataManager";
 import LogoBadge from "./LogoBadge";
@@ -32,6 +34,8 @@ export default function VaultSidebar() {
   const openSettings = useUIStore((s) => s.openSettings);
   const openCloudAuth = useUIStore((s) => s.openCloudAuth);
   const openWhatsNew = useUIStore((s) => s.openWhatsNew);
+
+  const orphanVaultIds = useOrphanVaultIds();
 
   const teams = useTeamStore((s) => s.teams);
   const pendingInvites = useTeamStore((s) => s.myPendingInvitations);
@@ -128,6 +132,24 @@ export default function VaultSidebar() {
                 }}
               />
               <TeamVaultBadge teamId={team.id} />
+            </div>
+          );
+        })}
+
+        {/* Unnamed vaults, kept visible so their hosts stay reachable */}
+        {orphanVaultIds.map((id) => {
+          const isActive = selectedVaultIds.includes(id) && !homeView;
+          return (
+            <div key={id} className="relative flex items-center justify-center w-full shrink-0">
+              <VaultButton
+                initial="?"
+                label={unknownVaultLabel(id)}
+                isActive={isActive}
+                onClick={() => {
+                  selectVaultOnly(id);
+                  setHomeView(false);
+                }}
+              />
             </div>
           );
         })}

--- a/src/components/mobile/sheets/VaultSwitcherSheet.tsx
+++ b/src/components/mobile/sheets/VaultSwitcherSheet.tsx
@@ -5,6 +5,8 @@ import BottomSheet from "./BottomSheet";
 import { useVaultStore } from "@/stores/vaultStore";
 import { useTeamStore } from "@/stores/teamStore";
 import { useMobileNavStore } from "@/stores/mobileNavStore";
+import { useOrphanVaultIds } from "@/hooks/useAccessibleVaultIds";
+import { unknownVaultLabel } from "@/hooks/accessibleVaults";
 
 export default function VaultSwitcherSheet() {
   const { t } = useTranslation();
@@ -14,6 +16,7 @@ export default function VaultSwitcherSheet() {
   const selectVaultOnly = useVaultStore((s) => s.selectVaultOnly);
   const addVault = useVaultStore((s) => s.addVault);
   const closeSheet = useMobileNavStore((s) => s.closeSheet);
+  const orphanVaultIds = useOrphanVaultIds();
   const [creating, setCreating] = useState(false);
   const [name, setName] = useState("");
 
@@ -22,6 +25,11 @@ export default function VaultSwitcherSheet() {
   const entries = [
     ...vaults.map((v) => ({ id: v.id, name: v.name, icon: "lucide:vault" })),
     ...teams.filter((team) => !linkedTeamIds.has(team.id)).map((team) => ({ id: team.id, name: team.name, icon: "lucide:users-round" })),
+    ...orphanVaultIds.map((id) => ({
+      id,
+      name: unknownVaultLabel(id),
+      icon: "lucide:circle-help",
+    })),
   ];
 
   const create = () => {

--- a/src/hooks/accessibleVaults.test.ts
+++ b/src/hooks/accessibleVaults.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "vitest";
-import { deriveAccessibleVaultIds, deriveScopedVaultId } from "./accessibleVaults";
+import { describe, test, expect } from "vitest";
+import { deriveAccessibleVaultIds, deriveScopedVaultId, deriveOrphanVaultIds } from "./accessibleVaults";
 import type { Vault } from "@/stores/vaultStore";
 import type { Team } from "@/stores/teamStore";
 
@@ -56,6 +56,53 @@ test("an unknown id that is neither a vault nor a loaded team is dropped", () =>
   expect(
     deriveAccessibleVaultIds({ selectedVaultIds: ["ghost"], vaults: [], teams: [], cloudActive: true }),
   ).toEqual([]);
+});
+
+test("an unknown id is kept once it is known to be an orphan vault", () => {
+  expect(
+    deriveAccessibleVaultIds({
+      selectedVaultIds: ["ghost"],
+      vaults: [],
+      teams: [],
+      cloudActive: true,
+      orphanVaultIds: ["ghost"],
+    }),
+  ).toEqual(["ghost"]);
+});
+
+test("an orphan id keeps its place among the vaults around it", () => {
+  expect(
+    deriveAccessibleVaultIds({
+      selectedVaultIds: ["personal", "ghost", "v1"],
+      vaults: [localVault("v1")],
+      teams: [],
+      cloudActive: true,
+      orphanVaultIds: ["ghost"],
+    }),
+  ).toEqual(["personal", "ghost", "v1"]);
+});
+
+describe("deriveOrphanVaultIds", () => {
+  const input = (objectVaultIds: (string | undefined)[], vaults: Vault[] = [], teams: Team[] = []) =>
+    deriveOrphanVaultIds({ objectVaultIds, vaults, teams });
+
+  test("a vault id carried by an object but held by no local vault is an orphan", () => {
+    expect(input(["ghost"])).toEqual(["ghost"]);
+  });
+
+  test("personal, known vaults, their team ids, and loaded teams are all not orphans", () => {
+    expect(
+      input(
+        ["personal", "v1", "t1", "t2", undefined],
+        [localVault("v1"), teamVault("v2", "t1")],
+        [team("t2")],
+      ),
+    ).toEqual([]);
+  });
+
+  test("repeated ids collapse to one, in a stable order", () => {
+    expect(input(["b", "a", "b"])).toEqual(["a", "b"]);
+  });
 });
 
 test("a standalone server team UUID (not backed by a local vault) is kept when the team is loaded", () => {

--- a/src/hooks/accessibleVaults.ts
+++ b/src/hooks/accessibleVaults.ts
@@ -1,3 +1,4 @@
+import i18n from "@/i18n";
 import type { Vault } from "@/stores/vaultStore";
 import type { Team } from "@/stores/teamStore";
 
@@ -6,6 +7,8 @@ interface DeriveAccessibleVaultIdsInput {
   vaults: Vault[];
   teams: Team[];
   cloudActive: boolean;
+  /** See `deriveOrphanVaultIds`. */
+  orphanVaultIds?: string[];
 }
 
 export function deriveAccessibleVaultIds({
@@ -13,8 +16,10 @@ export function deriveAccessibleVaultIds({
   vaults,
   teams,
   cloudActive,
+  orphanVaultIds = [],
 }: DeriveAccessibleVaultIdsInput): string[] {
   const loadedTeamIds = new Set(teams.map((t) => t.id));
+  const orphanIds = new Set(orphanVaultIds);
   const result: string[] = [];
 
   for (const vid of selectedVaultIds) {
@@ -25,12 +30,43 @@ export function deriveAccessibleVaultIds({
         result.push(vid);
         if (vault.teamId && (cloudActive || loadedTeamIds.has(vault.teamId))) result.push(vault.teamId);
       }
-    } else if (loadedTeamIds.has(vid)) {
+    } else if (loadedTeamIds.has(vid) || orphanIds.has(vid)) {
       result.push(vid);
     }
   }
 
   return result;
+}
+
+interface DeriveOrphanVaultIdsInput {
+  objectVaultIds: (string | undefined)[];
+  vaults: Vault[];
+  teams: Team[];
+}
+
+/**
+ * Vault ids objects are filed under that nothing local can name. Surfacing them
+ * under a placeholder keeps a vault the device never received from hiding every
+ * host inside it. A team vault whose team has not loaded yet looks like an
+ * orphan until it does — a better wrong answer than a hidden host.
+ */
+export function deriveOrphanVaultIds({
+  objectVaultIds,
+  vaults,
+  teams,
+}: DeriveOrphanVaultIdsInput): string[] {
+  const known = new Set<string>(["personal"]);
+  for (const vault of vaults) {
+    known.add(vault.id);
+    if (vault.teamId) known.add(vault.teamId);
+  }
+  for (const team of teams) known.add(team.id);
+
+  const orphans = new Set<string>();
+  for (const id of objectVaultIds) {
+    if (id && !known.has(id)) orphans.add(id);
+  }
+  return [...orphans].sort();
 }
 
 interface DeriveScopedVaultIdInput {
@@ -58,4 +94,8 @@ export function deriveScopedVaultId({
   const selected = selectedVaultIds[0];
   const canonical = vaults.find((v) => v.id === selected)?.teamId ?? selected;
   return accessibleVaultIds.includes(canonical) ? canonical : null;
+}
+
+export function unknownVaultLabel(id: string): string {
+  return i18n.t("layout.vaultSidebar.unknownVaultLabel", { id: id.slice(0, 8) });
 }

--- a/src/hooks/useAccessibleVaultIds.ts
+++ b/src/hooks/useAccessibleVaultIds.ts
@@ -1,8 +1,36 @@
 import { useMemo, useEffect, useState } from "react";
 import { useVaultStore } from "@/stores/vaultStore";
 import { useTeamStore } from "@/stores/teamStore";
+import { useConnectionStore } from "@/stores/connectionStore";
+import { useFolderStore } from "@/stores/folderStore";
+import { useKeyStore } from "@/stores/keyStore";
+import { useIdentityStore } from "@/stores/identityStore";
+import { useSnippetStore } from "@/stores/snippetStore";
 import { getSyncState, onSyncStateChange } from "@/services/sync";
-import { deriveAccessibleVaultIds, deriveScopedVaultId } from "@/hooks/accessibleVaults";
+import { deriveAccessibleVaultIds, deriveOrphanVaultIds, deriveScopedVaultId } from "@/hooks/accessibleVaults";
+
+/** See `deriveOrphanVaultIds`. */
+export function useOrphanVaultIds(): string[] {
+  const vaults = useVaultStore((s) => s.vaults);
+  const teams = useTeamStore((s) => s.teams);
+  const connections = useConnectionStore((s) => s.connections);
+  const folders = useFolderStore((s) => s.folders);
+  const keys = useKeyStore((s) => s.keys);
+  const identities = useIdentityStore((s) => s.identities);
+  const snippets = useSnippetStore((s) => s.snippets);
+
+  return useMemo(() => deriveOrphanVaultIds({
+    objectVaultIds: [
+      ...connections.map((o) => o.vault_id),
+      ...folders.map((o) => o.vault_id),
+      ...keys.map((o) => o.vault_id),
+      ...identities.map((o) => o.vault_id),
+      ...snippets.map((o) => o.vault_id),
+    ],
+    vaults,
+    teams,
+  }), [connections, folders, keys, identities, snippets, vaults, teams]);
+}
 
 /**
  * Returns the subset of selectedVaultIds that are currently accessible.
@@ -18,6 +46,7 @@ export function useAccessibleVaultIds(): string[] {
   const selectedVaultIds = useVaultStore((s) => s.selectedVaultIds);
   const vaults = useVaultStore((s) => s.vaults);
   const teams = useTeamStore((s) => s.teams);
+  const orphanVaultIds = useOrphanVaultIds();
   const [cloudActive, setCloudActive] = useState(() => getSyncState().cloudActive);
 
   useEffect(() => {
@@ -29,7 +58,8 @@ export function useAccessibleVaultIds(): string[] {
     vaults,
     teams,
     cloudActive,
-  }), [selectedVaultIds, vaults, teams, cloudActive]);
+    orphanVaultIds,
+  }), [selectedVaultIds, vaults, teams, cloudActive, orphanVaultIds]);
 }
 
 /**

--- a/src/i18n/locales/en/importExport.json
+++ b/src/i18n/locales/en/importExport.json
@@ -108,7 +108,8 @@
         "uiPreferences": { "label": "UI Preferences" },
         "shortcuts": { "label": "Shortcuts" },
         "appSettings": { "label": "App Settings" },
-        "recentPeople": { "label": "Recent People" }
+        "recentPeople": { "label": "Recent People" },
+        "vaults": { "label": "Vaults" }
       },
       "describe": {
         "themes_one": "{{count}} custom theme",
@@ -120,7 +121,9 @@
         "appSettingsShell": "shell: {{shell}}",
         "appSettingsDefault": "Default settings",
         "recentPeople_one": "{{count}} recent person",
-        "recentPeople_other": "{{count}} recent people"
+        "recentPeople_other": "{{count}} recent people",
+        "vaults_one": "{{count}} vault",
+        "vaults_other": "{{count}} vaults"
       }
     }
   }

--- a/src/i18n/locales/en/layout.json
+++ b/src/i18n/locales/en/layout.json
@@ -199,6 +199,7 @@
     },
     "vaultSidebar": {
       "cloudVaultLabel": "{{name}} (Cloud vault)",
+      "unknownVaultLabel": "Unknown vault {{id}} — its name has not reached this device",
       "vaultInviteTitle": "Vault invite: {{name}}",
       "vaultInvitation": "Vault invitation",
       "inviterFallback": "Someone",

--- a/src/i18n/locales/fr/importExport.json
+++ b/src/i18n/locales/fr/importExport.json
@@ -108,7 +108,8 @@
         "uiPreferences": { "label": "Préférences d'interface" },
         "shortcuts": { "label": "Raccourcis" },
         "appSettings": { "label": "Paramètres de l'application" },
-        "recentPeople": { "label": "Personnes récentes" }
+        "recentPeople": { "label": "Personnes récentes" },
+        "vaults": { "label": "Coffres" }
       },
       "describe": {
         "themes_one": "{{count}} thème personnalisé",
@@ -120,7 +121,9 @@
         "appSettingsShell": "shell : {{shell}}",
         "appSettingsDefault": "Paramètres par défaut",
         "recentPeople_one": "{{count}} personne récente",
-        "recentPeople_other": "{{count}} personnes récentes"
+        "recentPeople_other": "{{count}} personnes récentes",
+        "vaults_one": "{{count}} coffre",
+        "vaults_other": "{{count}} coffres"
       }
     }
   }

--- a/src/i18n/locales/fr/layout.json
+++ b/src/i18n/locales/fr/layout.json
@@ -199,6 +199,7 @@
     },
     "vaultSidebar": {
       "cloudVaultLabel": "{{name}} (Coffre cloud)",
+      "unknownVaultLabel": "Coffre inconnu {{id}} — son nom n'est pas parvenu à cet appareil",
       "vaultInviteTitle": "Invitation au coffre : {{name}}",
       "vaultInvitation": "Invitation au coffre",
       "inviterFallback": "Quelqu'un",

--- a/src/i18n/locales/ru/importExport.json
+++ b/src/i18n/locales/ru/importExport.json
@@ -136,7 +136,8 @@
         "uiPreferences": { "label": "Настройки интерфейса" },
         "shortcuts": { "label": "Сочетания клавиш" },
         "appSettings": { "label": "Настройки приложения" },
-        "recentPeople": { "label": "Недавние люди" }
+        "recentPeople": { "label": "Недавние люди" },
+        "vaults": { "label": "Хранилища" }
       },
       "describe": {
         "themes_one": "{{count}} пользовательская тема",
@@ -154,7 +155,11 @@
         "recentPeople_one": "{{count}} недавний контакт",
         "recentPeople_few": "{{count}} недавних контакта",
         "recentPeople_many": "{{count}} недавних контактов",
-        "recentPeople_other": "{{count}} недавних контактов"
+        "recentPeople_other": "{{count}} недавних контактов",
+        "vaults_one": "{{count}} хранилище",
+        "vaults_few": "{{count}} хранилища",
+        "vaults_many": "{{count}} хранилищ",
+        "vaults_other": "{{count}} хранилищ"
       }
     }
   }

--- a/src/i18n/locales/ru/layout.json
+++ b/src/i18n/locales/ru/layout.json
@@ -201,6 +201,7 @@
     },
     "vaultSidebar": {
       "cloudVaultLabel": "{{name}} (облачное хранилище)",
+      "unknownVaultLabel": "Неизвестное хранилище {{id}} — его имя не дошло до этого устройства",
       "vaultInviteTitle": "Приглашение в хранилище: {{name}}",
       "vaultInvitation": "Приглашение в хранилище",
       "inviterFallback": "Кто-то",

--- a/src/i18n/locales/zh/importExport.json
+++ b/src/i18n/locales/zh/importExport.json
@@ -108,7 +108,8 @@
         "uiPreferences": { "label": "UI 偏好" },
         "shortcuts": { "label": "快捷键" },
         "appSettings": { "label": "应用设置" },
-        "recentPeople": { "label": "最近的联系人" }
+        "recentPeople": { "label": "最近的联系人" },
+        "vaults": { "label": "保险库" }
       },
       "describe": {
         "themes_one": "{{count}} 个自定义主题",
@@ -120,7 +121,9 @@
         "appSettingsShell": "shell: {{shell}}",
         "appSettingsDefault": "默认设置",
         "recentPeople_one": "{{count}} 位最近联系人",
-        "recentPeople_other": "{{count}} 位最近联系人"
+        "recentPeople_other": "{{count}} 位最近联系人",
+        "vaults_one": "{{count}} 个保险库",
+        "vaults_other": "{{count}} 个保险库"
       }
     }
   }

--- a/src/i18n/locales/zh/layout.json
+++ b/src/i18n/locales/zh/layout.json
@@ -199,6 +199,7 @@
     },
     "vaultSidebar": {
       "cloudVaultLabel": "{{name}} (云保险库)",
+      "unknownVaultLabel": "未知保险库 {{id}} — 其名称尚未同步到此设备",
       "vaultInviteTitle": "保险库邀请：{{name}}",
       "vaultInvitation": "保险库邀请",
       "inviterFallback": "某人",

--- a/src/services/user-data/handler.test.ts
+++ b/src/services/user-data/handler.test.ts
@@ -21,10 +21,14 @@ describe("lastWriteWins", () => {
 });
 
 describe("registered handlers", () => {
-  test("every handler merges last-write-wins", () => {
+  // `vaults` is a keyed map merged row by row; every other section is taken whole.
+  const CUSTOM_MERGE = ["vaults"];
+
+  test("every handler merges last-write-wins, bar the documented exceptions", () => {
     expect(USER_DATA_HANDLERS.length).toBeGreaterThan(0);
     for (const h of USER_DATA_HANDLERS) {
-      expect(h.merge, h.key).toBe(lastWriteWins);
+      if (CUSTOM_MERGE.includes(h.key)) expect(h.merge, h.key).not.toBe(lastWriteWins);
+      else expect(h.merge, h.key).toBe(lastWriteWins);
     }
   });
 });

--- a/src/services/user-data/handlers/vaults.test.ts
+++ b/src/services/user-data/handlers/vaults.test.ts
@@ -1,0 +1,167 @@
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import { vaultsHandler } from "./vaults";
+import {
+  isAliveVaultRow,
+  mergeVaultSections,
+  TOMBSTONE_TTL_MS,
+  type VaultsSection,
+} from "@/services/vaultSection";
+import { useVaultStore } from "@/stores/vaultStore";
+
+const scheduleSync = vi.fn();
+vi.mock("@/services/sync", () => ({ scheduleSync: () => scheduleSync() }));
+
+// Relative: a fixed date would eventually age past TOMBSTONE_TTL_MS and be pruned.
+const ago = (hours: number) => new Date(Date.now() - hours * 3600_000).toISOString();
+const T1 = ago(3);
+const T2 = ago(2);
+const T3 = ago(1);
+
+const row = (name: string, updatedAt: string, extra: Partial<VaultsSection[string]> = {}) =>
+  ({ name, updatedAt, ...extra });
+
+const merge = mergeVaultSections;
+
+beforeEach(() => {
+  scheduleSync.mockClear();
+  useVaultStore.setState({ vaults: [{ id: "personal", name: "Personal" }], deletedVaults: {}, selectedVaultIds: ["personal"] });
+});
+
+describe("mergeVaultSections", () => {
+  test("a vault present on only one side survives the merge", () => {
+    const { value, updated } = merge({ a: row("A", T1) }, { b: row("B", T1) });
+    expect(Object.keys(value).sort()).toEqual(["a", "b"]);
+    expect(updated).toBe(true);
+  });
+
+  test("concurrent creates on two devices both survive", () => {
+    const { value } = merge({ prod: row("Prod", T1) }, { staging: row("Staging", T2) });
+    expect(value.prod.name).toBe("Prod");
+    expect(value.staging.name).toBe("Staging");
+  });
+
+  test("the newer name wins for a vault both sides know", () => {
+    const { value, updated } = merge({ a: row("Old", T1) }, { a: row("New", T2) });
+    expect(value.a.name).toBe("New");
+    expect(updated).toBe(true);
+  });
+
+  test("an older remote name loses and reports no change", () => {
+    const { value, updated } = merge({ a: row("New", T2) }, { a: row("Old", T1) });
+    expect(value.a.name).toBe("New");
+    expect(updated).toBe(false);
+  });
+
+  test("equal timestamps keep local, like every other section", () => {
+    const { value, updated } = merge({ a: row("Local", T1) }, { a: row("Remote", T1) });
+    expect(value.a.name).toBe("Local");
+    expect(updated).toBe(false);
+  });
+
+  test("a tombstone is kept, not dropped, so the deletion keeps propagating", () => {
+    const { value } = merge({ a: row("A", T1) }, { a: row("A", T1, { deletedAt: T2 }) });
+    expect(value.a.deletedAt).toBe(T2);
+    expect(isAliveVaultRow(value.a)).toBe(false);
+  });
+
+  test("a deletion is not resurrected by the other device's live copy", () => {
+    const { value } = merge({ a: row("A", T1, { deletedAt: T2 }) }, { a: row("A", T1) });
+    expect(isAliveVaultRow(value.a)).toBe(false);
+  });
+
+  test("a rename newer than the delete revives the vault under the new name", () => {
+    const { value } = merge({ a: row("A", T1, { deletedAt: T2 }) }, { a: row("Renamed", T3) });
+    expect(isAliveVaultRow(value.a)).toBe(true);
+    expect(value.a.name).toBe("Renamed");
+  });
+
+  test("a delete newer than the rename wins", () => {
+    const { value } = merge({ a: row("Renamed", T1) }, { a: row("A", T1, { deletedAt: T2 }) });
+    expect(isAliveVaultRow(value.a)).toBe(false);
+  });
+
+  test("teamId travels with the newer row, and unlinking clears it", () => {
+    expect(merge({ a: row("A", T1) }, { a: row("A", T2, { teamId: "t1" }) }).value.a.teamId).toBe("t1");
+    expect(merge({ a: row("A", T1, { teamId: "t1" }) }, { a: row("A", T2) }).value.a.teamId).toBeUndefined();
+  });
+
+  test("a missing or malformed side is treated as empty rather than throwing", () => {
+    expect(merge(undefined, { a: row("A", T1) }).value.a.name).toBe("A");
+    expect(merge({ a: row("A", T1) }, undefined).updated).toBe(false);
+    expect(merge({}, { a: { name: "A" } }).value.a).toBeUndefined();
+  });
+});
+
+describe("vaultsHandler export/import", () => {
+  test("exports user-created vaults and omits the built-in personal one", () => {
+    useVaultStore.getState().addVault("Prod");
+    const section = vaultsHandler.export() as VaultsSection;
+
+    expect(Object.keys(section)).toHaveLength(1);
+    expect(Object.values(section)[0].name).toBe("Prod");
+    expect(section.personal).toBeUndefined();
+  });
+
+  test("exports a deleted vault as a tombstone", () => {
+    const vault = useVaultStore.getState().addVault("Gone");
+    useVaultStore.getState().removeVault(vault.id);
+
+    const section = vaultsHandler.export() as VaultsSection;
+    expect(section[vault.id].deletedAt).toBeTruthy();
+    expect(isAliveVaultRow(section[vault.id])).toBe(false);
+  });
+
+  test("importing a live row adds the vault and selects it, so its hosts are visible", async () => {
+    await vaultsHandler.import({ v1: row("From Device A", T1) } satisfies VaultsSection);
+
+    const state = useVaultStore.getState();
+    expect(state.vaults.map((v) => v.id)).toEqual(["personal", "v1"]);
+    expect(state.selectedVaultIds).toContain("v1");
+  });
+
+  test("importing a tombstone removes the vault and deselects it", async () => {
+    useVaultStore.setState({
+      vaults: [{ id: "personal", name: "Personal" }, { id: "v1", name: "Doomed", updatedAt: T1 }],
+      selectedVaultIds: ["personal", "v1"],
+    });
+
+    await vaultsHandler.import({ v1: row("Doomed", T1, { deletedAt: T2 }) } satisfies VaultsSection);
+
+    const state = useVaultStore.getState();
+    expect(state.vaults.map((v) => v.id)).toEqual(["personal"]);
+    expect(state.selectedVaultIds).toEqual(["personal"]);
+    expect(state.deletedVaults.v1.deletedAt).toBe(T2);
+  });
+
+  test("a vault the device already has is not re-selected after the user hid it", async () => {
+    useVaultStore.setState({
+      vaults: [{ id: "personal", name: "Personal" }, { id: "v1", name: "Prod", updatedAt: T1 }],
+      selectedVaultIds: ["personal"],
+    });
+
+    await vaultsHandler.import({ v1: row("Prod", T2) } satisfies VaultsSection);
+
+    expect(useVaultStore.getState().selectedVaultIds).toEqual(["personal"]);
+    expect(useVaultStore.getState().vaults.find((v) => v.id === "v1")?.name).toBe("Prod");
+  });
+
+  test("getTimestamp reports the newest row, tombstones included", () => {
+    useVaultStore.setState({
+      vaults: [{ id: "personal", name: "Personal" }, { id: "v1", name: "Prod", updatedAt: T1 }],
+      deletedVaults: { v2: row("Gone", T1, { deletedAt: T3 }) },
+    });
+
+    expect(vaultsHandler.getTimestamp()).toBe(T3);
+  });
+
+  test("getTimestamp is the epoch with nothing but the personal vault", () => {
+    expect(vaultsHandler.getTimestamp()).toBe(new Date(0).toISOString());
+  });
+
+  test("a tombstone past its TTL stops being exported", () => {
+    const stale = new Date(Date.now() - TOMBSTONE_TTL_MS - 1000).toISOString();
+    useVaultStore.setState({ deletedVaults: { old: row("Old", stale, { deletedAt: stale }) } });
+
+    expect(vaultsHandler.export()).toEqual({});
+  });
+});

--- a/src/services/user-data/handlers/vaults.ts
+++ b/src/services/user-data/handlers/vaults.ts
@@ -1,0 +1,43 @@
+import i18n from "@/i18n";
+import { useVaultStore } from "@/stores/vaultStore";
+import {
+  isAliveVaultRow,
+  mergeVaultSections,
+  newestVaultTimestamp,
+  parseVaultsSection,
+  vaultsSectionFrom,
+  type VaultsSection,
+} from "@/services/vaultSection";
+import type { UserDataHandler } from "../handler";
+
+function section(): VaultsSection {
+  const { vaults, deletedVaults } = useVaultStore.getState();
+  return vaultsSectionFrom(vaults, deletedVaults);
+}
+
+// The one section that does not merge `lastWriteWins` — see `services/vaultSection`.
+export const vaultsHandler: UserDataHandler = {
+  key: "vaults",
+  label: "Vaults",
+  icon: "lucide:vault",
+
+  export(): VaultsSection {
+    return section();
+  },
+
+  async import(data: unknown): Promise<void> {
+    useVaultStore.getState().applySyncedVaults(parseVaultsSection(data));
+  },
+
+  merge: (local, remote) => mergeVaultSections(local, remote),
+
+  getTimestamp(): string {
+    return newestVaultTimestamp(section());
+  },
+
+  describe(): string {
+    return i18n.t("importExport.userData.describe.vaults", {
+      count: Object.values(section()).filter(isAliveVaultRow).length,
+    });
+  },
+};

--- a/src/services/user-data/registry.ts
+++ b/src/services/user-data/registry.ts
@@ -6,6 +6,7 @@ import { uiPreferencesHandler } from "./handlers/uiPreferences";
 import { shortcutsHandler } from "./handlers/shortcuts";
 import { appSettingsHandler } from "./handlers/appSettings";
 import { recentPeopleHandler } from "./handlers/recentPeople";
+import { vaultsHandler } from "./handlers/vaults";
 
 // ─── Handler registry ─────────────────────────────────────────────────────────
 // Order matters for UI rendering. Adding a new settings domain:
@@ -18,6 +19,7 @@ export const USER_DATA_HANDLERS: UserDataHandler[] = [
   shortcutsHandler,
   appSettingsHandler,
   recentPeopleHandler,
+  vaultsHandler,
 ];
 
 // ─── Build ────────────────────────────────────────────────────────────────────

--- a/src/services/vaultSection.ts
+++ b/src/services/vaultSection.ts
@@ -1,0 +1,106 @@
+// A keyed map merged row by row: a list under last-write-wins would lose a vault
+// created on another device and revive one deleted there.
+
+import type { Vault } from "@/stores/vaultStore";
+
+export interface SyncedVault {
+  name: string;
+  teamId?: string;
+  updatedAt: string;
+  deletedAt?: string;
+}
+
+export type VaultsSection = Record<string, SyncedVault>;
+
+export const TOMBSTONE_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+const EPOCH = new Date(0).toISOString();
+
+export function isAliveVaultRow(row: SyncedVault): boolean {
+  return !row.deletedAt || row.updatedAt > row.deletedAt;
+}
+
+export function parseVaultsSection(value: unknown): VaultsSection {
+  if (!value || typeof value !== "object") return {};
+  const out: VaultsSection = {};
+  for (const [id, row] of Object.entries(value as Record<string, unknown>)) {
+    const r = row as Partial<SyncedVault>;
+    if (typeof r?.name !== "string" || typeof r?.updatedAt !== "string") continue;
+    out[id] = buildRow(r.name, r.updatedAt, r.teamId, r.deletedAt);
+  }
+  return out;
+}
+
+function buildRow(name: string, updatedAt: string, teamId?: string, deletedAt?: string): SyncedVault {
+  const row: SyncedVault = { name, updatedAt };
+  if (teamId) row.teamId = teamId;
+  if (deletedAt) row.deletedAt = deletedAt;
+  return row;
+}
+
+function sameRow(a: SyncedVault, b: SyncedVault): boolean {
+  return a.name === b.name && a.teamId === b.teamId
+    && a.updatedAt === b.updatedAt && a.deletedAt === b.deletedAt;
+}
+
+// Field-wise, like `crdt.ts`: `deletedAt` takes the later of the two so a device
+// that never saw the deletion cannot drop it. Equal timestamps keep local.
+function mergeRow(local: SyncedVault, remote: SyncedVault): SyncedVault {
+  const winner = remote.updatedAt > local.updatedAt ? remote : local;
+  const deletedAt = [local.deletedAt, remote.deletedAt].filter(Boolean).sort().pop();
+  return buildRow(winner.name, winner.updatedAt, winner.teamId, deletedAt);
+}
+
+export function mergeVaultSections(
+  local: unknown,
+  remote: unknown,
+): { value: VaultsSection; updated: boolean } {
+  const l = parseVaultsSection(local);
+  const r = parseVaultsSection(remote);
+  const value: VaultsSection = {};
+  let updated = false;
+
+  for (const id of new Set([...Object.keys(l), ...Object.keys(r)])) {
+    const localRow = l[id];
+    const remoteRow = r[id];
+    const merged = localRow && remoteRow ? mergeRow(localRow, remoteRow) : (localRow ?? remoteRow);
+    value[id] = merged;
+    if (!localRow || !sameRow(localRow, merged)) updated = true;
+  }
+
+  return { value, updated };
+}
+
+export function pruneVaultTombstones(section: VaultsSection, now: number = Date.now()): VaultsSection {
+  const out: VaultsSection = {};
+  for (const [id, row] of Object.entries(section)) {
+    if (row.deletedAt && !isAliveVaultRow(row) && now - Date.parse(row.deletedAt) > TOMBSTONE_TTL_MS) continue;
+    out[id] = row;
+  }
+  return out;
+}
+
+export function vaultsSectionFrom(vaults: Vault[], deletedVaults: VaultsSection): VaultsSection {
+  const section: VaultsSection = { ...deletedVaults };
+  for (const vault of vaults) {
+    if (vault.id === "personal") continue;
+    section[vault.id] = buildRow(vault.name, vault.updatedAt ?? EPOCH, vault.teamId);
+  }
+  return pruneVaultTombstones(section);
+}
+
+export function vaultRowToVault(id: string, row: SyncedVault): Vault {
+  const vault: Vault = { id, name: row.name, updatedAt: row.updatedAt };
+  if (row.teamId) vault.teamId = row.teamId;
+  return vault;
+}
+
+export function newestVaultTimestamp(section: VaultsSection): string {
+  let newest = EPOCH;
+  for (const row of Object.values(section)) {
+    for (const ts of [row.updatedAt, row.deletedAt]) {
+      if (ts && ts > newest) newest = ts;
+    }
+  }
+  return newest;
+}

--- a/src/stores/persistedAccountUiState.ts
+++ b/src/stores/persistedAccountUiState.ts
@@ -5,10 +5,11 @@ interface PersistedAccountStorage {
 }
 
 /**
- * Zustand stores whose persisted state belongs to one account. They are never
- * synced to the server, so switching accounts has to move them by hand: cleared
- * for the incoming account, and stashed for the outgoing one — dropping them
- * outright would hide every host filed under a user-created vault.
+ * Zustand stores whose persisted state belongs to one account. Their contents
+ * are not, by themselves, restored from the server, so switching accounts has to
+ * move them by hand: cleared for the incoming account, and stashed for the
+ * outgoing one — dropping them outright would hide every host filed under a
+ * user-created vault.
  *
  * A store belongs here when its contents name the account's own things — its
  * vaults, teams, hosts, teammates, sessions. Device preferences (UI scale,
@@ -16,6 +17,8 @@ interface PersistedAccountStorage {
  * the machine, not the person signed in on it.
  */
 export const ACCOUNT_SCOPED_STORAGE_KEYS = [
+  // The vault list rides the sync blob now, so parking it only spares the sidebar
+  // a pull's worth of emptiness — but `selectedVaultIds` has no other way home.
   "voltius-vaults",
   "voltius-teams",
   // Teammates this account invited, by handle.

--- a/src/stores/vaultStore.ts
+++ b/src/stores/vaultStore.ts
@@ -1,17 +1,28 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { pushSettingsChange, settingsStamp } from "./remoteApplyGuard";
+import {
+  isAliveVaultRow,
+  pruneVaultTombstones,
+  vaultRowToVault,
+  type VaultsSection,
+} from "@/services/vaultSection";
 
 export interface Vault {
   id: string;
   name: string;
   /** Cloud team ID backing this vault, set when user first enables sharing. */
   teamId?: string;
+  /** Clock for the `vaults` sync section. Absent on pre-sync entries, which date at the epoch. */
+  updatedAt?: string;
 }
 
 const PERSONAL_VAULT: Vault = { id: "personal", name: "Personal" };
 
 interface VaultStore {
   vaults: Vault[];
+  /** Tombstones, kept so a deletion reaches other devices. */
+  deletedVaults: VaultsSection;
   selectedVaultIds: string[];
   toggleVault: (id: string) => void;
   selectVaultOnly: (id: string) => void;
@@ -20,12 +31,14 @@ interface VaultStore {
   renameVault: (id: string, name: string) => void;
   removeVault: (id: string) => void;
   setVaultTeamId: (vaultId: string, teamId: string | null) => void;
+  applySyncedVaults: (section: VaultsSection) => void;
 }
 
 export const useVaultStore = create<VaultStore>()(
   persist(
     (set, get) => ({
       vaults: [PERSONAL_VAULT],
+      deletedVaults: {},
       selectedVaultIds: ["personal"],
       toggleVault: (id) =>
         set((s) => ({
@@ -36,41 +49,82 @@ export const useVaultStore = create<VaultStore>()(
       selectVaultOnly: (id) => set({ selectedVaultIds: [id] }),
       isSelected: (id) => get().selectedVaultIds.includes(id),
       addVault: (name) => {
-        const vault: Vault = { id: crypto.randomUUID(), name };
+        const vault: Vault = { id: crypto.randomUUID(), name, updatedAt: settingsStamp() };
         set((s) => ({ vaults: [...s.vaults, vault] }));
+        pushSettingsChange();
         return vault;
       },
-      renameVault: (id, name) =>
+      renameVault: (id, name) => {
         set((s) => ({
-          vaults: s.vaults.map((v) => v.id === id ? { ...v, name } : v),
-        })),
+          vaults: s.vaults.map((v) => v.id === id ? { ...v, name, updatedAt: settingsStamp() } : v),
+        }));
+        pushSettingsChange();
+      },
       removeVault: (id) => {
         if (id === "personal") return;
-        set((s) => ({
-          vaults: s.vaults.filter((v) => v.id !== id),
-          selectedVaultIds: s.selectedVaultIds.filter((v) => v !== id),
-        }));
+        set((s) => {
+          const gone = s.vaults.find((v) => v.id === id);
+          const deletedAt = settingsStamp();
+          return {
+            vaults: s.vaults.filter((v) => v.id !== id),
+            selectedVaultIds: s.selectedVaultIds.filter((v) => v !== id),
+            deletedVaults: gone
+              ? { ...s.deletedVaults, [id]: { name: gone.name, updatedAt: gone.updatedAt ?? deletedAt, deletedAt } }
+              : s.deletedVaults,
+          };
+        });
+        pushSettingsChange();
       },
-      setVaultTeamId: (vaultId, teamId) =>
+      setVaultTeamId: (vaultId, teamId) => {
         set((s) => ({
           vaults: s.vaults.map((v) => {
             if (v.id !== vaultId) return v;
-            if (teamId === null) { const { teamId: _, ...rest } = v; return rest; }
-            return { ...v, teamId };
+            const updatedAt = settingsStamp();
+            if (teamId === null) { const { teamId: _, ...rest } = v; return { ...rest, updatedAt }; }
+            return { ...v, teamId, updatedAt };
           }),
-        })),
+        }));
+        pushSettingsChange();
+      },
+      // Rows carry their own clocks, so nothing is stamped here. A vault arriving
+      // for the first time is also selected: `selectedVaultIds` is device-local and
+      // holds only "personal" on a device that has never seen the vault, so syncing
+      // it unselected would leave its hosts just as invisible.
+      applySyncedVaults: (section) => {
+        set((s) => {
+          const rows = Object.entries(pruneVaultTombstones(section));
+          const alive = rows.filter(([, row]) => isAliveVaultRow(row));
+          const dead = rows.filter(([, row]) => !isAliveVaultRow(row));
+          const deadIds = new Set(dead.map(([id]) => id));
+          const known = new Set(s.vaults.map((v) => v.id));
+
+          const selectedVaultIds = s.selectedVaultIds.filter((id) => !deadIds.has(id));
+          for (const [id] of alive) {
+            if (!known.has(id) && !selectedVaultIds.includes(id)) selectedVaultIds.push(id);
+          }
+
+          return {
+            vaults: [PERSONAL_VAULT, ...alive.map(([id, row]) => vaultRowToVault(id, row))],
+            deletedVaults: Object.fromEntries(dead),
+            selectedVaultIds,
+          };
+        });
+        pushSettingsChange();
+      },
     }),
     {
       name: "voltius-vaults",
       partialize: (state) => ({
         vaults: state.vaults.filter((v) => v.id !== "personal"),
+        deletedVaults: state.deletedVaults,
         selectedVaultIds: state.selectedVaultIds,
       }),
       merge: (persisted, current) => {
-        const p = persisted as { vaults?: Vault[]; selectedVaultIds?: string[] };
+        const p = persisted as { vaults?: Vault[]; deletedVaults?: VaultsSection; selectedVaultIds?: string[] };
         return {
           ...current,
           vaults: [PERSONAL_VAULT, ...(p.vaults ?? [])],
+          deletedVaults: p.deletedVaults ?? {},
           selectedVaultIds: p.selectedVaultIds ?? current.selectedVaultIds,
         };
       },


### PR DESCRIPTION
The list of user-created vaults existed only in `localStorage`. Everything filed inside those vaults syncs — connections, folders, keys, identities and snippets all carry a `vault_id` — but the UI filters them against the local vault list. On a fresh install, after a machine reset, or after a sign-out and back in, the objects arrived from the cloud and rendered nowhere. Since a vault cannot be recreated under its old UUID, the hosts could not be recovered by hand.

Account switching (#127/#128/#129) had to work around this by parking `voltius-vaults` on the outgoing account's saved entry.

## What changed

A `vaults` section in the user-data sync bundle, carried inside the existing encrypted blob — vault names are user data and never touch a plaintext server field.

It is the one section that is a keyed map merged row by row rather than a value merged whole. A list under last-write-wins loses a vault created on another device and revives one deleted there, and either failure takes every host filed inside it out of view. Each row carries its own clock and an optional `deletedAt`, reusing the liveness rule from `crdt.ts`. Tombstones are kept for 90 days.

Per-row clocks also make the section clock harmless: `registry.ts` stamps a merged section with the remote timestamp whenever anything changed, which would otherwise date a locally-newer row backwards and lose it on the next exchange. The section timestamp is derived from the newest row, so there is no separate timestamp store to reset on an account switch.

Applying a section adjusts the selection too. `selectedVaultIds` stays device-local, and a device that has never seen a vault holds only `personal` — syncing the vault without selecting it would leave its hosts just as invisible. Vaults the device already knows keep the selection the user gave them.

`voltius-vaults` stays in `ACCOUNT_SCOPED_STORAGE_KEYS`: it still holds `selectedVaultIds`, which has no other way home, and parking it spares the switcher an empty sidebar while a pull runs. The guard test needed no change.

Second commit: vault ids that objects carry but nothing local can name are now surfaced as placeholder vaults in the sidebar and the mobile switcher, instead of being filtered away. Syncing the list closes most of the gap, but only for devices and versions that have it; a placeholder turns whatever remains into data that is misfiled rather than gone.

## Behaviour change worth knowing about

Deleting a vault has never reassigned its contents, so objects orphaned by a deletion made long before this change become visible again under a placeholder. Showing them is the intent — the user can then move or delete them — but it is visible on upgrade.

A team vault whose team has not loaded yet reads as a placeholder until it does.

## Verification

Unit: handler export/import/merge including tombstone-does-not-resurrect, concurrent creates on two devices, rename-beats-older-delete and delete-beats-older-rename, derived timestamp, TTL pruning; `deriveAccessibleVaultIds` with an unknown id; `deriveOrphanVaultIds`. `handler.test.ts` now lists `vaults` as the documented exception to the all-handlers-are-`lastWriteWins` invariant.

Live, two app instances against an isolated server:

- vault + host created on A appeared by name on B, host inside;
- deleting on A removed it on B and it did not come back over several sync cycles;
- the host stayed reachable under the placeholder on both devices.

Full suite 3481/3482; the one failure (`StackList.test.tsx`, plus a `folderTree.test.ts` worker timeout) is the known parallel-load flake and passes in isolation. `tsc --noEmit` clean.
