### PR TITLE
fix(vaults): float the members popover and trust our own presence

### DIFF
--- a/src/components/layout/VaultHeader.tsx
+++ b/src/components/layout/VaultHeader.tsx
@@ -10,6 +10,7 @@ import { useTeamStore } from "@/stores/teamStore";
 import type { TeamMember, TeamRole } from "@/services/teamService";
 import { StatusDot } from "@/components/shared/StatusDot";
 import { MiniAvatar, avatarColor } from "@/components/shared/AvatarStack";
+import { PickerSurface } from "@/components/shared/PickerSurface";
 import { getSyncState, onSyncStateChange } from "@/services/sync";
 import { getAccountMode } from "@/services/account";
 
@@ -30,9 +31,26 @@ function OnlineMembersStack({ members, roles, onInviteClick }: { members: TeamMe
   const [hovered, setHovered] = useState(false);
   const [invHovered, setInvHovered] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const closeTimer = useRef<number | null>(null);
   const visible = members.slice(0, MAX_STACK);
   const overflow = members.length - MAX_STACK;
   const onlineCount = members.filter((m) => m.is_online).length;
+
+  // The popover is portalled out of the header, so moving the pointer into it
+  // fires the stack's mouseleave. Defer the close so the popover's own
+  // mouseenter can cancel it.
+  const openPopover = () => {
+    if (closeTimer.current !== null) window.clearTimeout(closeTimer.current);
+    closeTimer.current = null;
+    setHovered(true);
+  };
+  const closePopover = () => {
+    if (closeTimer.current !== null) window.clearTimeout(closeTimer.current);
+    closeTimer.current = window.setTimeout(() => setHovered(false), 120);
+  };
+  useEffect(() => () => {
+    if (closeTimer.current !== null) window.clearTimeout(closeTimer.current);
+  }, []);
 
   return (
     <div className="flex items-center gap-2 shrink-0">
@@ -41,8 +59,8 @@ function OnlineMembersStack({ members, roles, onInviteClick }: { members: TeamMe
         <div
           ref={ref}
           className="relative flex items-center cursor-default"
-          onMouseEnter={() => setHovered(true)}
-          onMouseLeave={() => setHovered(false)}
+          onMouseEnter={openPopover}
+          onMouseLeave={closePopover}
         >
           {visible.map((m, i) => (
             <div
@@ -80,12 +98,18 @@ function OnlineMembersStack({ members, roles, onInviteClick }: { members: TeamMe
             </div>
           )}
 
-          {/* Hover popover */}
-          {hovered && (
-            <div
-              className="surface-float absolute top-full mt-2 left-0 z-50 overflow-hidden"
-              style={{ minWidth: 190 }}
-            >
+          {/* Hover popover — portalled: the page overlay in MainPanel outranks the
+              header's stacking context, so an in-flow popover paints under it. */}
+          <PickerSurface
+            open={hovered}
+            onClose={() => setHovered(false)}
+            anchorRef={ref}
+            width={220}
+            align="right"
+            gap={0}
+            title={t("layout.vaultHeader.members")}
+          >
+            <div onMouseEnter={openPopover} onMouseLeave={closePopover}>
               <div className="px-3 py-2" style={{ borderBottom: "1px solid var(--t-border)" }}>
                 <span className="text-[10px] font-bold uppercase tracking-widest" style={{ color: "var(--t-text-dim)" }}>
                   {onlineCount > 0 ? t("layout.vaultHeader.onlineCount", { count: onlineCount }) : t("layout.vaultHeader.noOneOnline")}
@@ -124,7 +148,7 @@ function OnlineMembersStack({ members, roles, onInviteClick }: { members: TeamMe
                 );
               })}
             </div>
-          )}
+          </PickerSurface>
         </div>
       )}
 

--- a/src/components/shared/PickerSurface.tsx
+++ b/src/components/shared/PickerSurface.tsx
@@ -13,7 +13,7 @@ type AnchorRef = { readonly current: HTMLElement | null };
  *  `anchorRef` (with below/above flip). Mobile: a BottomSheet. Open state + the trigger
  *  stay owned by the caller; this owns only the open surface + its dismiss. */
 export function PickerSurface({
-  open, onClose, anchorRef, title, children, width,
+  open, onClose, anchorRef, title, children, width, align = "left", gap = 4,
 }: {
   open: boolean;
   onClose: () => void;
@@ -21,6 +21,12 @@ export function PickerSurface({
   title?: string;
   children: ReactNode;
   width?: number;
+  /** Which anchor edge the surface lines up with. Right-align keeps a surface wider
+   *  than its anchor on screen when the anchor sits near the right edge. */
+  align?: "left" | "right";
+  /** Vertical distance between anchor and surface. 0 keeps them touching, so a
+   *  hover-opened surface has no gap for the pointer to fall through. */
+  gap?: number;
 }) {
   const isAndroid = useIsAndroid();
   const surfaceRef = useRef<HTMLDivElement>(null);
@@ -35,12 +41,13 @@ export function PickerSurface({
       if (!el) return;
       const r = el.getBoundingClientRect();
       const w = width ?? r.width;
+      const left = align === "right" ? Math.max(8, r.right - w) : r.left;
       const spaceBelow = window.innerHeight - r.bottom - 8;
       const spaceAbove = r.top - 8;
       const goUp = spaceBelow < 150 && spaceAbove > spaceBelow;
       setPos(goUp
-        ? { bottom: window.innerHeight - r.top + 4, left: r.left, width: w, maxHeight: Math.min(spaceAbove, 320) }
-        : { top: r.bottom + 4, left: r.left, width: w, maxHeight: Math.min(spaceBelow, 320) });
+        ? { bottom: window.innerHeight - r.top + gap, left, width: w, maxHeight: Math.min(spaceAbove, 320) }
+        : { top: r.bottom + gap, left, width: w, maxHeight: Math.min(spaceBelow, 320) });
     };
     measure();
     window.addEventListener("scroll", measure, true); // capture: catch scrolls in any ancestor
@@ -49,7 +56,7 @@ export function PickerSurface({
       window.removeEventListener("scroll", measure, true);
       window.removeEventListener("resize", measure);
     };
-  }, [open, isAndroid, anchorRef, width]);
+  }, [open, isAndroid, anchorRef, width, align, gap]);
 
   // Desktop: outside-mousedown dismiss (ignores the anchor so the trigger toggles cleanly).
   useEffect(() => {

--- a/src/i18n/locales/en/layout.json
+++ b/src/i18n/locales/en/layout.json
@@ -181,6 +181,7 @@
       }
     },
     "vaultHeader": {
+      "members": "Members",
       "teamBadge": "team",
       "memberCount_one": "{{count}} member",
       "memberCount_other": "{{count}} members",

--- a/src/i18n/locales/fr/layout.json
+++ b/src/i18n/locales/fr/layout.json
@@ -181,6 +181,7 @@
       }
     },
     "vaultHeader": {
+      "members": "Membres",
       "teamBadge": "équipe",
       "memberCount_one": "{{count}} membre",
       "memberCount_other": "{{count}} membres",

--- a/src/i18n/locales/ru/layout.json
+++ b/src/i18n/locales/ru/layout.json
@@ -181,6 +181,7 @@
       }
     },
     "vaultHeader": {
+      "members": "Участники",
       "teamBadge": "команда",
       "memberCount_one": "{{count}} участник",
       "memberCount_few": "{{count}} участника",

--- a/src/i18n/locales/zh/layout.json
+++ b/src/i18n/locales/zh/layout.json
@@ -181,6 +181,7 @@
       }
     },
     "vaultHeader": {
+      "members": "成员",
       "teamBadge": "团队",
       "memberCount_one": "{{count}} 名成员",
       "memberCount_other": "{{count}} 名成员",

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -904,6 +904,7 @@ async function _sseConnect(signal: AbortSignal): Promise<void> {
 
   _cloudActive = true;
   _listeners.forEach((fn) => fn());
+  setMyPresence(true);
 
   // Sync immediately on (re)connect to catch any events missed while offline
   syncNow().catch(() => {});
@@ -951,5 +952,17 @@ async function _sseConnect(signal: AbortSignal): Promise<void> {
   } finally {
     _cloudActive = false;
     _listeners.forEach((fn) => fn());
+    setMyPresence(false);
   }
+}
+
+/** Presence events only carry other members — the server never tells us about
+ *  ourselves. Mirror our own stream state into any loaded members list so our
+ *  row doesn't sit on whatever the server's presence map held at fetch time. */
+function setMyPresence(online: boolean): void {
+  void (async () => {
+    const { getMyUserId } = await import("@/services/teamService");
+    const myUserId = await getMyUserId();
+    if (myUserId) useTeamStore.getState().setSelfOnline(myUserId, online);
+  })().catch(() => {});
 }

--- a/src/stores/teamStore.test.ts
+++ b/src/stores/teamStore.test.ts
@@ -29,7 +29,7 @@ beforeEach(() => {
   tauri.invoke.mockReset();
   useTeamStore.setState({
     teams: [], membersByTeam: {}, rolesByTeam: {}, pendingInvitationsByTeam: {},
-    myPendingInvitations: [], activeTeamId: null, loading: false,
+    myPendingInvitations: [], activeTeamId: null, loading: false, self: null,
   });
 });
 
@@ -65,6 +65,19 @@ test("loadMembers / loadRoles store by team id", async () => {
   await get().loadRoles("t1");
   expect(get().membersByTeam.t1.map((m) => m.user_id)).toEqual(["u1"]);
   expect(get().rolesByTeam.t1.map((r) => r.id)).toEqual(["r1"]);
+});
+
+test("loadMembers keeps our own presence from the stream, not the server payload", async () => {
+  get().setSelfOnline("me", true);
+  api.listMembers.mockResolvedValue([
+    { ...member("me"), is_online: false },
+    { ...member("u1"), is_online: false },
+  ]);
+  await get().loadMembers("t1");
+  expect(get().membersByTeam.t1.map((m) => m.is_online)).toEqual([true, false]);
+
+  get().setSelfOnline("me", false);
+  expect(get().membersByTeam.t1[0].is_online).toBe(false);
 });
 
 test("createRole appends to the team's roles", async () => {

--- a/src/stores/teamStore.ts
+++ b/src/stores/teamStore.ts
@@ -13,6 +13,9 @@ interface TeamStore {
   myPendingInvitations: MyPendingInvitation[];
   activeTeamId: string | null;
   loading: boolean;
+  /** Our own presence, owned by the realtime layer rather than the server's
+   *  members payload — see `setSelfOnline`. Null until the stream first opens. */
+  self: { userId: string; online: boolean } | null;
 
   loadTeams: () => Promise<void>;
   createTeam: (name: string) => Promise<Team>;
@@ -23,6 +26,7 @@ interface TeamStore {
   setActiveTeam: (teamId: string | null) => void;
   getActiveMembers: () => TeamMember[];
   setMemberOnline: (userId: string, online: boolean) => void;
+  setSelfOnline: (userId: string, online: boolean) => void;
   loadPendingInvitations: (teamId: string) => Promise<void>;
   loadMyPendingInvitations: () => Promise<void>;
   removeTeam: (teamId: string) => void;
@@ -86,6 +90,7 @@ export const useTeamStore = create<TeamStore>()(
   myPendingInvitations: [],
   activeTeamId: null,
   loading: false,
+  self: null,
 
   loadTeams: async () => {
     set({ loading: true });
@@ -117,7 +122,15 @@ export const useTeamStore = create<TeamStore>()(
 
   loadMembers: async (teamId) => {
     const members = await api.listMembers(teamId);
-    set((s) => ({ membersByTeam: { ...s.membersByTeam, [teamId]: members } }));
+    // The server derives is_online from its presence map, which only gains our
+    // entry once it handles our SSE stream. On a fresh vault this fetch can win
+    // that race and report us offline forever (nothing refetches). Our own
+    // stream state is the better answer for our own row.
+    const self = get().self;
+    const withSelf = self
+      ? members.map((m) => (m.user_id === self.userId ? { ...m, is_online: self.online } : m))
+      : members;
+    set((s) => ({ membersByTeam: { ...s.membersByTeam, [teamId]: withSelf } }));
   },
 
   addMember: async (teamId, email, role) => {
@@ -166,6 +179,11 @@ export const useTeamStore = create<TeamStore>()(
         pendingInvitationsByTeam,
       };
     });
+  },
+
+  setSelfOnline: (userId, online) => {
+    set({ self: { userId, online } });
+    get().setMemberOnline(userId, online);
   },
 
   setMemberOnline: (userId, online) =>


### PR DESCRIPTION
Two bugs reported against the members hover popover in `VaultHeader`.

## 1. Popover painted under the page toolbar

Not a z-index shortfall on the popover. `DesktopShell` wraps `VaultHeader` + `NavBar` in `relative z-10`, and `MainPanel` renders page overlays as `absolute z-20` (SFTP at `z-30`) in that *same* stacking context — so no z-index on an in-flow child of the header can outrank them.

The popover now goes through `PickerSurface`, which portals to the body as a fixed float. `PickerSurface` gained two props for this: `align="left"|"right"` (the surface is wider than its anchor, which sits at the window's right edge) and `gap` (0 keeps anchor and surface touching). Because the surface leaves the anchor's DOM subtree, the close is deferred 120 ms so the pointer can travel into it.

## 2. Own row showed offline on a fresh vault

The server derives `is_online` from the in-memory presence map its SSE handler fills. A members fetch issued moments after the stream opens — the fresh-vault case — can beat that insert and report us offline, and nothing refetches: presence events never carry the subscriber themselves, so the stale `false` survives until an app restart.

The realtime layer now records our own presence on stream open/close, and `loadMembers` applies it over the server's value for our own row. No server change.

## Verification

- `tsc --noEmit` clean; `teamStore.test.ts` 12/12, including a new test that `loadMembers` keeps our own presence from the stream rather than the payload.
- Popover verified live in the headless dev build: portalled surface reports `position: fixed`, `z-index: 9999`, fully in-viewport, and `elementFromPoint` at its centre returns the popover. Re-inserting the same node in its old in-flow position (with ≥1 open session, so `MainPanel` uses its `z-20` overlay branch) reproduces the bug — `elementFromPoint` there returns the page's scroll container.
- The presence fix is covered by unit test only; proving it live needs two real accounts.