### PR TITLE
feat(deeplink): https fallback in front of every route

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 # the whole worktree, which carries a multi-gigabyte cargo target/ and
 # node_modules and takes minutes before the first instruction runs.
 *
+!rust-toolchain.toml

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,7 @@
 # mount at run time, not baked into the image. Without this, every build tars
 # the whole worktree, which carries a multi-gigabyte cargo target/ and
 # node_modules and takes minutes before the first instruction runs.
+# Dockerfile.android:42 does COPY rust-toolchain.toml, so it has to survive
+# the blanket ignore below.
 *
 !rust-toolchain.toml

--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -45,9 +45,10 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" />
                 <data android:host="voltius.app" />
+                <data android:path="/open" />
+                <data android:path="/open/" />
                 
                 
-                <data android:pathPrefix="/open" />
                 
             </intent-filter>
             <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->

--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -23,12 +23,34 @@
                 <!-- AndroidTV support -->
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
-            <intent-filter>
+            <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
+            <intent-filter >
                 <action android:name="android.intent.action.VIEW" />
+                <!-- ChromeOS ARC++ uses a different action for deep links -->
+                <action android:name="org.chromium.arc.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="voltius" />
+                
+                
+                
+                
+                
             </intent-filter>
+            <intent-filter android:autoVerify="true" >
+                <action android:name="android.intent.action.VIEW" />
+                <!-- ChromeOS ARC++ uses a different action for deep links -->
+                <action android:name="org.chromium.arc.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" />
+                <data android:host="voltius.app" />
+                
+                
+                <data android:pathPrefix="/open" />
+                
+            </intent-filter>
+            <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
         </activity>
 
         <provider

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -59,7 +59,10 @@
       "desktop": {
         "schemes": ["voltius"]
       },
-      "mobile": [{ "scheme": ["voltius"] }]
+      "mobile": [
+        { "scheme": ["voltius"] },
+        { "scheme": ["https"], "host": "voltius.app", "pathPrefix": ["/open"] }
+      ]
     },
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDUxRDA4QkIxNzE3MDY4OEIKUldTTGFIQnhzWXZRVWNKR2w5LzRMS0cxZkF0RGs1KzdSUU1aVzdRM2lGZGozWjNHMkh6NXdvREwK",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -61,7 +61,7 @@
       },
       "mobile": [
         { "scheme": ["voltius"] },
-        { "scheme": ["https"], "host": "voltius.app", "pathPrefix": ["/open"] }
+        { "scheme": ["https"], "host": "voltius.app", "path": ["/open", "/open/"] }
       ]
     },
     "updater": {

--- a/src/components/terminal/ShareMenu.test.tsx
+++ b/src/components/terminal/ShareMenu.test.tsx
@@ -87,11 +87,11 @@ async function generateInviteLink() {
 test("generating an invite link copies the code to the clipboard and shows the copied state", async () => {
   await generateInviteLink();
 
-  await waitFor(() => expect(writeClipboard).toHaveBeenCalledWith("voltius://join?s=mp-1&t=tok-abc"));
+  await waitFor(() => expect(writeClipboard).toHaveBeenCalledWith("https://voltius.app/open#join?s=mp-1&t=tok-abc"));
   await waitFor(() => expect(screen.getByText("terminal.shared.copied")).toBeTruthy());
 
-  const input = screen.getByDisplayValue("voltius://join?s=mp-1&t=tok-abc") as HTMLInputElement;
-  expect(input.value).toBe("voltius://join?s=mp-1&t=tok-abc");
+  const input = screen.getByDisplayValue("https://voltius.app/open#join?s=mp-1&t=tok-abc") as HTMLInputElement;
+  expect(input.value).toBe("https://voltius.app/open#join?s=mp-1&t=tok-abc");
 });
 
 test("with only the host in participants, the waiting line renders and no lone self-chip appears", () => {
@@ -125,9 +125,9 @@ test("a rejecting writeClipboard leaves the share successful and the field uncop
 
   await generateInviteLink();
 
-  await waitFor(() => expect(writeClipboard).toHaveBeenCalledWith("voltius://join?s=mp-1&t=tok-abc"));
+  await waitFor(() => expect(writeClipboard).toHaveBeenCalledWith("https://voltius.app/open#join?s=mp-1&t=tok-abc"));
   // Share itself still succeeded: the code field is rendered, no error surfaced.
-  expect(screen.getByDisplayValue("voltius://join?s=mp-1&t=tok-abc")).toBeTruthy();
+  expect(screen.getByDisplayValue("https://voltius.app/open#join?s=mp-1&t=tok-abc")).toBeTruthy();
   expect(screen.queryByText("terminal.share.failedToGenerateLink")).toBeNull();
   expect(screen.getByText("common.action.copy")).toBeTruthy();
   expect(screen.queryByText("terminal.shared.copied")).toBeNull();

--- a/src/services/deepLinkScheme.test.ts
+++ b/src/services/deepLinkScheme.test.ts
@@ -9,9 +9,34 @@ test("the voltius scheme is declared for desktop and mobile", () => {
   const conf = JSON.parse(tauriConfSource);
   const deepLink = conf.plugins["deep-link"];
   expect(deepLink.desktop.schemes).toContain("voltius");
-  expect(deepLink.mobile).toEqual([{ scheme: ["voltius"] }]);
+  expect(deepLink.mobile).toContainEqual({ scheme: ["voltius"] });
 });
 
 test("the generated Android manifest carries the scheme", () => {
   expect(androidManifest).toContain('android:scheme="voltius"');
+});
+
+// The App Link entry must name exact paths, not a prefix: a prefix would let a
+// hostile subpath (e.g. /open/../something) ride the same verified association.
+// `scheme` must be spelled out as `https` only — the plugin's `AssociatedDomain`
+// defaults to `["https", "http"]`, and an `http` entry registers an insecure,
+// hijackable App Link.
+test("the voltius.app App Link is registered for https only, with exact paths", () => {
+  const conf = JSON.parse(tauriConfSource);
+  const deepLink = conf.plugins["deep-link"];
+  expect(deepLink.mobile).toContainEqual({
+    scheme: ["https"],
+    host: "voltius.app",
+    path: ["/open", "/open/"],
+  });
+  const webLinkEntries = deepLink.mobile.filter((entry: { host?: string }) => entry.host === "voltius.app");
+  expect(webLinkEntries).toHaveLength(1);
+  expect(webLinkEntries[0].scheme).not.toContain("http");
+});
+
+test("the generated Android manifest carries an autoVerify App Link filter for voltius.app", () => {
+  expect(androidManifest).toContain('android:autoVerify="true"');
+  expect(androidManifest).toContain('android:host="voltius.app"');
+  expect(androidManifest).toContain('android:path="/open"');
+  expect(androidManifest).not.toContain('android:scheme="http"');
 });

--- a/src/services/deepLinkUrl.test.ts
+++ b/src/services/deepLinkUrl.test.ts
@@ -1,8 +1,9 @@
 import { test, expect } from "vitest";
-import { intentKey, isConfirmIntent, isSilentIntent, parseDeepLink } from "./deepLinkUrl";
+import { intentKey, isConfirmIntent, isSilentIntent, parseDeepLink, buildDeepLink } from "./deepLinkUrl";
 
 const SESSION = "3f2504e0-4f89-11d3-9a0c-0305e82c3301";
 const TOKEN = "deadbeefdeadbeefdeadbeefdeadbeef";
+const USER = "9f1e2d3c-4b5a-6978-8765-43210fedcba9";
 
 test("parses a join link", () => {
   expect(parseDeepLink(`voltius://join?s=${SESSION}&t=${TOKEN}`)).toEqual({
@@ -42,8 +43,6 @@ test("rejects junk without throwing", () => {
   expect(parseDeepLink("")).toBeNull();
 });
 
-const USER = "9f1e2d3c-4b5a-6978-8765-43210fedcba9";
-
 test("parses a verified link", () => {
   expect(parseDeepLink(`voltius://verified?u=${USER}`)).toEqual({
     route: "verified",
@@ -80,4 +79,24 @@ test("intent keys match for the same link parsed twice", () => {
 test("join is a confirm route and verified is a silent one", () => {
   expect(isConfirmIntent(parseDeepLink(`voltius://join?s=${SESSION}&t=${TOKEN}`)!)).toBe(true);
   expect(isSilentIntent(parseDeepLink(`voltius://verified?u=${USER}`)!)).toBe(true);
+});
+
+test("builds a join link in both forms", () => {
+  const intent = { route: "join", sessionId: SESSION, token: TOKEN } as const;
+  expect(buildDeepLink(intent, "scheme")).toBe(`voltius://join?s=${SESSION}&t=${TOKEN}`);
+  expect(buildDeepLink(intent, "https")).toBe(
+    `https://voltius.app/open#join?s=${SESSION}&t=${TOKEN}`,
+  );
+});
+
+test("builds a verified link and defaults to the https form", () => {
+  const intent = { route: "verified", userId: USER } as const;
+  expect(buildDeepLink(intent)).toBe(`https://voltius.app/open#verified?u=${USER}`);
+  expect(buildDeepLink(intent, "scheme")).toBe(`voltius://verified?u=${USER}`);
+});
+
+test("percent-encodes parameters that need it", () => {
+  const built = buildDeepLink({ route: "join", sessionId: SESSION, token: "a+b" }, "scheme");
+  expect(built).toBe(`voltius://join?s=${SESSION}&t=a%2Bb`);
+  expect(parseDeepLink(built)).toMatchObject({ token: "a+b" });
 });

--- a/src/services/deepLinkUrl.test.ts
+++ b/src/services/deepLinkUrl.test.ts
@@ -100,3 +100,49 @@ test("percent-encodes parameters that need it", () => {
   expect(built).toBe(`voltius://join?s=${SESSION}&t=a%2Bb`);
   expect(parseDeepLink(built)).toMatchObject({ token: "a+b" });
 });
+
+test("parses the https form", () => {
+  expect(parseDeepLink(`https://voltius.app/open#join?s=${SESSION}&t=${TOKEN}`)).toEqual({
+    route: "join",
+    sessionId: SESSION,
+    token: TOKEN,
+  });
+  expect(parseDeepLink(`https://www.voltius.app/open/#verified?u=${USER}`)).toEqual({
+    route: "verified",
+    userId: USER,
+  });
+});
+
+test("every route round-trips through both forms", () => {
+  for (const intent of [
+    { route: "join", sessionId: SESSION, token: TOKEN },
+    { route: "verified", userId: USER },
+  ] as const) {
+    expect(parseDeepLink(buildDeepLink(intent, "https"))).toEqual(intent);
+    expect(parseDeepLink(buildDeepLink(intent, "scheme"))).toEqual(intent);
+  }
+});
+
+test("rejects an https link on a foreign host", () => {
+  expect(parseDeepLink(`https://evil.example/open#join?s=${SESSION}&t=${TOKEN}`)).toBeNull();
+  expect(parseDeepLink(`https://voltius.app.evil.example/open#join?s=${SESSION}&t=${TOKEN}`))
+    .toBeNull();
+});
+
+test("rejects an https link on the wrong path", () => {
+  expect(parseDeepLink(`https://voltius.app/blog#join?s=${SESSION}&t=${TOKEN}`)).toBeNull();
+});
+
+test("rejects an https link that carries the route in the query string", () => {
+  expect(parseDeepLink(`https://voltius.app/open?join&s=${SESSION}&t=${TOKEN}`)).toBeNull();
+});
+
+test("rejects an unknown route in the fragment", () => {
+  expect(parseDeepLink(`https://voltius.app/open#vault?s=${SESSION}`)).toBeNull();
+  expect(parseDeepLink("https://voltius.app/open#")).toBeNull();
+  expect(parseDeepLink("https://voltius.app/open")).toBeNull();
+});
+
+test("rejects the http form", () => {
+  expect(parseDeepLink(`http://voltius.app/open#join?s=${SESSION}&t=${TOKEN}`)).toBeNull();
+});

--- a/src/services/deepLinkUrl.ts
+++ b/src/services/deepLinkUrl.ts
@@ -26,23 +26,57 @@ type RouteOfClass<C extends TrustClass> = {
 export type ConfirmIntent = Extract<DeepLinkIntent, { route: RouteOfClass<"confirm"> }>;
 export type SilentIntent = Extract<DeepLinkIntent, { route: RouteOfClass<"silent"> }>;
 
-type RouteParsers = {
-  [K in Route]: (params: URLSearchParams) => Extract<DeepLinkIntent, { route: K }> | null;
+/**
+ * One codec per route, both directions declared together so the builder and the
+ * parser cannot drift as routes are added.
+ */
+type RouteCodec<K extends Route> = {
+  parse: (params: URLSearchParams) => Extract<DeepLinkIntent, { route: K }> | null;
+  params: (intent: Extract<DeepLinkIntent, { route: K }>) => Record<string, string>;
 };
 
-const ROUTES: RouteParsers = {
-  join: (params) => {
-    const sessionId = params.get("s") ?? "";
-    const token = params.get("t") ?? "";
-    if (!isSessionId(sessionId) || !token) return null;
-    return { route: "join", sessionId, token };
+const ROUTES: { [K in Route]: RouteCodec<K> } = {
+  join: {
+    parse: (params) => {
+      const sessionId = params.get("s") ?? "";
+      const token = params.get("t") ?? "";
+      if (!isSessionId(sessionId) || !token) return null;
+      return { route: "join", sessionId, token };
+    },
+    params: ({ sessionId, token }) => ({ s: sessionId, t: token }),
   },
-  verified: (params) => {
-    const userId = params.get("u") ?? "";
-    if (!isSessionId(userId)) return null;
-    return { route: "verified", userId };
+  verified: {
+    parse: (params) => {
+      const userId = params.get("u") ?? "";
+      if (!isSessionId(userId)) return null;
+      return { route: "verified", userId };
+    },
+    params: ({ userId }) => ({ u: userId }),
   },
 };
+
+export type LinkForm = "https" | "scheme";
+
+/** The landing site that bridges an `https` link back to the scheme. */
+export const WEB_ORIGIN = "https://voltius.app";
+const WEB_PATH = "/open";
+
+/**
+ * The one link builder. Every route goes through it; a new route means a new
+ * entry in `ROUTES`, never a second builder.
+ *
+ * The `https` form carries the route in the fragment, so a join token never
+ * reaches a web server log, a CDN, or a `Referer` header.
+ */
+export function buildDeepLink(intent: DeepLinkIntent, form: LinkForm = "https"): string {
+  // The codec is picked by the intent's own route, so the pairing is right by
+  // construction — TypeScript cannot prove that through the index.
+  const codec = ROUTES[intent.route] as RouteCodec<Route>;
+  const query = new URLSearchParams(codec.params(intent)).toString();
+  return form === "scheme"
+    ? `voltius://${intent.route}?${query}`
+    : `${WEB_ORIGIN}${WEB_PATH}#${intent.route}?${query}`;
+}
 
 export function parseDeepLink(url: string): DeepLinkIntent | null {
   let parsed: URL;
@@ -56,7 +90,7 @@ export function parseDeepLink(url: string): DeepLinkIntent | null {
   // on some platforms and `pathname` on others.
   const route = parsed.hostname || parsed.pathname.replace(/^\/+/, "");
   if (!isRoute(route)) return null;
-  return ROUTES[route](parsed.searchParams);
+  return ROUTES[route].parse(parsed.searchParams);
 }
 
 // Own-property only: `"toString" in TRUST` is true, and an inherited hit would

--- a/src/services/deepLinkUrl.ts
+++ b/src/services/deepLinkUrl.ts
@@ -78,6 +78,8 @@ export function buildDeepLink(intent: DeepLinkIntent, form: LinkForm = "https"):
     : `${WEB_ORIGIN}${WEB_PATH}#${intent.route}?${query}`;
 }
 
+const WEB_HOSTS = new Set(["voltius.app", "www.voltius.app"]);
+
 export function parseDeepLink(url: string): DeepLinkIntent | null {
   let parsed: URL;
   try {
@@ -85,12 +87,40 @@ export function parseDeepLink(url: string): DeepLinkIntent | null {
   } catch {
     return null;
   }
-  if (parsed.protocol !== "voltius:") return null;
-  // Custom schemes are not special-scheme URLs, so the route lands in `hostname`
-  // on some platforms and `pathname` on others.
-  const route = parsed.hostname || parsed.pathname.replace(/^\/+/, "");
+
+  if (parsed.protocol === "voltius:") {
+    // Custom schemes are not special-scheme URLs, so the route lands in
+    // `hostname` on some platforms and `pathname` on others.
+    const route = parsed.hostname || parsed.pathname.replace(/^\/+/, "");
+    return parseRoute(route, parsed.searchParams);
+  }
+
+  // The `https` fallback form. `http` is rejected: an App Link registered for
+  // cleartext would be hijackable on a hostile network.
+  if (
+    parsed.protocol === "https:" &&
+    WEB_HOSTS.has(parsed.hostname) &&
+    parsed.pathname.replace(/\/+$/, "") === WEB_PATH
+  ) {
+    return parseFragment(parsed.hash);
+  }
+
+  return null;
+}
+
+/** `#join?s=…&t=…` — the route, then its parameters, all after the hash. */
+function parseFragment(hash: string): DeepLinkIntent | null {
+  const body = hash.replace(/^#/, "");
+  if (!body) return null;
+  const queryAt = body.indexOf("?");
+  const route = queryAt === -1 ? body : body.slice(0, queryAt);
+  const params = new URLSearchParams(queryAt === -1 ? "" : body.slice(queryAt + 1));
+  return parseRoute(route, params);
+}
+
+function parseRoute(route: string, params: URLSearchParams): DeepLinkIntent | null {
   if (!isRoute(route)) return null;
-  return ROUTES[route].parse(parsed.searchParams);
+  return ROUTES[route].parse(params);
 }
 
 // Own-property only: `"toString" in TRUST` is true, and an inherited hit would

--- a/src/services/inviteCode.test.ts
+++ b/src/services/inviteCode.test.ts
@@ -48,7 +48,7 @@ test("parseInviteCode returns null when session id or token is empty", () => {
 
 test("buildInviteLink round-trips through parseInviteCode", () => {
   const link = buildInviteLink(SESSION, TOKEN);
-  expect(link.startsWith("voltius://join?")).toBe(true);
+  expect(link.startsWith("https://voltius.app/open#join?")).toBe(true);
   expect(parseInviteCode(link)).toEqual({ sessionId: SESSION, token: TOKEN });
 });
 
@@ -87,4 +87,22 @@ test("an uppercase-host voltius:// link returns null instead of colon-splitting"
 test("bare sessionId:token still parses when it is not a URL", () => {
   expect(parseInviteCode(`${SESSION}:${TOKEN}`)).toEqual({ sessionId: SESSION, token: TOKEN });
   expect(isInviteCode(`${SESSION}:${TOKEN}`)).toBe(true);
+});
+
+test("buildInviteLink emits the https form", () => {
+  expect(buildInviteLink(SESSION, TOKEN)).toBe(
+    `https://voltius.app/open#join?s=${SESSION}&t=${TOKEN}`,
+  );
+});
+
+test("parseInviteCode accepts all three shapes", () => {
+  const expected = { sessionId: SESSION, token: TOKEN };
+  expect(parseInviteCode(`${SESSION}:${TOKEN}`)).toEqual(expected);
+  expect(parseInviteCode(`voltius://join?s=${SESSION}&t=${TOKEN}`)).toEqual(expected);
+  expect(parseInviteCode(`https://voltius.app/open#join?s=${SESSION}&t=${TOKEN}`)).toEqual(expected);
+});
+
+test("parseInviteCode rejects an https link that is not an invite", () => {
+  expect(parseInviteCode("https://voltius.app/open#verified?u=" + SESSION)).toBeNull();
+  expect(parseInviteCode("https://example.com/open#join?s=x&t=y")).toBeNull();
 });

--- a/src/services/inviteCode.ts
+++ b/src/services/inviteCode.ts
@@ -1,4 +1,4 @@
-import { parseDeepLink } from "./deepLinkUrl";
+import { buildDeepLink, parseDeepLink } from "./deepLinkUrl";
 import { isSessionId } from "./sessionId";
 
 export { isSessionId };
@@ -8,8 +8,7 @@ export function buildInviteCode(sessionId: string, token: string): string {
 }
 
 export function buildInviteLink(sessionId: string, token: string): string {
-  const params = new URLSearchParams({ s: sessionId, t: token });
-  return `voltius://join?${params.toString()}`;
+  return buildDeepLink({ route: "join", sessionId, token });
 }
 
 export function parseInviteCode(code: string): { sessionId: string; token: string } | null {

--- a/src/services/resolveJoinInput.test.ts
+++ b/src/services/resolveJoinInput.test.ts
@@ -60,3 +60,10 @@ test("quick-connect shapes are not treated as invites", async () => {
   await expect(resolveJoinInput("host:22")).rejects.toThrow("common.error.inviteCodeMalformed");
   expect(redeemSessionCode).not.toHaveBeenCalled();
 });
+
+test("resolves an https invite link", async () => {
+  expect(await resolveJoinInput(`https://voltius.app/open#join?s=${SESSION}&t=faketoken`)).toEqual({
+    sessionId: SESSION,
+    inviteToken: "faketoken",
+  });
+});


### PR DESCRIPTION
Makes `https://voltius.app/open#<route>?<params>` the shareable form of every deep link, with the `voltius://` scheme reduced to an implementation detail behind it. Closes Part 1 of #144 except the Apple side.

## The client changes

Each route now declares its parser **and** its serializer together in one codec table, so `buildDeepLink(intent, form)` covers every route and the two directions cannot drift as routes are added. There is no second builder and no per-route builder.

`parseDeepLink` accepts the `https` form — host `voltius.app` or `www.voltius.app`, path `/open`, route and parameters read from the fragment — alongside the scheme form. `parseInviteCode`, `isInviteCode`, `resolveJoinInput` and `isJoinInput` inherit it with no edit of their own, and a bare `sessionId:token` still parses. `http` is rejected: an App Link registered over cleartext is hijackable on a hostile network.

`buildInviteLink` emits the `https` form. Clicking an old-form link still works everywhere — the scheme is unchanged, and the landing page hands the OS a `voltius://` URL. A client older than this release cannot *paste* an `https` link, which is why the page also shows the bare code.

## Android

`voltius.app/open` is registered as an App Link with `android:autoVerify="true"`, verified against the release signing certificate in the landing site's `assetlinks.json`. The paths are exact (`/open`, `/open/`) rather than a prefix — `pathPrefix` would also capture `/open-source` and `/openapi` and flash the app on URLs the client rejects.

The hand-written `voltius` scheme intent-filter is gone; the plugin's `build.rs` now generates both filters from `tauri.conf.json`, so the manifest no longer carries a duplicate. Desktop is unaffected: Windows and Linux have no universal-link equivalent, so the browser-to-scheme hop stays the mechanism there.

The `.dockerignore` line rides along because `Dockerfile.android:42` does `COPY rust-toolchain.toml` and the blanket `*` ignore made that fail — `scripts/android-build.sh` could not build its image at all without it.

## Depends on

VoltiusApp/web#10 must merge and deploy first. It serves `/open` and `/.well-known/assetlinks.json`; until then these links point at a 404.

## Verification

Full suite green: 479 files, 3672 tests. The App Link filter is genuine `build.rs` output, but **not yet verified on a device** — that needs `assetlinks.json` live plus a release-signed build, since a debug build cannot pass domain verification. The `adb shell am start` check is owed before the release that ships this.
