### PR TITLE
fix(deep-link): install snippets into the vault the sheet disclosed

### DIFF
--- a/src/components/terminal/DeepLinkConfirmModal.test.tsx
+++ b/src/components/terminal/DeepLinkConfirmModal.test.tsx
@@ -31,8 +31,12 @@ vi.mock("@/services/snippetCatalogInstall", () => ({
   installCatalogEntries: (...args: unknown[]) => installEntriesMock(...args),
 }));
 
+let vaultState = {
+  selectedVaultIds: ["team-a"],
+  vaults: [{ id: "team-a", name: "Ops" }, { id: "team-b", name: "Staging" }],
+};
 vi.mock("@/stores/vaultStore", () => ({
-  useVaultStore: { getState: () => ({ selectedVaultIds: ["team-a"], vaults: [{ id: "team-a", name: "Ops" }] }) },
+  useVaultStore: { getState: () => vaultState },
 }));
 
 const joinMock = vi.fn(async (..._args: unknown[]) => "local-1");
@@ -85,6 +89,10 @@ beforeEach(() => {
   teamConnections = {};
   activeLocalSessionId = null;
   snippetEntries = [];
+  vaultState = {
+    selectedVaultIds: ["team-a"],
+    vaults: [{ id: "team-a", name: "Ops" }, { id: "team-b", name: "Staging" }],
+  };
   fetchSnippetCatalogMock.mockClear();
   installEntriesMock.mockClear().mockResolvedValue({ imported: 1, errors: 0 });
   marketplaceSources = [];
@@ -234,6 +242,21 @@ test("a snippet-install sheet names the entry and its destination vault before i
       "team-a",
     ),
   );
+});
+
+test("a snippet-install writes to the vault the sheet disclosed, not the one selected at accept", async () => {
+  snippetEntries = [{ id: "docker-cleanup", kind: "pack", name: "Docker cleanup", author: "kevin", snippets: [{}] }];
+  useDeepLinkStore.setState({ prompt: { route: "snippet-install", entryId: "docker-cleanup" } });
+  render(<DeepLinkConfirmModal />);
+  await waitFor(() => expect(screen.getByText("snippets.deepLinkInstall.destination")).toBeTruthy());
+
+  // The sheet named "Ops" while it was open; selecting another vault behind it
+  // must not silently redirect the write it disclosed.
+  vaultState = { ...vaultState, selectedVaultIds: ["team-b"] };
+  await userEvent.click(screen.getByText("snippets.deepLinkInstall.action"));
+
+  await waitFor(() => expect(installEntriesMock).toHaveBeenCalled());
+  expect(installEntriesMock.mock.calls[0][1]).toBe("team-a");
 });
 
 test("a snippet-install link naming an entry the catalogue does not list cannot be accepted", async () => {

--- a/src/components/terminal/deepLinkConfirmSpecs.tsx
+++ b/src/components/terminal/deepLinkConfirmSpecs.tsx
@@ -65,11 +65,19 @@ export interface PluginInstallLoad {
   sourceName: string;
 }
 
+export interface SnippetInstallLoad {
+  entry: CatalogEntry;
+  /** Resolved with the entry, not again at accept: the vault the sheet names is
+   *  then provably the vault written to, however the selection moves while the
+   *  sheet is open. */
+  vault: { id: string; name: string };
+}
+
 /** What each route's `load` produces. `void` for a route with nothing to fetch. */
 export interface ConfirmLoad {
   join: void;
   invite: InviteLoad;
-  "snippet-install": CatalogEntry;
+  "snippet-install": SnippetInstallLoad;
   "plugin-install": PluginInstallLoad;
 }
 
@@ -82,11 +90,6 @@ function shareableSessionId(): string | null {
   const id = useSessionStore.getState().activeSessionId;
   if (!id) return null;
   return useTeamSessionStore.getState().connections[id]?.sessionKeyBytes ? id : null;
-}
-
-/** The vault an install lands in — read directly since the spec is not a component. */
-function installTargetVault(): { id: string; name: string } {
-  return resolveInstallVault(useVaultStore.getState());
 }
 
 export const CONFIRM_SPECS: { [K in ConfirmRoute]: ConfirmSpec<K, ConfirmLoad[K]> } = {
@@ -149,7 +152,10 @@ export const CONFIRM_SPECS: { [K in ConfirmRoute]: ConfirmSpec<K, ConfirmLoad[K]
       // Rejecting here is what leaves accept dead: a sheet that cannot name what
       // it would install must never be acceptable.
       if (!entry) throw new Error("snippet catalogue entry not found");
-      return entry;
+      // Read here rather than in `details` and again in `accept` — the store is
+      // read directly since the spec is not a component, so two reads are two
+      // answers whenever the selection moves while the sheet is open.
+      return { entry, vault: resolveInstallVault(useVaultStore.getState()) };
     },
     details: (_intent, loaded, t) => ({
       title: t("snippets.deepLinkInstall.title"),
@@ -158,22 +164,22 @@ export const CONFIRM_SPECS: { [K in ConfirmRoute]: ConfirmSpec<K, ConfirmLoad[K]
         ? // Named on purpose: the install lands in whichever vault is selected, and a
           // link the user did not author should not quietly write into one they were
           // not thinking about.
-          t("snippets.deepLinkInstall.destination", { vault: installTargetVault().name })
+          t("snippets.deepLinkInstall.destination", { vault: loaded.vault.name })
         : undefined,
     }),
     extra: (loaded, t) =>
       loaded ? (
         <p className="text-sm text-(--t-text-bright)">
           {t("snippets.deepLinkInstall.summary", {
-            name: loaded.name,
-            author: loaded.author ?? t("snippets.deepLinkInstall.unknownAuthor"),
-            count: loaded.snippets.length,
+            name: loaded.entry.name,
+            author: loaded.entry.author ?? t("snippets.deepLinkInstall.unknownAuthor"),
+            count: loaded.entry.snippets.length,
           })}
         </p>
       ) : null,
     accept: async (_intent, loaded) => {
       if (!loaded) return;
-      await installCatalogEntries([{ entry: loaded }], installTargetVault().id);
+      await installCatalogEntries([{ entry: loaded.entry }], loaded.vault.id);
     },
   },
   "plugin-install": {


### PR DESCRIPTION
Follow-up 2 of 3 from the #150/#152 review (follow-up 1 shipped in #153).

## The bug

`src/components/terminal/deepLinkConfirmSpecs.tsx` resolved the destination vault twice for one snippet-install sheet: once in `details` for the "installs into <vault>" note, and again inside `accept`. The spec is not a component, so both reads go straight to `useVaultStore.getState()` — two reads, two answers. Change the selected vault while the sheet is open and the write lands somewhere the sheet never named.

## The fix

`load` resolves the vault alongside the catalogue entry and returns both (`SnippetInstallLoad { entry, vault }`); the note and `accept` read that one captured value. `installTargetVault()` had a single call site afterwards and is gone.

Practically unreachable today — the sheet is modal — but the disclosure is the whole point of that note, and it should be authoritative rather than incidentally correct.

## Tests

`DeepLinkConfirmModal.test.tsx`: the vault mock became mutable (reset per test), and a new test moves the selection from `team-a` to `team-b` after the sheet has painted its destination, then accepts and asserts `installCatalogEntries` still receives `team-a`. Fails on `dev` with `expected 'team-b' to be 'team-a'`, passes here.

## Verification

- Real typecheck `node ./node_modules/typescript/bin/tsc --noEmit -p tsconfig.json`: exit 0, no output.
- Full `CI=true vitest run`: 479/480 files, 3719/3720 tests. Sole failure `tests/pluginBundleBuild.test.ts` (35057ms, 5000ms budget) — the documented contention flake. Proven not mine: it passes 8/8 on pristine `origin/dev` (detached worktree) and 8/8 twice on this branch run alone. The box is carrying a stray `vite` process at ~88% CPU, load average 4.75 on 2 cores.