### PR TITLE
chore(inbox): drop the InboxKind that nothing emits

### DIFF
--- a/src/stores/notificationStore.ts
+++ b/src/stores/notificationStore.ts
@@ -54,13 +54,15 @@ export interface HistoryEntry {
   dismissedAt: number;
 }
 
+/** Every kind here is actionable: the bell badge counts these entries, so a
+ *  confirmation with nothing to decide (control landing on a guest) is a toast
+ *  in `reconcileControlRequests`, not a kind. */
 export type InboxKind =
   | "invite"
   | "sessionShared"
   | "sessionInvite"
   | "sessionKnock"
   | "controlRequest"
-  | "controlGranted"
   | "awaitingKey";
 
 export interface InboxAction {


### PR DESCRIPTION
`"controlGranted"` sat in the `InboxKind` union with no producer and no consumer — the only other mentions in the repo are untracked plan docs under `specs/`.

It reads like a missing feature, but it isn't: the guest's confirmation that control landed on them is implemented as a 4s toast at the end of `reconcileControlRequests` (`notifications.inbox.control.granted`, deduped through `controlHeldSessions` so it fires once per grant). `teamInbox.test.ts` covers the dedupe, the re-fire on a second grant, and the host exclusion.

That is the right surface, so the comment now says why: the bell badge counts inbox entries, and a confirmation with nothing to decide would leave the badge nagging about something already done.

No runtime change — the union member is compile-time only and nothing branches on `InboxKind` (no switch, no `Record<InboxKind, …>`; `NotificationBell` renders rows generically).

`tsc --noEmit` clean; notification suites 3 files / 51 tests green.