### PR TITLE
fix(deep-links): report plugin integrity failures as tampering, not a bad link

### DIFF
--- a/src/components/settings/sections/PluginsSection.tsx
+++ b/src/components/settings/sections/PluginsSection.tsx
@@ -7,8 +7,8 @@ import { usePluginRegistryStore } from "@/stores/pluginRegistryStore";
 import { useMarketplaceStore, type MarketplacePlugin } from "@/stores/marketplaceStore";
 import { useUIStore } from "@/stores/uiStore";
 import { useNotificationStore } from "@/stores/notificationStore";
-import { PluginHashMismatchError } from "@/plugins/integrity";
-import { satisfiesMinAppVersion, MinAppVersionError } from "@/plugins/version";
+import { pluginInstallErrorMessage } from "@/plugins/installErrors";
+import { satisfiesMinAppVersion } from "@/plugins/version";
 import { availableUpdate, availableSeededUpdate, addedPermissions } from "@/plugins/updates";
 import { mergeBrowseCatalog, seededActiveIds as computeSeededActiveIds } from "@/plugins/floor";
 import { useSeededTombstoneStore, loadSeededEntries, type SeededEntry } from "@/stores/seededTombstoneStore";
@@ -183,11 +183,7 @@ function usePluginInstaller() {
       source: { kind: "plugin", id: "system", name: "Voltius" },
       type: "toast",
       severity: "error",
-      message: e instanceof PluginHashMismatchError
-        ? t("settings.plugins.install.integrityFailed")
-        : e instanceof MinAppVersionError
-        ? t("settings.plugins.install.versionUnsupported", { version: e.required })
-        : t("settings.plugins.install.failed"),
+      message: pluginInstallErrorMessage(e, t, "settings.plugins.install.failed"),
       duration: 0,
     });
   };

--- a/src/components/settings/sections/PluginsSection.tsx
+++ b/src/components/settings/sections/PluginsSection.tsx
@@ -179,11 +179,12 @@ function usePluginInstaller() {
   const busy = new Set<string>([...installing, ...preparing]);
 
   const notifyError = (e: unknown) => {
+    const { key, params } = pluginInstallErrorMessage(e, "settings.plugins.install.failed");
     useNotificationStore.getState().addToast({
       source: { kind: "plugin", id: "system", name: "Voltius" },
       type: "toast",
       severity: "error",
-      message: pluginInstallErrorMessage(e, t, "settings.plugins.install.failed"),
+      message: t(key, params),
       duration: 0,
     });
   };

--- a/src/components/terminal/DeepLinkConfirmModal.test.tsx
+++ b/src/components/terminal/DeepLinkConfirmModal.test.tsx
@@ -3,6 +3,11 @@ import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { DeepLinkConfirmModal } from "./DeepLinkConfirmModal";
 import { useDeepLinkStore } from "@/stores/deepLinkStore";
+import { PluginHashMismatchError } from "@/plugins/integrity";
+import { MinAppVersionError } from "@/plugins/version";
+
+const acceptButton = (labelKey: string) =>
+  screen.getByText(labelKey).closest("button") as HTMLButtonElement;
 
 let teamConnections: Record<string, { sessionKeyBytes?: Uint8Array }> = {};
 let activeLocalSessionId: string | null = null;
@@ -171,9 +176,7 @@ test("an invite sheet names the handle and invites the resolved user", async () 
   teamConnections = { "local-1": { sessionKeyBytes: new Uint8Array(32) } };
   useDeepLinkStore.setState({ prompt: { route: "invite", handle: "kevin-p" } });
   render(<DeepLinkConfirmModal />);
-  await waitFor(() =>
-    expect((screen.getByText("terminal.share.deepLinkInviteAction").closest("button") as HTMLButtonElement).disabled).toBe(false),
-  );
+  await waitFor(() => expect(acceptButton("terminal.share.deepLinkInviteAction").disabled).toBe(false));
   await userEvent.click(screen.getByText("terminal.share.deepLinkInviteAction"));
   await waitFor(() =>
     expect(inviteMock).toHaveBeenCalledWith("local-1", expect.objectContaining({ user_id: "u1", handle: "kevin-p" })),
@@ -187,6 +190,7 @@ test("an invite link whose handle only fuzzily matches invites nobody", async ()
   useDeepLinkStore.setState({ prompt: { route: "invite", handle: "kevin-p" } });
   render(<DeepLinkConfirmModal />);
   await waitFor(() => expect(screen.getByText("terminal.share.deepLinkInviteUnknownUser")).toBeTruthy());
+  expect(acceptButton("terminal.share.deepLinkInviteAction").disabled).toBe(true);
   await userEvent.click(screen.getByText("terminal.share.deepLinkInviteAction"));
   expect(inviteMock).not.toHaveBeenCalled();
 });
@@ -198,6 +202,7 @@ test("an invite link with no shareable session names the handle but cannot be ac
   useDeepLinkStore.setState({ prompt: { route: "invite", handle: "kevin-p" } });
   render(<DeepLinkConfirmModal />);
   await waitFor(() => expect(screen.getByText("terminal.share.deepLinkInviteNoActiveSession")).toBeTruthy());
+  expect(acceptButton("terminal.share.deepLinkInviteAction").disabled).toBe(true);
   await userEvent.click(screen.getByText("terminal.share.deepLinkInviteAction"));
   expect(inviteMock).not.toHaveBeenCalled();
 });
@@ -223,6 +228,7 @@ test("a snippet-install link naming an entry the catalogue does not list cannot 
   useDeepLinkStore.setState({ prompt: { route: "snippet-install", entryId: "docker-cleanup" } });
   render(<DeepLinkConfirmModal />);
   await waitFor(() => expect(screen.getByText("snippets.deepLinkInstall.failed")).toBeTruthy());
+  expect(acceptButton("snippets.deepLinkInstall.action").disabled).toBe(true);
   await userEvent.click(screen.getByText("snippets.deepLinkInstall.action"));
   expect(installEntriesMock).not.toHaveBeenCalled();
 });
@@ -251,9 +257,38 @@ test("a plugin-install link naming a source this device does not have installs n
   useDeepLinkStore.setState({ prompt: { route: "plugin-install", pluginId: "docker", sourceId: "someone-elses" } });
   render(<DeepLinkConfirmModal />);
   await waitFor(() => expect(screen.getByText("settings.plugins.deepLinkInstall.failed")).toBeTruthy());
+  expect(acceptButton("settings.plugins.deepLinkInstall.action").disabled).toBe(true);
   await userEvent.click(screen.getByText("settings.plugins.deepLinkInstall.action"));
   expect(installPluginMock).not.toHaveBeenCalled();
   expect(fetchManifestMock).not.toHaveBeenCalled();
+});
+
+async function acceptPluginInstall() {
+  marketplaceSources = [{ id: "voltius", name: "Voltius Marketplace", enabled: true }];
+  marketplaceCatalog = [{ id: "docker", name: "Docker", author: "Voltius", version: "1.2.0", sourceId: "voltius" }];
+  useDeepLinkStore.setState({ prompt: { route: "plugin-install", pluginId: "docker", sourceId: "voltius" } });
+  render(<DeepLinkConfirmModal />);
+  await waitFor(() => expect(acceptButton("settings.plugins.deepLinkInstall.action").disabled).toBe(false));
+  await userEvent.click(screen.getByText("settings.plugins.deepLinkInstall.action"));
+}
+
+test("a plugin bundle failing its hash check is reported as tampering, not as a bad link", async () => {
+  installPluginMock.mockRejectedValue(new PluginHashMismatchError("aaa", "bbb"));
+  await acceptPluginInstall();
+  await waitFor(() => expect(screen.getByText("settings.plugins.install.integrityFailed")).toBeTruthy());
+  expect(screen.queryByText("settings.plugins.deepLinkInstall.failed")).toBeNull();
+});
+
+test("a plugin the running app is too old for names the version requirement", async () => {
+  installPluginMock.mockRejectedValue(new MinAppVersionError("2.0.0", "1.0.0"));
+  await acceptPluginInstall();
+  await waitFor(() => expect(screen.getByText("settings.plugins.install.versionUnsupported")).toBeTruthy());
+});
+
+test("any other plugin-install failure falls back to the deep-link message", async () => {
+  installPluginMock.mockRejectedValue(new Error("network down"));
+  await acceptPluginInstall();
+  await waitFor(() => expect(screen.getByText("settings.plugins.deepLinkInstall.failed")).toBeTruthy());
 });
 
 test("a plugin-install link naming a disabled source installs nothing", async () => {

--- a/src/components/terminal/DeepLinkConfirmModal.test.tsx
+++ b/src/components/terminal/DeepLinkConfirmModal.test.tsx
@@ -183,6 +183,19 @@ test("an invite sheet names the handle and invites the resolved user", async () 
   );
 });
 
+test("a re-render does not re-run load", async () => {
+  // `useTranslation` hands back a fresh `t` on every render, as the real hook does
+  // on a locale change. A `t` in the load effect's deps turns that into a second
+  // searchUsers — or, once the load's own setState re-renders, an unbounded loop.
+  searchUsersMock.mockResolvedValue([{ user_id: "u1", handle: "kevin-p", is_teammate: false }]);
+  activeLocalSessionId = "local-1";
+  teamConnections = { "local-1": { sessionKeyBytes: new Uint8Array(32) } };
+  useDeepLinkStore.setState({ prompt: { route: "invite", handle: "kevin-p" } });
+  render(<DeepLinkConfirmModal />);
+  await waitFor(() => expect(acceptButton("terminal.share.deepLinkInviteAction").disabled).toBe(false));
+  expect(searchUsersMock).toHaveBeenCalledTimes(1);
+});
+
 test("an invite link whose handle only fuzzily matches invites nobody", async () => {
   searchUsersMock.mockResolvedValue([{ user_id: "u1", handle: "kevin-porter", is_teammate: false }]);
   activeLocalSessionId = "local-1";

--- a/src/components/terminal/DeepLinkConfirmModal.tsx
+++ b/src/components/terminal/DeepLinkConfirmModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
 import { Icon } from "@iconify/react";
 import { Modal, ModalCard } from "@/components/shared/Modal";
 import { useDeepLinkStore } from "@/stores/deepLinkStore";
@@ -12,6 +13,11 @@ export function DeepLinkConfirmModal() {
   // failure's error and re-runs `load` against the new target. The key embeds a
   // join token, so it must never be logged.
   return prompt ? <ConfirmSheet key={intentKey(prompt)} intent={prompt} /> : null;
+}
+
+/** Module scope so the load effect can use it without taking it as a dependency. */
+function failureMessage(spec: ConfirmSpec<ConfirmRoute, unknown>, e: unknown, t: TFunction): string {
+  return spec.errorMessage?.(e, t, spec.errorKey) ?? t(spec.errorKey);
 }
 
 function ConfirmSheet({ intent }: { intent: ConfirmIntent }) {
@@ -36,10 +42,10 @@ function ConfirmSheet({ intent }: { intent: ConfirmIntent }) {
       .then((value) => {
         if (!cancelled) setLoaded(value);
       })
-      .catch(() => {
+      .catch((e: unknown) => {
         if (cancelled) return;
         setLoadFailed(true);
-        setError(t(spec.errorKey));
+        setError(failureMessage(spec, e, t));
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -61,8 +67,8 @@ function ConfirmSheet({ intent }: { intent: ConfirmIntent }) {
     try {
       await spec.accept(intent, loaded, t);
       dismissPrompt();
-    } catch {
-      setError(t(spec.errorKey));
+    } catch (e) {
+      setError(failureMessage(spec, e, t));
     } finally {
       setBusy(false);
     }

--- a/src/components/terminal/DeepLinkConfirmModal.tsx
+++ b/src/components/terminal/DeepLinkConfirmModal.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import type { TFunction } from "i18next";
 import { Icon } from "@iconify/react";
 import { Modal, ModalCard } from "@/components/shared/Modal";
 import { useDeepLinkStore } from "@/stores/deepLinkStore";
 import { intentKey, type ConfirmIntent } from "@/services/deepLinkUrl";
 import { CONFIRM_SPECS, type ConfirmRoute, type ConfirmSpec } from "./deepLinkConfirmSpecs";
+import type { TranslatableMessage } from "@/plugins/installErrors";
 
 export function DeepLinkConfirmModal() {
   const prompt = useDeepLinkStore((s) => s.prompt);
@@ -15,9 +15,8 @@ export function DeepLinkConfirmModal() {
   return prompt ? <ConfirmSheet key={intentKey(prompt)} intent={prompt} /> : null;
 }
 
-/** Module scope so the load effect can use it without taking it as a dependency. */
-function failureMessage(spec: ConfirmSpec<ConfirmRoute, unknown>, e: unknown, t: TFunction): string {
-  return spec.errorMessage?.(e, t, spec.errorKey) ?? t(spec.errorKey);
+function failureMessage(spec: ConfirmSpec<ConfirmRoute, unknown>, e: unknown): TranslatableMessage {
+  return spec.errorMessage?.(e, spec.errorKey) ?? { key: spec.errorKey };
 }
 
 function ConfirmSheet({ intent }: { intent: ConfirmIntent }) {
@@ -32,11 +31,17 @@ function ConfirmSheet({ intent }: { intent: ConfirmIntent }) {
   const [loading, setLoading] = useState(!!spec.load);
   const [loadFailed, setLoadFailed] = useState(false);
   const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<TranslatableMessage | null>(null);
 
+  // `t` is deliberately absent from the deps: it is a new function on every
+  // locale change, and re-running `load` would fetch a second time without
+  // resetting the state below, leaving accept live over a stale result.
   useEffect(() => {
     if (!spec.load) return;
     let cancelled = false;
+    setLoading(true);
+    setLoadFailed(false);
+    setError(null);
     void spec
       .load(intent)
       .then((value) => {
@@ -45,7 +50,7 @@ function ConfirmSheet({ intent }: { intent: ConfirmIntent }) {
       .catch((e: unknown) => {
         if (cancelled) return;
         setLoadFailed(true);
-        setError(failureMessage(spec, e, t));
+        setError(failureMessage(spec, e));
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -53,7 +58,7 @@ function ConfirmSheet({ intent }: { intent: ConfirmIntent }) {
     return () => {
       cancelled = true;
     };
-  }, [intent, spec, t]);
+  }, [intent, spec]);
 
   const details = spec.details(intent, loaded, t);
   // A sheet that could not name what it is about must never be acceptable. A
@@ -68,7 +73,7 @@ function ConfirmSheet({ intent }: { intent: ConfirmIntent }) {
       await spec.accept(intent, loaded, t);
       dismissPrompt();
     } catch (e) {
-      setError(failureMessage(spec, e, t));
+      setError(failureMessage(spec, e));
     } finally {
       setBusy(false);
     }
@@ -90,7 +95,7 @@ function ConfirmSheet({ intent }: { intent: ConfirmIntent }) {
         {loading && <p className="text-xs text-(--t-text-dim)">{t("common.state.loading")}</p>}
         {spec.extra?.(loaded, t)}
         {details.note && <p className="text-xs text-(--t-text-dim)">{details.note}</p>}
-        {error && <p className="text-xs text-(--t-status-error)">{error}</p>}
+        {error && <p className="text-xs text-(--t-status-error)">{t(error.key, error.params)}</p>}
         <div className="flex gap-2 justify-end">
           <button
             onClick={dismissPrompt}

--- a/src/components/terminal/deepLinkConfirmSpecs.tsx
+++ b/src/components/terminal/deepLinkConfirmSpecs.tsx
@@ -13,7 +13,7 @@ import type { CatalogEntry } from "@/services/snippetCatalog";
 import { useVaultStore } from "@/stores/vaultStore";
 import { PluginPermissionList } from "@/components/settings/sections/PluginPermissionList";
 import { useMarketplaceStore, type MarketplacePlugin } from "@/stores/marketplaceStore";
-import { pluginInstallErrorMessage } from "@/plugins/installErrors";
+import { pluginInstallErrorMessage, type TranslatableMessage } from "@/plugins/installErrors";
 import type { PluginManifest } from "@/plugins/api";
 
 export type ConfirmRoute = ConfirmIntent["route"];
@@ -32,10 +32,11 @@ export interface ConfirmSpec<K extends ConfirmRoute, L> {
   errorKey: string;
   /**
    * Distinguishes failures that mean something specific to the user from the
-   * generic `errorKey`, which it receives as the fallback. Absent means every
-   * failure reads the same.
+   * generic `errorKey`, which it receives as the fallback. Returns a key rather
+   * than translated text so the sheet can hold it across a locale change.
+   * Absent means every failure reads the same.
    */
-  errorMessage?: (e: unknown, t: TFunction, fallbackKey: string) => string;
+  errorMessage?: (e: unknown, fallbackKey: string) => TranslatableMessage;
   /**
    * Resolves what the link names. Omitted where the intent already says
    * everything, so such a sheet paints complete in its first frame rather than

--- a/src/components/terminal/deepLinkConfirmSpecs.tsx
+++ b/src/components/terminal/deepLinkConfirmSpecs.tsx
@@ -13,6 +13,7 @@ import type { CatalogEntry } from "@/services/snippetCatalog";
 import { useVaultStore } from "@/stores/vaultStore";
 import { PluginPermissionList } from "@/components/settings/sections/PluginPermissionList";
 import { useMarketplaceStore, type MarketplacePlugin } from "@/stores/marketplaceStore";
+import { pluginInstallErrorMessage } from "@/plugins/installErrors";
 import type { PluginManifest } from "@/plugins/api";
 
 export type ConfirmRoute = ConfirmIntent["route"];
@@ -29,6 +30,12 @@ export interface ConfirmSpec<K extends ConfirmRoute, L> {
   icon: string;
   acceptLabelKey: string;
   errorKey: string;
+  /**
+   * Distinguishes failures that mean something specific to the user from the
+   * generic `errorKey`, which it receives as the fallback. Absent means every
+   * failure reads the same.
+   */
+  errorMessage?: (e: unknown, t: TFunction, fallbackKey: string) => string;
   /**
    * Resolves what the link names. Omitted where the intent already says
    * everything, so such a sheet paints complete in its first frame rather than
@@ -172,6 +179,9 @@ export const CONFIRM_SPECS: { [K in ConfirmRoute]: ConfirmSpec<K, ConfirmLoad[K]
     icon: "lucide:puzzle",
     acceptLabelKey: "settings.plugins.deepLinkInstall.action",
     errorKey: "settings.plugins.deepLinkInstall.failed",
+    // An integrity mismatch is the user's only tamper signal, so it must not be
+    // reported as a link that did not work.
+    errorMessage: pluginInstallErrorMessage,
     load: async ({ pluginId, sourceId }) => {
       await useMarketplaceStore.getState().loadSources();
       const source = useMarketplaceStore

--- a/src/plugins/installErrors.ts
+++ b/src/plugins/installErrors.ts
@@ -1,6 +1,11 @@
-import type { TFunction } from "i18next";
 import { PluginHashMismatchError } from "./integrity";
 import { MinAppVersionError } from "./version";
+
+/** A message named by its i18n key, so a caller can hold one across a locale change. */
+export interface TranslatableMessage {
+  key: string;
+  params?: Record<string, string>;
+}
 
 /**
  * The user-facing message for a failed plugin install, matched on the error's
@@ -8,9 +13,9 @@ import { MinAppVersionError } from "./version";
  * so it must never collapse into whatever generic failure the caller shows;
  * `fallbackKey` covers everything else.
  */
-export function pluginInstallErrorMessage(e: unknown, t: TFunction, fallbackKey: string): string {
-  if (e instanceof PluginHashMismatchError) return t("settings.plugins.install.integrityFailed");
+export function pluginInstallErrorMessage(e: unknown, fallbackKey: string): TranslatableMessage {
+  if (e instanceof PluginHashMismatchError) return { key: "settings.plugins.install.integrityFailed" };
   if (e instanceof MinAppVersionError)
-    return t("settings.plugins.install.versionUnsupported", { version: e.required });
-  return t(fallbackKey);
+    return { key: "settings.plugins.install.versionUnsupported", params: { version: e.required } };
+  return { key: fallbackKey };
 }

--- a/src/plugins/installErrors.ts
+++ b/src/plugins/installErrors.ts
@@ -1,0 +1,16 @@
+import type { TFunction } from "i18next";
+import { PluginHashMismatchError } from "./integrity";
+import { MinAppVersionError } from "./version";
+
+/**
+ * The user-facing message for a failed plugin install, matched on the error's
+ * type rather than its text. A hash mismatch is the user's only tamper signal,
+ * so it must never collapse into whatever generic failure the caller shows;
+ * `fallbackKey` covers everything else.
+ */
+export function pluginInstallErrorMessage(e: unknown, t: TFunction, fallbackKey: string): string {
+  if (e instanceof PluginHashMismatchError) return t("settings.plugins.install.integrityFailed");
+  if (e instanceof MinAppVersionError)
+    return t("settings.plugins.install.versionUnsupported", { version: e.required });
+  return t(fallbackKey);
+}

--- a/src/services/deepLink.test.ts
+++ b/src/services/deepLink.test.ts
@@ -7,6 +7,10 @@ const SESSION = "3f2504e0-4f89-11d3-9a0c-0305e82c3301";
 const OTHER = "11111111-2222-3333-4444-555555555555";
 const link = (s: string) => `voltius://join?s=${s}&t=tok`;
 
+/** Waits out the store's promote hold, which keeps a queued sheet off the screen
+ *  long enough that a double-click cannot carry into it. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 350));
+
 beforeEach(() => {
   useDeepLinkStore.setState({ ready: false, queue: [], prompt: null });
   useDeepLinkStore.getState().setUnpromptedHandler(null);
@@ -47,21 +51,34 @@ test("a duplicate arriving before ready is dropped", () => {
   expect(useDeepLinkStore.getState().queue).toHaveLength(1);
 });
 
-test("dismissing then redelivering the same link prompts again", () => {
+test("dismissing then redelivering the same link prompts again", async () => {
   useDeepLinkStore.getState().setReady(true);
   handleDeepLink(link(SESSION));
   useDeepLinkStore.getState().dismissPrompt();
   handleDeepLink(link(SESSION));
+  await settle();
   expect(useDeepLinkStore.getState().prompt).toMatchObject({ route: "join", sessionId: SESSION });
 });
 
-test("two different links queued before ready are both delivered, in order", () => {
+test("two different links queued before ready are both delivered, in order", async () => {
   handleDeepLink(link(SESSION));
   handleDeepLink(link(OTHER));
   useDeepLinkStore.getState().setReady(true);
   expect(useDeepLinkStore.getState().prompt).toMatchObject({ route: "join", sessionId: SESSION });
   useDeepLinkStore.getState().dismissPrompt();
+  await settle();
   expect(useDeepLinkStore.getState().prompt).toMatchObject({ route: "join", sessionId: OTHER });
+});
+
+test("the sheet behind the one just dismissed is not promoted into the same click", () => {
+  useDeepLinkStore.getState().setReady(true);
+  handleDeepLink(link(SESSION));
+  handleDeepLink(link(OTHER));
+  useDeepLinkStore.getState().dismissPrompt();
+  // Still queued, not on screen: a double-click's second half has nothing to hit.
+  const s = useDeepLinkStore.getState();
+  expect(s.prompt).toBeNull();
+  expect(s.queue).toHaveLength(1);
 });
 
 test("an unknown route is dropped without prompting or throwing", () => {
@@ -78,7 +95,7 @@ test("dropping a link never logs the query string", () => {
   warn.mockRestore();
 });
 
-test("a different link while a prompt is on screen queues behind it", () => {
+test("a different link while a prompt is on screen queues behind it", async () => {
   useDeepLinkStore.getState().setReady(true);
   handleDeepLink(link(SESSION));
   const shown = useDeepLinkStore.getState().prompt;
@@ -87,6 +104,7 @@ test("a different link while a prompt is on screen queues behind it", () => {
   expect(s.prompt).toBe(shown);
   expect(s.queue).toHaveLength(1);
   s.dismissPrompt();
+  await settle();
   expect(useDeepLinkStore.getState().prompt).toMatchObject({ route: "join", sessionId: OTHER });
 });
 

--- a/src/stores/deepLinkStore.ts
+++ b/src/stores/deepLinkStore.ts
@@ -26,6 +26,17 @@ let unpromptedHandler: ((intent: UnpromptedIntent) => void) | null = null;
 let lastUnprompted: { key: string; at: number } | null = null;
 const UNPROMPTED_ECHO_WINDOW_MS = 5000;
 
+/**
+ * A sheet dismissed by a click leaves the second half of a double-click still
+ * coming. The next queued sheet paints its accept button at the same screen
+ * position, and a route with no `load` — `join` — is live in its first frame, so
+ * promoting in the same tick lets one double-click confirm two different links.
+ * Only a *queued* sheet waits; a link arriving on its own still prompts at once.
+ */
+const CONFIRM_PROMOTE_DELAY_MS = 300;
+let confirmHeldUntil = 0;
+let promoteTimer: ReturnType<typeof setTimeout> | null = null;
+
 interface DeepLinkStore {
   ready: boolean;
   queue: DeepLinkIntent[];
@@ -42,9 +53,14 @@ export const useDeepLinkStore = create<DeepLinkStore>((set, get) => ({
   queue: [],
   prompt: null,
 
+  // Installing a handler marks a fresh app lifecycle, so every piece of
+  // module-level scheduling state is dropped with it.
   setUnpromptedHandler: (fn) => {
     unpromptedHandler = fn;
     lastUnprompted = null;
+    confirmHeldUntil = 0;
+    if (promoteTimer) clearTimeout(promoteTimer);
+    promoteTimer = null;
   },
 
   setReady: (ready) => {
@@ -67,6 +83,7 @@ export const useDeepLinkStore = create<DeepLinkStore>((set, get) => ({
 
   // Surfaces a link queued behind the prompt, rather than losing it.
   dismissPrompt: () => {
+    confirmHeldUntil = Date.now() + CONFIRM_PROMOTE_DELAY_MS;
     set({ prompt: null });
     drain();
   },
@@ -84,10 +101,15 @@ function drain(): void {
     for (;;) {
       const { ready, queue, prompt } = useDeepLinkStore.getState();
       if (!ready) return;
-      // A confirm intent needs a free prompt slot; everything else is handled
-      // where it sits, so an unprompted link never waits behind an open sheet.
-      const intent = queue.find((queued) => !prompt || !isConfirmIntent(queued));
-      if (!intent) return;
+      // A confirm intent needs a free prompt slot and a settled one before it;
+      // everything else is handled where it sits, so an unprompted link never
+      // waits behind an open sheet.
+      const held = Date.now() < confirmHeldUntil;
+      const intent = queue.find((queued) => !isConfirmIntent(queued) || (!prompt && !held));
+      if (!intent) {
+        if (held && queue.some(isConfirmIntent)) schedulePromotion();
+        return;
+      }
       useDeepLinkStore.setState({ queue: queue.filter((queued) => queued !== intent) });
 
       if (isUnpromptedIntent(intent)) {
@@ -101,6 +123,18 @@ function drain(): void {
   } finally {
     draining = false;
   }
+}
+
+/** Re-drains once the hold expires, so a queued sheet is delayed, never dropped. */
+function schedulePromotion(): void {
+  if (promoteTimer) return;
+  promoteTimer = setTimeout(
+    () => {
+      promoteTimer = null;
+      drain();
+    },
+    Math.max(0, confirmHeldUntil - Date.now()),
+  );
 }
 
 function dispatchUnprompted(intent: UnpromptedIntent): void {


### PR DESCRIPTION
Follow-ups 1 and 3 from the #150 confirm-routes review. Part of #144.

## An integrity mismatch read as "bad link"

A plugin-install confirm sheet surfaced every accept failure as the generic `settings.plugins.deepLinkInstall.failed`, so `PluginHashMismatchError` and `MinAppVersionError` were misreported. A hash mismatch is the user's only tamper signal, and it must not look like a link that simply did not work. The settings click path already distinguished both, so the mapping now exists once:

- New `src/plugins/installErrors.ts` — `pluginInstallErrorMessage(e, t, fallbackKey)`, matched on error type rather than message, per the project rule.
- `ConfirmSpec` gains `errorMessage?: (e, t, fallbackKey) => string`; `plugin-install` sets it to `pluginInstallErrorMessage` directly.
- `DeepLinkConfirmModal`'s two `setError` sites both go through a module-scope `failureMessage(spec, e, t)` — module scope so the `load` effect gains no dependency.
- `PluginsSection.notifyError`'s inline three-way ternary collapses onto the shared helper.

The review proposed `errorKeyFor?: (e) => string`. A bare key cannot carry `versionUnsupported`'s `{version}` interpolation, so the seam takes `t` and returns the message; passing the fallback key in means `errorKey` is still stated only once.

## Two tests that could not fail

Both `invite` negative tests clicked an accept button that was already `disabled`, so their "invites nobody" assertions were vacuous. Explicit `.disabled` assertions added — and to the snippet and plugin negative tests, which had the identical hole.

New coverage: hash mismatch, min-version, and generic failure each produce their own message in the sheet.

## Verification

- `node ./node_modules/typescript/bin/tsc --noEmit -p tsconfig.json` — exit 0, no output.
- Full `CI=true pnpm vitest run` — `1 failed | 3713 passed`. The failure is `tests/pluginBundleBuild.test.ts` timing out at 5000ms under load; it passes 8/8 run alone. Known flake on pristine `dev`, unrelated to this diff.

Not covered: the sheets have still never been opened in a running app.

---

## Added after review: follow-ups 2 and 4

### A locale change re-ran the sheet's `load`

The sheet stored its error already translated, which forced `t` into the load effect's dependencies. `t` is a new function on every locale change, so changing language over an open sheet ran `load` again — a second `searchUsers` or manifest fetch — without resetting `loading` or `loadFailed`, leaving accept enabled over a stale result.

Errors are now held as a key plus parameters and translated at render, so `t` leaves the deps. `pluginInstallErrorMessage` returns that descriptor rather than a string, which is also what lets it carry `versionUnsupported`'s `version`. The effect also resets its own state, since a redelivered link can change the intent's identity without remounting the sheet. A test pins the call count: it was 2, it is now 1.

### A double-click could cross two sheets

`dismissPrompt` promoted the next queued intent in the same tick, and `join` has no `load`, so its accept button was live in the first frame at the same screen position as the button just clicked — a double-click on Install could land its second half on Join.

Queue promotion now waits 300ms, and only a sheet arriving behind another pays it: a link that arrives on its own still prompts immediately, and unprompted intents are untouched. The delay was chosen over arming every sheet's accept button late, so a single link stays instant.

Re-verified: `tsc --noEmit` exit 0 with no output; full `CI=true pnpm vitest run` = `1 failed | 3715 passed`, the failure again being `tests/pluginBundleBuild.test.ts` at 5000ms, which passes 8/8 alone.
