### PR TITLE
fix(share): presence on Recent rows, and a dot that actually paints

### DIFF
--- a/src/components/terminal/PeopleTab.test.tsx
+++ b/src/components/terminal/PeopleTab.test.tsx
@@ -19,7 +19,7 @@ vi.mock("@/services/teamService", async () => {
   return { ...actual, searchUsers: h.searchUsers };
 });
 
-import { PeopleTab } from "./PeopleTab";
+import { PeopleTab, PERSON_TEXT_INDENT } from "./PeopleTab";
 import { useRecentPeopleStore } from "@/stores/recentPeopleStore";
 import { useTeamStore } from "@/stores/teamStore";
 
@@ -110,6 +110,26 @@ test("only recent rows offer forget", async () => {
   await userEvent.type(screen.getByRole("textbox"), "sam-q");
   await screen.findByRole("button", { name: /sam-q/i });
   expect(screen.queryByRole("button", { name: "terminal.share.forgetPerson" })).toBeNull();
+});
+
+// A row's handle sits past the reserved presence slot, so a label at the row's
+// own padding hangs 14px to its left. Every section label shares one indent.
+test("every section label starts at the handle column", async () => {
+  h.allTeammates.mockResolvedValue(roster);
+  h.searchUsers.mockResolvedValue([{ user_id: "s1", handle: "sam-lynx-9001", is_teammate: false }]);
+  useRecentPeopleStore.setState({
+    recent: [{ user_id: "r1", handle: "kevin-lynx-6620", last_invited_at: "" }],
+    recentUpdatedAt: "",
+  });
+  render(<PeopleTab {...base} />);
+  await userEvent.type(screen.getByRole("textbox"), "lynx");
+  await screen.findByRole("button", { name: /sam-lynx-9001/i });
+  const labels = [
+    screen.getByText("terminal.share.recentLabel"),
+    screen.getByText("terminal.share.yourTeamsLabel"),
+    screen.getByText("terminal.share.elsewhereLabel"),
+  ];
+  for (const label of labels) expect(label.className).toContain(PERSON_TEXT_INDENT);
 });
 
 test("the presence dot names the state it shows", async () => {

--- a/src/components/terminal/PeopleTab.test.tsx
+++ b/src/components/terminal/PeopleTab.test.tsx
@@ -112,6 +112,59 @@ test("only recent rows offer forget", async () => {
   expect(screen.queryByRole("button", { name: "terminal.share.forgetPerson" })).toBeNull();
 });
 
+test("the presence dot names the state it shows", async () => {
+  h.allTeammates.mockResolvedValue(roster);
+  render(<PeopleTab {...base} />);
+  const online = await screen.findByRole("button", { name: /amber-lynx-4410/i });
+  const offline = await screen.findByRole("button", { name: /brisk-otter-8823/i });
+  expect(within(online).getByRole("img", { name: "terminal.share.presenceOnline" })).toBeTruthy();
+  expect(within(offline).getByRole("img", { name: "terminal.share.presenceOffline" })).toBeTruthy();
+});
+
+// `--t-status-success` is not a token this app defines (useApplyTheme sets
+// `--t-status-connected`), so the online dot painted transparent.
+test("the online dot uses a theme token that exists", async () => {
+  h.allTeammates.mockResolvedValue(roster);
+  render(<PeopleTab {...base} />);
+  const row = await screen.findByRole("button", { name: /amber-lynx-4410/i });
+  const dot = within(row).getByRole("img", { name: "terminal.share.presenceOnline" });
+  expect(dot.getAttribute("style")).toContain("--t-status-connected");
+});
+
+// Recent wins the dedupe, so a teammate listed under Recent loses the dot they
+// had under Your teams — for presence we already hold locally, at no privacy cost.
+test("a recent row who is also a teammate keeps their presence", async () => {
+  h.allTeammates.mockResolvedValue(roster);
+  useRecentPeopleStore.setState({
+    recent: [{ user_id: "u-alice", handle: "amber-lynx-4410", last_invited_at: "" }],
+    recentUpdatedAt: "",
+  });
+  render(<PeopleTab {...base} />);
+  const row = await screen.findByRole("button", { name: /amber-lynx-4410/i });
+  expect(within(row).getByRole("img", { name: "terminal.share.presenceOnline" })).toBeTruthy();
+});
+
+// Presence for a non-teammate would mean asking the server "is user X online",
+// which hands it the social graph Recent exists to keep local. No dot instead.
+test("a recent row who is not a teammate shows no presence", async () => {
+  h.allTeammates.mockResolvedValue(roster);
+  useRecentPeopleStore.setState({
+    recent: [{ user_id: "r1", handle: "kevin-p-6620", last_invited_at: "" }],
+    recentUpdatedAt: "",
+  });
+  render(<PeopleTab {...base} />);
+  const row = await screen.findByRole("button", { name: /kevin-p-6620/i });
+  expect(within(row).queryByRole("img")).toBeNull();
+});
+
+test("a search hit shows no presence", async () => {
+  h.searchUsers.mockResolvedValue([{ user_id: "s1", handle: "sam-q", is_teammate: false }]);
+  render(<PeopleTab {...base} />);
+  await userEvent.type(screen.getByRole("textbox"), "sam-q");
+  const row = await screen.findByRole("button", { name: /sam-q/i });
+  expect(within(row).queryByRole("img")).toBeNull();
+});
+
 test("an invitable row reads as clickable and a blocked one does not", async () => {
   h.allTeammates.mockResolvedValue(roster);
   render(<PeopleTab {...base} session={{ vaultIds: ["t1"], participantIds: [], invitedIds: [] }} />);

--- a/src/components/terminal/PeopleTab.tsx
+++ b/src/components/terminal/PeopleTab.tsx
@@ -39,7 +39,7 @@ interface RowEntry {
   /** Teammate group memberships, for `memberHasAccess`. Empty for Recent/stranger rows. */
   teamIds: string[];
   isStranger: boolean;
-  /** Only teammates carry live presence; undefined omits the dot entirely. */
+  /** Only teammates carry live presence; undefined keeps the slot but draws no dot. */
   isOnline?: boolean;
   /** Only Recent rows: the roster and search hits aren't ours to delete. */
   canForget?: boolean;
@@ -93,6 +93,8 @@ function PersonRow({
 }) {
   const { target, isStranger, isOnline, onContextMenu } = entry;
   const actionable = !hasAccess && !inFlight && !invited && !capBlocked;
+  const presenceLabel =
+    isOnline === undefined ? "" : t(isOnline ? "terminal.share.presenceOnline" : "terminal.share.presenceOffline");
   return (
     <div className={`group flex items-center gap-1 rounded-md transition-colors ${actionable ? "hover:bg-(--t-bg-elevated)" : ""}`}>
       <button
@@ -102,10 +104,18 @@ function PersonRow({
         onClick={onInvite}
         onContextMenu={onContextMenu}
       >
-        {isOnline !== undefined && (
+        {isOnline === undefined ? (
+          /* The slot is held even with no dot to draw: Recent mixes rows whose
+             presence we know with rows we deliberately don't ask about, and a
+             per-row indent would make the handles ragged. */
+          <span className="w-1.5 shrink-0" aria-hidden="true" />
+        ) : (
           <span
+            role="img"
+            aria-label={presenceLabel}
+            title={presenceLabel}
             className="w-1.5 h-1.5 rounded-full shrink-0"
-            style={{ background: isOnline ? "var(--t-status-success)" : "var(--t-text-dim)" }}
+            style={{ background: isOnline ? "var(--t-status-connected)" : "var(--t-text-dim)" }}
           />
         )}
         <span className="flex-1 min-w-0 text-left">
@@ -250,6 +260,9 @@ export function PeopleTab({ session, invitedThisSession, guestCap, tier, onUpgra
       },
       teamIds: teammate?.teamIds ?? [],
       isStranger: false,
+      // Only a teammate's presence is already in hand. Asking the server about
+      // anyone else would hand it the social graph Recent keeps local.
+      isOnline: teammate ? !!teammate.is_online : undefined,
       canForget: true,
       onContextMenu: (e: React.MouseEvent) => {
         e.preventDefault();

--- a/src/components/terminal/PeopleTab.tsx
+++ b/src/components/terminal/PeopleTab.tsx
@@ -53,6 +53,24 @@ interface RowEntry {
 const REVEAL =
   "opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100";
 
+/**
+ * A row's handle starts past its own padding plus the reserved presence slot
+ * (`px-2` + `w-1.5` + `gap-2`). Anything that should read as the same column —
+ * the section labels, Recent's empty state — carries this instead of `pl-2`.
+ */
+export const PERSON_TEXT_INDENT = "pl-[1.375rem]";
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p
+      className={`text-[10px] font-semibold uppercase mb-0.5 pr-2 ${PERSON_TEXT_INDENT}`}
+      style={{ color: "var(--t-text-dim)" }}
+    >
+      {children}
+    </p>
+  );
+}
+
 function ErrorBanner({ children }: { children: React.ReactNode }) {
   return (
     <div
@@ -345,13 +363,11 @@ export function PeopleTab({ session, invitedThisSession, guestCap, tier, onUpgra
       ) : (
         <div className="flex flex-col gap-2">
           <div>
-            <p className="text-[10px] font-semibold uppercase mb-0.5 px-2" style={{ color: "var(--t-text-dim)" }}>
-              {t("terminal.share.recentLabel")}
-            </p>
+            <SectionLabel>{t("terminal.share.recentLabel")}</SectionLabel>
             {recentEntries.length > 0 ? (
               <div className="flex flex-col gap-0.5">{recentEntries.map(renderRow)}</div>
             ) : (
-              <p className="text-xs px-2 py-1" style={{ color: "var(--t-text-dim)" }}>
+              <p className={`text-xs pr-2 py-1 ${PERSON_TEXT_INDENT}`} style={{ color: "var(--t-text-dim)" }}>
                 {t("terminal.share.recentEmpty")}
               </p>
             )}
@@ -359,18 +375,14 @@ export function PeopleTab({ session, invitedThisSession, guestCap, tier, onUpgra
 
           {teammateEntries.length > 0 && (
             <div>
-              <p className="text-[10px] font-semibold uppercase mb-0.5 px-2" style={{ color: "var(--t-text-dim)" }}>
-                {t("terminal.share.yourTeamsLabel")}
-              </p>
+              <SectionLabel>{t("terminal.share.yourTeamsLabel")}</SectionLabel>
               <div className="flex flex-col gap-0.5">{teammateEntries.map(renderRow)}</div>
             </div>
           )}
 
           {strangerEntries.length > 0 && (
             <div>
-              <p className="text-[10px] font-semibold uppercase mb-0.5 px-2" style={{ color: "var(--t-text-dim)" }}>
-                {t("terminal.share.elsewhereLabel")}
-              </p>
+              <SectionLabel>{t("terminal.share.elsewhereLabel")}</SectionLabel>
               <div className="flex flex-col gap-0.5">{strangerEntries.map(renderRow)}</div>
             </div>
           )}

--- a/src/i18n/locales/en/terminal.json
+++ b/src/i18n/locales/en/terminal.json
@@ -159,6 +159,8 @@
       "yourTeamsLabel": "Your teams",
       "elsewhereLabel": "Elsewhere on Voltius",
       "notInYourTeams": "Not in your teams",
+      "presenceOnline": "Online",
+      "presenceOffline": "Offline",
       "forgetPerson": "Remove from recent",
       "deepLinkJoinTitle": "Join shared terminal?",
       "deepLinkJoinBody": "Someone shared a live terminal session with you. Joining connects you to it now.",

--- a/src/i18n/locales/fr/terminal.json
+++ b/src/i18n/locales/fr/terminal.json
@@ -159,6 +159,8 @@
       "yourTeamsLabel": "Vos équipes",
       "elsewhereLabel": "Ailleurs sur Voltius",
       "notInYourTeams": "Pas dans vos équipes",
+      "presenceOnline": "En ligne",
+      "presenceOffline": "Hors ligne",
       "forgetPerson": "Retirer des récents",
       "deepLinkJoinTitle": "Rejoindre le terminal partagé ?",
       "deepLinkJoinBody": "Quelqu'un a partagé une session de terminal en direct avec vous. En rejoignant, vous vous y connectez immédiatement.",

--- a/src/i18n/locales/ru/terminal.json
+++ b/src/i18n/locales/ru/terminal.json
@@ -169,6 +169,8 @@
       "yourTeamsLabel": "Ваши команды",
       "elsewhereLabel": "Другие пользователи Voltius",
       "notInYourTeams": "Не в ваших командах",
+      "presenceOnline": "В сети",
+      "presenceOffline": "Не в сети",
       "forgetPerson": "Убрать из недавних",
       "deepLinkJoinTitle": "Присоединиться к общему терминалу?",
       "deepLinkJoinBody": "Кто-то поделился с вами активной сессией терминала. Присоединение подключит вас к ней сейчас.",

--- a/src/i18n/locales/zh/terminal.json
+++ b/src/i18n/locales/zh/terminal.json
@@ -159,6 +159,8 @@
       "yourTeamsLabel": "您的团队",
       "elsewhereLabel": "Voltius 上的其他人",
       "notInYourTeams": "不在您的团队中",
+      "presenceOnline": "在线",
+      "presenceOffline": "离线",
       "forgetPerson": "从最近记录中移除",
       "deepLinkJoinTitle": "加入共享终端？",
       "deepLinkJoinBody": "有人与你共享了一个实时终端会话。加入后将立即连接。",


### PR DESCRIPTION
## What

ShareMenu's People tab showed presence only under **Your teams**. A teammate who also sits in **Recent** lost their dot, because Recent wins the dedupe and dropped `is_online` while merging. That value is already in `teamStore`, so the Recent row now carries it.

Non-teammates (Recent entries who are not in any of your teams, and every search hit) still get **no** dot. Their status would have to be fetched by `user_id`, which hands the server the social graph Recent deliberately keeps local — and an invite is grant-first and offline-durable, so presence never gates the action anyway.

The dot slot is reserved even when nothing is drawn, so a Recent list mixing known and unknown presence keeps its handles aligned.

## Also fixed

The online dot never painted. It used `var(--t-status-success)`, a token `useApplyTheme` does not define, so `background` computed to `rgba(0, 0, 0, 0)`. Every other presence surface (`VaultHeader`, `MembersPage`) uses `--t-status-connected`. The dot also had no accessible name — it now carries an `aria-label` + `title` (`Online` / `Offline`, 4 locales).

## Verified live

Isolated server + DB, three accounts, real presence over the sync SSE stream:

| state | result |
|---|---|
| teammate online (Your teams) | green dot, `aria-label="Online"`, `rgb(34, 197, 94)` |
| same teammate in Recent | green dot — the change |
| non-teammate in Recent | no dot, reserved slot, handles aligned |
| teammate after their stream closed | grey dot, `aria-label="Offline"` |

Tests: `PeopleTab.test.tsx` 27/27; `src/components/terminal` + `src/components/layout` 122/122; full suite 3594/3594 green before the token fix, affected suites re-run after.

## Known, not addressed here

- Presence in this menu is a snapshot taken when the menu opens: `PeopleTab` keeps its own `allTeammates()` array, so `teamStore`'s presence SSE updates do not reach it until the menu is reopened. Pre-existing.
- `src/components/filetransfer/editor/diffRibbons.css:9` uses the same nonexistent `--t-status-success` token. Different feature, left alone.
