### PR TITLE
fix(vault): unlock with the key that actually encrypted secrets.enc

### DIFF
--- a/src/services/account.serverAuth.test.ts
+++ b/src/services/account.serverAuth.test.ts
@@ -4,6 +4,8 @@ const h = vi.hoisted(() => ({
   invoke: vi.fn(),
   appFetch: vi.fn(),
   setVaultKey: vi.fn(),
+  getVaultStatus: vi.fn(async () => ({ exists: false, path: "" })),
+  verifyVaultKey: vi.fn(async (_key: number[]) => undefined as void),
   wipeLocalConfig: vi.fn(async () => undefined),
   load: vi.fn(async () => undefined),
   keysSet: vi.fn(),
@@ -18,9 +20,9 @@ vi.mock("@/i18n", () => ({ default: { t: (k: string) => k } }));
 vi.mock("@/services/http", () => ({ appFetch: h.appFetch, isAbortError: () => false }));
 vi.mock("./vault", () => ({
   setVaultKey: h.setVaultKey,
-  verifyVaultKey: vi.fn(async () => undefined),
+  verifyVaultKey: h.verifyVaultKey,
   lockVault: vi.fn(async () => undefined),
-  getVaultStatus: vi.fn(async () => ({ exists: false, path: "" })),
+  getVaultStatus: h.getVaultStatus,
   unlockVaultIfNeeded: vi.fn(async () => undefined),
   wipeLocalConfig: h.wipeLocalConfig,
   resetVault: vi.fn(async () => undefined),
@@ -87,6 +89,10 @@ const err = (status: number, body: unknown = {}) => ({ ok: false, status, body }
 
 beforeEach(() => {
   for (const m of [h.invoke, h.appFetch, h.setVaultKey, h.wipeLocalConfig, h.load, h.keysSet]) m.mockReset();
+  h.getVaultStatus.mockReset();
+  h.getVaultStatus.mockResolvedValue({ exists: false, path: "" });
+  h.verifyVaultKey.mockReset();
+  h.verifyVaultKey.mockResolvedValue(undefined);
   h.store = {};
   h.http = {};
   h.dek = null;
@@ -145,6 +151,50 @@ test("login local mode sets the vault key without a server round-trip", async ()
   await login("pw");
   expect(h.setVaultKey).toHaveBeenCalledWith([9, 9, 9]); // enc_key
   expect(h.appFetch).not.toHaveBeenCalled();
+});
+
+// A cloud vault is encrypted with the dek carried in wrapped_user_secrets, not with
+// the password-derived kek. Verifying the kek against it rejected the correct master
+// password with "Decryption failed — wrong key or corrupted file" (issue #134).
+test("login opens a cloud vault encrypted with the dek, offline, without a server round-trip", async () => {
+  h.store.account_id = "acc";
+  h.store.mode = "server";
+  h.store.wrapped_user_secrets = "WRAPPED"; // no email/server_url → no re-auth
+  h.getVaultStatus.mockResolvedValue({ exists: true, path: "p" });
+  h.verifyVaultKey.mockImplementation(async (key: number[]) => {
+    if (String(key) !== String([1, 1, 1])) throw new Error("Decryption failed — wrong key or corrupted file");
+  });
+
+  await login("pw");
+  expect(h.setVaultKey).toHaveBeenCalledWith([1, 1, 1]); // dek
+  expect(h.appFetch).not.toHaveBeenCalled();
+});
+
+test("login defers to the server when no cached key opens the existing vault", async () => {
+  // Keychain cleared: no cached wrapped_user_secrets, so only the server can hand
+  // back the dek. Failing the local check here must not abort the sign-in.
+  h.store.account_id = "acc";
+  h.store.mode = "server";
+  h.store.email = "a@b.co";
+  h.store.server_url = S;
+  h.http["/auth/login"] = ok({ ...TOKENS, wrapped_user_secrets: "W" });
+  h.getVaultStatus.mockResolvedValue({ exists: true, path: "p" });
+  h.verifyVaultKey.mockImplementation(async (key: number[]) => {
+    if (String(key) !== String([1, 1, 1])) throw new Error("Decryption failed — wrong key or corrupted file");
+  });
+
+  await login("pw");
+  expect(h.setVaultKey).toHaveBeenLastCalledWith([1, 1, 1]); // dek
+});
+
+test("login rejects a password whose keys open nothing", async () => {
+  h.store.account_id = "acc";
+  h.store.mode = "local";
+  h.getVaultStatus.mockResolvedValue({ exists: true, path: "p" });
+  h.verifyVaultKey.mockRejectedValue(new Error("Decryption failed — wrong key or corrupted file"));
+
+  await expect(login("pw")).rejects.toThrow("common.error.incorrectPassword");
+  expect(h.setVaultKey).not.toHaveBeenCalled();
 });
 
 // ─── signInToCloud ───────────────────────────────────────────────────────────

--- a/src/services/account.serverAuth.test.ts
+++ b/src/services/account.serverAuth.test.ts
@@ -153,9 +153,8 @@ test("login local mode sets the vault key without a server round-trip", async ()
   expect(h.appFetch).not.toHaveBeenCalled();
 });
 
-// A cloud vault is encrypted with the dek carried in wrapped_user_secrets, not with
-// the password-derived kek. Verifying the kek against it rejected the correct master
-// password with "Decryption failed — wrong key or corrupted file" (issue #134).
+// Issue #134: verifying the kek against a dek-encrypted cloud vault rejected the
+// correct master password as a corrupted file.
 test("login opens a cloud vault encrypted with the dek, offline, without a server round-trip", async () => {
   h.store.account_id = "acc";
   h.store.mode = "server";
@@ -171,8 +170,7 @@ test("login opens a cloud vault encrypted with the dek, offline, without a serve
 });
 
 test("login defers to the server when no cached key opens the existing vault", async () => {
-  // Keychain cleared: no cached wrapped_user_secrets, so only the server can hand
-  // back the dek. Failing the local check here must not abort the sign-in.
+  // No cached wrapped_user_secrets: only the server can hand back the dek.
   h.store.account_id = "acc";
   h.store.mode = "server";
   h.store.email = "a@b.co";
@@ -185,6 +183,24 @@ test("login defers to the server when no cached key opens the existing vault", a
 
   await login("pw");
   expect(h.setVaultKey).toHaveBeenLastCalledWith([1, 1, 1]); // dek
+});
+
+// A pre-split device keeps a kek-encrypted vault while the server holds
+// wrapped_user_secrets. Adopting the dek there wiped the store on first access.
+test("login keeps the kek when the server's dek does not open this device's vault", async () => {
+  h.store.account_id = "acc";
+  h.store.mode = "server";
+  h.store.email = "a@b.co";
+  h.store.server_url = S;
+  h.http["/auth/login"] = ok({ ...TOKENS, wrapped_user_secrets: "W" });
+  h.getVaultStatus.mockResolvedValue({ exists: true, path: "p" });
+  h.verifyVaultKey.mockImplementation(async (key: number[]) => {
+    if (String(key) !== String([9, 9, 9])) throw new Error("Decryption failed — wrong key or corrupted file");
+  });
+
+  await login("pw");
+  expect(h.setVaultKey).toHaveBeenLastCalledWith([9, 9, 9]); // kek, not the server's dek
+  expect(h.keysSet).toHaveBeenCalledWith(expect.objectContaining({ dek: [1, 1, 1] }));
 });
 
 test("login rejects a password whose keys open nothing", async () => {

--- a/src/services/account.ts
+++ b/src/services/account.ts
@@ -59,6 +59,57 @@ function normalizeServerUrl(url: string): string {
   return url.replace(/\/+$/, "");
 }
 
+/**
+ * Unwrap cached user secrets into the vault-keys store and return the dek.
+ * Null when there are none, or when they are corrupt or belong to another
+ * account — the caller then stays on the kek.
+ */
+async function adoptUserSecrets(kek: number[], wrapped: string | null): Promise<number[] | null> {
+  if (!wrapped) return null;
+  try {
+    const unwrapped = await unwrapUserSecrets(kek, wrapped);
+    useVaultKeysStore.getState().set({
+      dek: unwrapped.dek,
+      x25519Private: unwrapped.x25519_private,
+      kek,
+    });
+    return unwrapped.dek;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The first candidate that actually opens secrets.enc, or null when none does.
+ * A cloud vault is encrypted with the dek, a legacy or local one with the kek,
+ * so the caller must never assume which of its keys the on-disk file holds.
+ * With no vault yet the first candidate wins — nothing to verify against.
+ */
+async function keyThatOpensVault(...candidates: number[][]): Promise<number[] | null> {
+  const { exists } = await getVaultStatus();
+  if (!exists) return candidates[0] ?? null;
+  for (const key of candidates) {
+    try {
+      await verifyVaultKey(key);
+      return key;
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return null;
+}
+
+/**
+ * The key that opens this device's vault for a password-derived account: the dek
+ * from the cached user secrets when secrets.enc was written by a cloud session,
+ * the kek when it was written by a local or pre-dek one. Null when a vault exists
+ * and neither opens it.
+ */
+async function passwordVaultKey(kek: number[]): Promise<number[] | null> {
+  const dek = await adoptUserSecrets(kek, await keychainGet("wrapped_user_secrets"));
+  return keyThatOpensVault(...(dek ? [dek, kek] : [kek]));
+}
+
 async function fetchWithTimeout(input: string, init?: RequestInit, timeoutMs = 10_000): Promise<Response> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -208,17 +259,32 @@ export async function login(password: string, email?: string, serverUrl?: string
 
   const mode = await keychainGet("mode");
 
+  // Re-authenticate with server if in server mode (e.g. after logout deleted the JWT)
+  const resolvedEmail = email ?? await keychainGet("email");
+  const rawServerUrl = serverUrl ?? await keychainGet("server_url");
+  const resolvedServerUrl = rawServerUrl ? normalizeServerUrl(rawServerUrl) : null;
+  const reauth =
+    resolvedEmail && resolvedServerUrl && (mode === "server" || serverUrl)
+      ? { email: resolvedEmail, serverUrl: resolvedServerUrl }
+      : null;
+
   let encKey: number[];
   if (mode === "local-nopassword") {
     // password IS the stored hex key — convert back to bytes
     encKey = hexToBytes(password);
+    if (!(await keyThatOpensVault(encKey))) throw new Error(i18n.t("common.error.incorrectPassword"));
   } else {
-    const { enc_key } = await deriveKeys(password, accountId);
-    encKey = enc_key;
+    const { enc_key: kek } = await deriveKeys(password, accountId);
+    // A cloud vault is encrypted with the dek held in wrapped_user_secrets, so the
+    // password-derived kek alone does not open it — checking the kek against a cloud
+    // vault rejected the correct master password as a corrupted file (issue #134).
+    const opened = await passwordVaultKey(kek);
+    // Without a cached dek only the server can hand back the key a cloud vault was
+    // encrypted with, so a failed local check is not yet a failed password.
+    if (!opened && !reauth) throw new Error(i18n.t("common.error.incorrectPassword"));
+    encKey = opened ?? kek;
   }
 
-  const { exists } = await getVaultStatus();
-  if (exists) await verifyVaultKey(encKey);
   setVaultKey(encKey);
 
   await keychainSet("master_password", password);
@@ -229,14 +295,9 @@ export async function login(password: string, email?: string, serverUrl?: string
     await keychainSet("mode", isHexEncoded32ByteKey(password) ? "local-nopassword" : "local");
   }
 
-  // Re-authenticate with server if in server mode (e.g. after logout deleted the JWT)
-  const resolvedEmail = email ?? await keychainGet("email");
-  const rawServerUrl = serverUrl ?? await keychainGet("server_url");
-  const resolvedServerUrl = rawServerUrl ? normalizeServerUrl(rawServerUrl) : null;
-
-  if (resolvedEmail && resolvedServerUrl && (mode === "server" || serverUrl)) {
+  if (reauth) {
     const { auth_key, enc_key: kek } = await deriveKeys(password, accountId);
-    const res = await fetchWithTimeout(`${resolvedServerUrl}/v1/auth/login`, {
+    const res = await fetchWithTimeout(`${reauth.serverUrl}/v1/auth/login`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ account_id: accountId, auth_key }),
@@ -246,8 +307,8 @@ export async function login(password: string, email?: string, serverUrl?: string
     await keychainSet("jwt", data.jwt_token);
     await keychainSet("refresh_token", data.refresh_token);
     await keychainSet("mode", "server");
-    await keychainSet("email", resolvedEmail);
-    await keychainSet("server_url", resolvedServerUrl);
+    await keychainSet("email", reauth.email);
+    await keychainSet("server_url", reauth.serverUrl);
 
     if (data.wrapped_user_secrets) {
       const unwrapped = await unwrapUserSecrets(kek, data.wrapped_user_secrets);
@@ -256,7 +317,7 @@ export async function login(password: string, email?: string, serverUrl?: string
       await keychainSet("wrapped_user_secrets", data.wrapped_user_secrets);
     } else {
       // Legacy account — trigger one-time migration
-      await migrateToWrappedUserSecrets(password, accountId, kek, resolvedServerUrl, data.jwt_token);
+      await migrateToWrappedUserSecrets(password, accountId, kek, reauth.serverUrl, data.jwt_token);
     }
 
     reloadSubscription();
@@ -298,38 +359,13 @@ export async function autoLogin(): Promise<boolean> {
     } else {
       if (!accountId) return false;
       const { enc_key: kek } = await deriveKeys(password, accountId);
-      encKey = kek;
 
       // Adopt dek when this device has previously unwrapped user secrets (cached at
       // login/migration). Converges every session onto dek so the kek/dek split heals.
       // Offline: unwrap + verify are local Tauri calls, no network — autoLogin stays instant.
-      const wrapped = await keychainGet("wrapped_user_secrets");
-      if (wrapped) {
-        try {
-          const unwrapped = await unwrapUserSecrets(kek, wrapped);
-          useVaultKeysStore.getState().set({
-            dek: unwrapped.dek,
-            x25519Private: unwrapped.x25519_private,
-            kek,
-          });
-          // Pick the key that actually opens secrets.enc — prefer dek, fall back to kek.
-          // Guards against a device whose on-disk vault is still kek-encrypted.
-          const { exists } = await getVaultStatus();
-          if (!exists) {
-            encKey = unwrapped.dek;
-          } else {
-            try {
-              await verifyVaultKey(unwrapped.dek);
-              encKey = unwrapped.dek;
-            } catch {
-              encKey = kek;
-            }
-          }
-        } catch {
-          // Corrupt/foreign cached secrets — stay on kek.
-          encKey = kek;
-        }
-      }
+      // Falls back to kek when nothing opens the vault: an auto-login must not strand
+      // the session, and ensureUnlocked still reports a genuinely unopenable store.
+      encKey = (await passwordVaultKey(kek)) ?? kek;
 
       if (!mode) {
         // Heal missing mode for local accounts (e.g. Windows after mock-keychain loss)

--- a/src/services/account.ts
+++ b/src/services/account.ts
@@ -59,11 +59,7 @@ function normalizeServerUrl(url: string): string {
   return url.replace(/\/+$/, "");
 }
 
-/**
- * Unwrap cached user secrets into the vault-keys store and return the dek.
- * Null when there are none, or when they are corrupt or belong to another
- * account — the caller then stays on the kek.
- */
+/** Unwrap cached user secrets into the vault-keys store; null when unusable. */
 async function adoptUserSecrets(kek: number[], wrapped: string | null): Promise<number[] | null> {
   if (!wrapped) return null;
   try {
@@ -79,12 +75,7 @@ async function adoptUserSecrets(kek: number[], wrapped: string | null): Promise<
   }
 }
 
-/**
- * The first candidate that actually opens secrets.enc, or null when none does.
- * A cloud vault is encrypted with the dek, a legacy or local one with the kek,
- * so the caller must never assume which of its keys the on-disk file holds.
- * With no vault yet the first candidate wins — nothing to verify against.
- */
+/** First candidate that opens secrets.enc; the first one when no vault exists yet. */
 async function keyThatOpensVault(...candidates: number[][]): Promise<number[] | null> {
   const { exists } = await getVaultStatus();
   if (!exists) return candidates[0] ?? null;
@@ -93,18 +84,13 @@ async function keyThatOpensVault(...candidates: number[][]): Promise<number[] | 
       await verifyVaultKey(key);
       return key;
     } catch {
-      // Try the next candidate.
+      continue;
     }
   }
   return null;
 }
 
-/**
- * The key that opens this device's vault for a password-derived account: the dek
- * from the cached user secrets when secrets.enc was written by a cloud session,
- * the kek when it was written by a local or pre-dek one. Null when a vault exists
- * and neither opens it.
- */
+/** A cloud vault is dek-encrypted, a local or pre-split one kek-encrypted. */
 async function passwordVaultKey(kek: number[]): Promise<number[] | null> {
   const dek = await adoptUserSecrets(kek, await keychainGet("wrapped_user_secrets"));
   return keyThatOpensVault(...(dek ? [dek, kek] : [kek]));
@@ -275,12 +261,8 @@ export async function login(password: string, email?: string, serverUrl?: string
     if (!(await keyThatOpensVault(encKey))) throw new Error(i18n.t("common.error.incorrectPassword"));
   } else {
     const { enc_key: kek } = await deriveKeys(password, accountId);
-    // A cloud vault is encrypted with the dek held in wrapped_user_secrets, so the
-    // password-derived kek alone does not open it — checking the kek against a cloud
-    // vault rejected the correct master password as a corrupted file (issue #134).
     const opened = await passwordVaultKey(kek);
-    // Without a cached dek only the server can hand back the key a cloud vault was
-    // encrypted with, so a failed local check is not yet a failed password.
+    // Without a cached dek only the server can supply a cloud vault's key.
     if (!opened && !reauth) throw new Error(i18n.t("common.error.incorrectPassword"));
     encKey = opened ?? kek;
   }
@@ -313,7 +295,8 @@ export async function login(password: string, email?: string, serverUrl?: string
     if (data.wrapped_user_secrets) {
       const unwrapped = await unwrapUserSecrets(kek, data.wrapped_user_secrets);
       useVaultKeysStore.getState().set({ dek: unwrapped.dek, x25519Private: unwrapped.x25519_private, kek });
-      setVaultKey(unwrapped.dek);
+      // This device's secrets.enc may predate the split and still be kek-encrypted.
+      setVaultKey((await keyThatOpensVault(unwrapped.dek, kek)) ?? unwrapped.dek);
       await keychainSet("wrapped_user_secrets", data.wrapped_user_secrets);
     } else {
       // Legacy account — trigger one-time migration
@@ -360,11 +343,7 @@ export async function autoLogin(): Promise<boolean> {
       if (!accountId) return false;
       const { enc_key: kek } = await deriveKeys(password, accountId);
 
-      // Adopt dek when this device has previously unwrapped user secrets (cached at
-      // login/migration). Converges every session onto dek so the kek/dek split heals.
-      // Offline: unwrap + verify are local Tauri calls, no network — autoLogin stays instant.
-      // Falls back to kek when nothing opens the vault: an auto-login must not strand
-      // the session, and ensureUnlocked still reports a genuinely unopenable store.
+      // Local Tauri calls only — autoLogin stays instant offline.
       encKey = (await passwordVaultKey(kek)) ?? kek;
 
       if (!mode) {


### PR DESCRIPTION
Fixes #134, plus a second defect on the same code path that silently wiped local secrets.

## 1. Correct master password rejected as a corrupted file (#134)

`login()` derived the KEK from the master password and verified it against `secrets.enc` *before* the block that unwraps `wrapped_user_secrets`. A cloud vault is encrypted with the **DEK** carried in those secrets, so the KEK never opens it and the raw decrypt error reached the unlock form:

> Decryption failed — wrong key or corrupted file

Clearing the keychain and local data does not help, which is what the reporter observed: the locked screen calls `login(password)` with no email, so the throw lands before the server round trip that would return the DEK. Present unchanged since v0.22.0.

`autoLogin()` was already correct — it prefers the DEK and falls back to the KEK — so only the explicit lock/unlock path broke.

## 2. Restored sessions land on the auth prompt, and secrets.enc is wiped

A device whose `secrets.enc` predates the KEK/DEK split is still KEK-encrypted while the server already holds `wrapped_user_secrets`. There, unlock succeeded and the damage came afterwards:

1. `login()` verified the KEK — passes, the file is KEK-encrypted.
2. The server re-auth then ran `setVaultKey(unwrapped.dek)` unconditionally, replacing the working key with one that cannot open the file.
3. First secret access → `ensureUnlocked` fails "wrong key or corrupted file" → in server mode `vault.ts` calls `secrets_wipe` and reopens an empty store.
4. `resolveConnectionCredentials` wraps every `getSecret` in `.catch(() => null)`, so an unusable vault reads as "nothing saved". Connect goes out with no auth, the backend returns `No authentication method provided`, and every restored tab shows `AuthPromptPanel`.

The local secrets file is destroyed in step 3, recovered only if a cloud blob still carried those secrets.

## Change

Pick the key that actually opens `secrets.enc` instead of assuming which one wrote it:

- `keyThatOpensVault(...candidates)` — first candidate that verifies; the first one when no vault exists yet.
- `passwordVaultKey(kek)` — DEK from cached user secrets first, then KEK. Shared by `login` and `autoLogin`, replacing the inline copy in `autoLogin`.
- The server re-auth branch verifies the unwrapped DEK and keeps the KEK when that is what opens the file.
- A failed local check no longer throws when a server re-auth can still supply the key.
- A password that opens nothing reports "Incorrect password" instead of the decrypt string.

## Tests

Four added to `account.serverAuth.test.ts`, each failing before its fix:

- opens a DEK-encrypted cloud vault offline, no server round trip
- defers to the server when no cached key opens the existing vault
- keeps the KEK when the server's DEK does not open this device's vault
- rejects a password whose keys open nothing

`tsc --noEmit` clean. Not live-clicked against a real cloud account.

## Not addressed here

- `ensureUnlocked`'s `secrets_wipe` destroys local secrets on any key mismatch in server mode, with no backup and no prompt. Intended for a stale key from a prior account, it fires for a transient one too.
- Swallowing vault errors in credential resolution turns "vault unavailable" into "no credentials saved", which is what made defect 2 look like a UI bug.
