### PR TITLE
feat(team): one presence component across bar, ShareMenu, cards and member list

### DIFF
--- a/src/components/layout/VaultHeader.tsx
+++ b/src/components/layout/VaultHeader.tsx
@@ -8,8 +8,8 @@ import { useVaultContents } from "@/hooks/useVaultContents";
 import { ContentCounts } from "@/components/shared/ContentCounts";
 import { useTeamStore } from "@/stores/teamStore";
 import type { TeamMember, TeamRole } from "@/services/teamService";
-import { StatusDot } from "@/components/shared/StatusDot";
-import { MiniAvatar, avatarColor } from "@/components/shared/AvatarStack";
+import { AvatarOverflow, MiniAvatar, avatarColor } from "@/components/shared/AvatarStack";
+import { PresenceAvatar } from "@/components/shared/PresenceAvatar";
 import { PickerSurface } from "@/components/shared/PickerSurface";
 import { getSyncState, onSyncStateChange } from "@/services/sync";
 import { getAccountMode } from "@/services/account";
@@ -81,22 +81,7 @@ function OnlineMembersStack({ members, roles, onInviteClick }: { members: TeamMe
               <MiniAvatar name={m.handle} size={24} />
             </div>
           ))}
-          {overflow > 0 && (
-            <div
-              className="flex items-center justify-center text-[10px] font-semibold rounded-full shrink-0"
-              style={{
-                marginLeft: -9,
-                zIndex: 0,
-                width: 26,
-                height: 26,
-                background: "var(--t-bg-elevated)",
-                border: "2px solid var(--t-bg-chrome)",
-                color: "var(--t-text-dim)",
-              }}
-            >
-              +{overflow}
-            </div>
-          )}
+          <AvatarOverflow count={overflow} size={24} ringColor="var(--t-bg-chrome)" />
 
           {/* Hover popover — portalled: the page overlay in MainPanel outranks the
               header's stacking context, so an in-flow popover paints under it. */}
@@ -121,10 +106,7 @@ function OnlineMembersStack({ members, roles, onInviteClick }: { members: TeamMe
                   .filter(Boolean) as TeamRole[];
                 return (
                   <div key={m.user_id} className="flex items-center gap-2.5 px-3 py-2" style={{ opacity: m.is_online ? 1 : 0.5 }}>
-                    <div className="relative shrink-0">
-                      <MiniAvatar name={m.handle} size={22} />
-                      {m.is_online && <StatusDot color="var(--t-status-connected)" size={7} />}
-                    </div>
+                    <PresenceAvatar handle={m.handle} size={22} online={m.is_online} />
                     <div className="flex flex-col min-w-0 flex-1">
                       <span className="text-xs truncate" style={{ color: "var(--t-text-primary)" }}>{m.handle}</span>
                       {memberRoles.length > 0 && (

--- a/src/components/members/MembersPage.tsx
+++ b/src/components/members/MembersPage.tsx
@@ -8,8 +8,8 @@ import { useSubscriptionStore } from "@/stores/subscriptionStore";
 import { useUIStore } from "@/stores/uiStore";
 import { useTeamSessionStore } from "@/stores/teamSessionStore";
 import { useHistoryStore } from "@/stores/historyStore";
-import { StatusDot } from "@/components/shared/StatusDot";
 import { MiniAvatar, avatarColor } from "@/components/shared/AvatarStack";
+import { PresenceAvatar } from "@/components/shared/PresenceAvatar";
 import { UserSearchField } from "@/components/shared/UserSearchField";
 import {
   getMyUserId,
@@ -274,14 +274,7 @@ interface MemberCardProps {
 }
 
 function MemberAvatar({ member, size }: { member: TeamMember; size: number }) {
-  return (
-    <div className="relative shrink-0">
-      <MiniAvatar name={member.handle} size={size} />
-      {member.is_online && (
-        <StatusDot color="var(--t-status-connected)" animate size={9} />
-      )}
-    </div>
-  );
+  return <PresenceAvatar handle={member.handle} size={size} online={member.is_online} animate />;
 }
 
 function MemberCard({

--- a/src/components/shared/AvatarStack.test.tsx
+++ b/src/components/shared/AvatarStack.test.tsx
@@ -1,5 +1,8 @@
-import { describe, expect, test } from "vitest";
-import { avatarColor, handleInitials } from "./AvatarStack";
+import { describe, expect, test, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { MiniAvatar, avatarColor, handleInitials } from "./AvatarStack";
+
+afterEach(cleanup);
 
 describe("handleInitials", () => {
   // Generated handles are adjective-noun-NNNN over 20 adjectives, so a single
@@ -44,5 +47,17 @@ describe("avatarColor", () => {
     expect(() => avatarColor(undefined)).not.toThrow();
     expect(() => avatarColor("")).not.toThrow();
     expect(avatarColor(undefined)).toBe(avatarColor(""));
+  });
+});
+
+describe("MiniAvatar initials size", () => {
+  test("floors small avatars at a legible size", () => {
+    const { container } = render(<MiniAvatar name="merry-quartz-2597" size={18} />);
+    expect((container.firstChild as HTMLElement).style.fontSize).toBe("9px");
+  });
+
+  test("keeps the derived size once it clears the floor", () => {
+    const { container } = render(<MiniAvatar name="merry-quartz-2597" size={40} />);
+    expect((container.firstChild as HTMLElement).style.fontSize).toBe("12.8px");
   });
 });

--- a/src/components/shared/AvatarStack.tsx
+++ b/src/components/shared/AvatarStack.tsx
@@ -46,6 +46,39 @@ export function MiniAvatar({ name, size = 26 }: MiniAvatarProps) {
   );
 }
 
+interface AvatarOverflowProps {
+  count: number;
+  /** Edge length of the avatars this chip trails, in px. */
+  size: number;
+  /** Separator ring colour — should match the surface behind the stack. */
+  ringColor?: string;
+  /** Pulls the chip back over the preceding avatar. Off for spaced (non-stacked) rows. */
+  overlap?: boolean;
+}
+
+/** The `+N` chip that closes an avatar row. */
+export function AvatarOverflow({
+  count, size, ringColor = "var(--t-bg-card)", overlap = true,
+}: AvatarOverflowProps) {
+  if (count <= 0) return null;
+  return (
+    <div
+      className="flex items-center justify-center text-[10px] font-semibold rounded-full shrink-0"
+      style={{
+        marginLeft: overlap ? -(size * 0.37) : 0,
+        zIndex: 0,
+        width: size + 2,
+        height: size + 2,
+        background: "var(--t-bg-elevated)",
+        border: `1.5px solid ${ringColor}`,
+        color: "var(--t-text-dim)",
+      }}
+    >
+      +{count}
+    </div>
+  );
+}
+
 interface AvatarStackProps {
   /** Named participants — when available, real initials are shown. */
   participants?: { name: string }[];
@@ -100,22 +133,7 @@ export function AvatarStack({
           <MiniAvatar name={p.name} size={size} />
         </div>
       ))}
-      {overflow > 0 && (
-        <div
-          className="flex items-center justify-center text-[10px] font-semibold rounded-full shrink-0"
-          style={{
-            marginLeft: -(size * 0.37),
-            zIndex: 0,
-            width: size + 2,
-            height: size + 2,
-            background: "var(--t-bg-elevated)",
-            border: `1.5px solid ${ringColor}`,
-            color: "var(--t-text-dim)",
-          }}
-        >
-          +{overflow}
-        </div>
-      )}
+      <AvatarOverflow count={overflow} size={size} ringColor={ringColor} />
     </div>
   );
 }

--- a/src/components/shared/AvatarStack.tsx
+++ b/src/components/shared/AvatarStack.tsx
@@ -29,6 +29,11 @@ interface MiniAvatarProps {
   size?: number;
 }
 
+/** Floor for the derived initials size. `size * 0.32` was tuned by the 26–40px
+ *  callers; below 28px it drops two letters under 9px, smaller than the 10px
+ *  the app uses for its smallest real text. */
+const MIN_INITIALS_PX = 9;
+
 export function MiniAvatar({ name, size = 26 }: MiniAvatarProps) {
   return (
     <div
@@ -38,7 +43,7 @@ export function MiniAvatar({ name, size = 26 }: MiniAvatarProps) {
         height: size,
         background: avatarColor(name),
         color: "#fff",
-        fontSize: size * 0.32,
+        fontSize: Math.max(MIN_INITIALS_PX, size * 0.32),
       }}
     >
       {handleInitials(name)}

--- a/src/components/shared/PresenceAvatar.test.tsx
+++ b/src/components/shared/PresenceAvatar.test.tsx
@@ -1,0 +1,48 @@
+import { test, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
+}));
+vi.mock("@iconify/react", () => ({ Icon: () => <i data-testid="icon" /> }));
+
+const { PresenceAvatar } = await import("./PresenceAvatar");
+const { avatarColor } = await import("./AvatarStack");
+
+afterEach(cleanup);
+
+test("uses the identity colour, so one person reads the same on every surface", () => {
+  const { container } = render(<PresenceAvatar handle="merry-quartz-2597" />);
+  const avatar = container.firstElementChild!.firstElementChild as HTMLElement;
+  expect(avatar.style.background).toBe(hexToRgb(avatarColor("merry-quartz-2597")));
+});
+
+test("marks the control holder with the accent ring and the pencil badge", () => {
+  const { container } = render(<PresenceAvatar handle="ada" hasControl />);
+  expect((container.firstChild as HTMLElement).style.boxShadow).toContain("var(--t-accent)");
+  expect(screen.getByTestId("icon")).toBeTruthy();
+  expect((container.firstChild as HTMLElement).title).toBe("ada · shared.presence.hasControl");
+});
+
+// Both markers sit in the same corner; drawing them together would overlap.
+test("suppresses the online dot while the control badge is shown", () => {
+  const { container } = render(<PresenceAvatar handle="ada" hasControl online />);
+  expect(container.querySelectorAll("span").length).toBe(1);
+});
+
+test("shows the online dot on its own", () => {
+  const { container } = render(<PresenceAvatar handle="ada" online />);
+  expect(container.querySelectorAll("span").length).toBeGreaterThan(0);
+  expect(screen.queryByTestId("icon")).toBeNull();
+});
+
+test("falls back to the bare handle as the tooltip when nobody has control", () => {
+  const { container } = render(<PresenceAvatar handle="ada" />);
+  expect((container.firstChild as HTMLElement).title).toBe("ada");
+});
+
+function hexToRgb(hex: string): string {
+  const n = parseInt(hex.slice(1), 16);
+  return `rgb(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255})`;
+}

--- a/src/components/shared/PresenceAvatar.tsx
+++ b/src/components/shared/PresenceAvatar.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from "react-i18next";
+import { Icon } from "@iconify/react";
+import { MiniAvatar } from "@/components/shared/AvatarStack";
+import { StatusDot } from "@/components/shared/StatusDot";
+
+interface PresenceAvatarProps {
+  handle: string | undefined;
+  size?: number;
+  /** Draws the has-control marker: accent ring + pencil badge. */
+  hasControl?: boolean;
+  /** Draws the online dot. Suppressed by `hasControl` — both occupy the same corner. */
+  online?: boolean;
+  /** Pulses the online dot. */
+  animate?: boolean;
+  /** Overrides the composed `handle · has control` tooltip. */
+  title?: string;
+  className?: string;
+}
+
+/** One person, drawn the same way on every surface: identity-coloured initials,
+ *  plus the shared status vocabulary (online, has-control). */
+export function PresenceAvatar({
+  handle, size = 22, hasControl = false, online = false, animate = false, title, className = "",
+}: PresenceAvatarProps) {
+  const { t } = useTranslation();
+  const badge = Math.max(9, Math.round(size * 0.42));
+  const composedTitle = title
+    ?? (hasControl ? `${handle ?? "?"} · ${t("shared.presence.hasControl")}` : handle);
+
+  return (
+    <div
+      className={`relative shrink-0 rounded-full ${className}`}
+      title={composedTitle}
+      style={hasControl ? { boxShadow: "0 0 0 2px var(--t-accent)" } : undefined}
+    >
+      <MiniAvatar name={handle} size={size} />
+      {hasControl ? (
+        <span
+          className="absolute -bottom-0.5 -right-0.5 rounded-full flex items-center justify-center"
+          style={{ width: badge, height: badge, background: "var(--t-accent)", color: "#fff" }}
+        >
+          <Icon icon="lucide:pencil" width={Math.round(badge * 0.6)} />
+        </span>
+      ) : (
+        online && (
+          <StatusDot
+            color="var(--t-status-connected)"
+            animate={animate}
+            size={Math.max(7, Math.round(size * 0.28))}
+          />
+        )
+      )}
+    </div>
+  );
+}

--- a/src/components/terminal/MultiplayerBar.tsx
+++ b/src/components/terminal/MultiplayerBar.tsx
@@ -2,7 +2,10 @@ import { useTranslation } from "react-i18next";
 import { Icon } from "@iconify/react";
 import { useTeamSessionStore } from "@/stores/teamSessionStore";
 import { useSessionStore } from "@/stores/sessionStore";
-import { handleInitials } from "@/components/shared/AvatarStack";
+import { AvatarOverflow } from "@/components/shared/AvatarStack";
+import { PresenceAvatar } from "@/components/shared/PresenceAvatar";
+
+const MAX_VISIBLE_PARTICIPANTS = 5;
 
 interface MultiplayerBarProps {
   localSessionId: string;
@@ -69,35 +72,21 @@ export function MultiplayerBar({ localSessionId }: MultiplayerBarProps) {
       </div>
 
       {/* Participants */}
-      <div className="flex items-center gap-1 flex-1">
-        {mpState.participants.slice(0, 5).map((p) => (
-          <div
+      <div className="flex items-center gap-1.5 flex-1">
+        {mpState.participants.slice(0, MAX_VISIBLE_PARTICIPANTS).map((p) => (
+          <PresenceAvatar
             key={p.user_id}
-            className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold"
-            style={{
-              background:
-                p.user_id === mpState.controlHolder
-                  ? "var(--t-accent)"
-                  : "var(--t-bg-card-avatar)",
-              color:
-                p.user_id === mpState.controlHolder
-                  ? "white"
-                  : "var(--t-text-muted)",
-              border:
-                p.user_id === mpState.controlHolder
-                  ? "1.5px solid var(--t-accent)"
-                  : "1.5px solid var(--t-border)",
-            }}
-            title={p.handle}
-          >
-            {handleInitials(p.handle)}
-          </div>
+            handle={p.handle}
+            size={24}
+            hasControl={p.user_id === mpState.controlHolder}
+          />
         ))}
-        {mpState.participants.length > 5 && (
-          <span className="text-xs" style={{ color: "var(--t-text-dim)" }}>
-            +{mpState.participants.length - 5}
-          </span>
-        )}
+        <AvatarOverflow
+          count={mpState.participants.length - MAX_VISIBLE_PARTICIPANTS}
+          size={24}
+          ringColor="var(--t-bg-terminal)"
+          overlap={false}
+        />
       </div>
 
       {/* Control actions — hidden when session has ended */}

--- a/src/components/terminal/ShareMenu.tsx
+++ b/src/components/terminal/ShareMenu.tsx
@@ -9,6 +9,7 @@ import { buildInviteLink } from "@/services/inviteCode";
 import { uninviteFromSession } from "@/services/teamService";
 import { guestCapFor, highestOwnerTier, inviteSessionOf, membersOfTeams, seatUsage, type InviteSession, type InviteTarget, type ShareTier } from "@/services/teamSharing";
 import { useDelayedUnmount } from "@/hooks/useDelayedUnmount";
+import { PresenceAvatar } from "@/components/shared/PresenceAvatar";
 import { InviteCodeField } from "./InviteCodeField";
 import { SpokenCodeRow } from "./SpokenCodeRow";
 import { PeopleTab } from "./PeopleTab";
@@ -478,7 +479,7 @@ function ActiveSharingView({
           {activeMp.participants.map((p) => (
             <div
               key={p.user_id}
-              className="flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px]"
+              className="flex items-center gap-1.5 pl-0.5 pr-2 py-0.5 rounded-full text-[10px]"
               style={{
                 background: p.user_id === activeMp.controlHolder
                   ? "color-mix(in srgb, var(--t-accent) 15%, transparent)"
@@ -486,9 +487,8 @@ function ActiveSharingView({
                 color: p.user_id === activeMp.controlHolder ? "var(--t-accent)" : "var(--t-text-secondary)",
                 border: "1px solid var(--t-border)",
               }}
-              title={p.user_id === activeMp.controlHolder ? t("terminal.share.hasControl") : undefined}
             >
-              {p.user_id === activeMp.controlHolder && <Icon icon="lucide:pencil" width={9} />}
+              <PresenceAvatar handle={p.handle} size={20} hasControl={p.user_id === activeMp.controlHolder} />
               {p.handle}
             </div>
           ))}

--- a/src/i18n/locales/en/shared.json
+++ b/src/i18n/locales/en/shared.json
@@ -47,6 +47,9 @@
       "participantCount_one": "{{count}} participant",
       "participantCount_other": "{{count}} participants"
     },
+    "presence": {
+      "hasControl": "Has control"
+    },
     "panel": {
       "saveState": {
         "dirty": "Editing...",

--- a/src/i18n/locales/en/terminal.json
+++ b/src/i18n/locales/en/terminal.json
@@ -141,7 +141,6 @@
       "guestsRatio_other": "{{participantCount}} of {{guestCap}} guests",
       "upgradeToTeams": "Upgrade to Teams",
       "upgradeToBusiness": "Upgrade to Business",
-      "hasControl": "Has control",
       "stopSharing": "Stop sharing",
       "inviteHasAccess": "Has access",
       "inviteSent": "Invited",

--- a/src/i18n/locales/fr/shared.json
+++ b/src/i18n/locales/fr/shared.json
@@ -47,6 +47,9 @@
       "participantCount_one": "{{count}} participant",
       "participantCount_other": "{{count}} participants"
     },
+    "presence": {
+      "hasControl": "A le contrôle"
+    },
     "panel": {
       "saveState": {
         "dirty": "Modification...",

--- a/src/i18n/locales/fr/terminal.json
+++ b/src/i18n/locales/fr/terminal.json
@@ -141,7 +141,6 @@
       "guestsRatio_other": "{{participantCount}} invités sur {{guestCap}}",
       "upgradeToTeams": "Passer à Teams",
       "upgradeToBusiness": "Passer à Business",
-      "hasControl": "A le contrôle",
       "stopSharing": "Arrêter le partage",
       "inviteHasAccess": "A déjà accès",
       "inviteSent": "Invitation envoyée",

--- a/src/i18n/locales/ru/shared.json
+++ b/src/i18n/locales/ru/shared.json
@@ -49,6 +49,9 @@
       "participantCount_many": "{{count}} участников",
       "participantCount_other": "{{count}} участников"
     },
+    "presence": {
+      "hasControl": "Управляет"
+    },
     "panel": {
       "saveState": {
         "dirty": "Редактирование...",

--- a/src/i18n/locales/ru/terminal.json
+++ b/src/i18n/locales/ru/terminal.json
@@ -151,7 +151,6 @@
       "guestsRatio_other": "{{participantCount}} / {{guestCap}} гостей",
       "upgradeToTeams": "Перейти на Teams",
       "upgradeToBusiness": "Перейти на Business",
-      "hasControl": "Управляет",
       "stopSharing": "Остановить совместный доступ",
       "inviteHasAccess": "Уже есть доступ",
       "inviteSent": "Приглашение отправлено",

--- a/src/i18n/locales/zh/shared.json
+++ b/src/i18n/locales/zh/shared.json
@@ -47,6 +47,9 @@
       "participantCount_one": "{{count}} 名参与者",
       "participantCount_other": "{{count}} 名参与者"
     },
+    "presence": {
+      "hasControl": "拥有控制权"
+    },
     "panel": {
       "saveState": {
         "dirty": "正在编辑...",

--- a/src/i18n/locales/zh/terminal.json
+++ b/src/i18n/locales/zh/terminal.json
@@ -141,7 +141,6 @@
       "guestsRatio_other": "{{participantCount}} / {{guestCap}} 位访客",
       "upgradeToTeams": "升级到 Teams",
       "upgradeToBusiness": "升级到 Business",
-      "hasControl": "拥有控制权",
       "stopSharing": "停止共享",
       "inviteHasAccess": "已有访问权限",
       "inviteSent": "已邀请",


### PR DESCRIPTION
Closes the bulk of #73.

## The problem

Presence was drawn three ways with no shared component:

- **MultiplayerBar** hand-rolled a circle. It used `handleInitials` but *not* `avatarColor`, so the same person showed a neutral fill here and their identity colour in the member list.
- **ShareMenu** drew name-only chips with a bare pencil glyph as its own control marker.
- **MembersPage** / **VaultHeader** each kept a private copy of the `relative` + `MiniAvatar` + `StatusDot` wrapper.

## What this does

`PresenceAvatar` owns the shared vocabulary: identity-coloured initials plus **online** (`StatusDot`) and **has-control** (accent ring + pencil badge). The two markers share a corner, so control suppresses the dot. All five surfaces call it.

`AvatarOverflow` replaces the `+N` chip, which existed in three shapes — a stacked chip in `AvatarStack`, a near-identical one in `VaultHeader`, and plain `+N` text in the bar.

`terminal.share.hasControl` moves to `shared.presence.hasControl` (en/fr/ru/zh) since the component composing the tooltip is no longer terminal-specific. Existing translations reused; no new strings.

## Second commit: the initials floor

`MiniAvatar` derived `fontSize` as `size * 0.32`, tuned by its 26-40px callers. Every avatar below 28px drew two-letter initials under 9px — smaller than the 10px the app uses for its smallest real text — and the bar inherited that when it stopped hard-coding 10px.

`Math.max(9, size * 0.32)` lifts the bar (7.68 to 9), the new 20px ShareMenu chips (6.4 to 9), the VaultHeader stack, and the 18px host-card avatar where 5.76px was mush. Sizes at or above 28px keep their derived value, so the member list and grid cards are untouched.

## Visible changes

- Bar avatars carry identity colour; the control holder keeps their colour and gains a ring plus badge instead of being repainted solid accent.
- ShareMenu chips gain a 20px avatar and grow ~8px taller.
- The member grid card's online dot is now derived (`size * 0.28`, floor 7): 9 to 11px at 40px. The 32px list row stays at 9px.
- VaultHeader's `+N` separator ring goes 2px to 1.5px, matching every other stack.

## Still open on #73

- Real avatar images. Everything is initials-only.
- `VaultHeader`'s compressed stack still signals online with a border ring and opacity rather than a dot; at -9px overlap a per-avatar dot collides with its neighbour.

## Tests

`PresenceAvatar.test.tsx` covers identity colour, the control ring and badge, dot suppression under control, the dot alone, and the tooltip fallback. `AvatarStack.test.tsx` gains the floor cases. `tsc --noEmit` clean; full suite 479 files / 3656 tests green.