### PR TITLE
feat(accounts): name the instance an account belongs to

### DIFF
--- a/src/components/layout/AuthPage.tsx
+++ b/src/components/layout/AuthPage.tsx
@@ -11,6 +11,8 @@ import {
 import { useNotificationStore } from "@/stores/notificationStore";
 import { VaultUnreadableError } from "@/services/vaultErrors";
 import { VaultBackups } from "@/components/shared/VaultBackups";
+import { ServerUrlField } from "@/components/shared/ServerUrlField";
+import { lastServerUrl } from "@/utils/serverInstance";
 
 
 type View = "home" | "cloud";
@@ -27,8 +29,6 @@ interface Props {
 /** Which way the vault turned out to be unreadable — they offer different exits. */
 type Unreadable = "no-password" | "wrong-key";
 
-const DEFAULT_SERVER = "https://api.voltius.app";
-
 export default function AuthPage({ isLocked, vaultUnreadable, onReady }: Props) {
   const { t } = useTranslation();
   const [view, setView] = useState<View>("home");
@@ -42,8 +42,7 @@ export default function AuthPage({ isLocked, vaultUnreadable, onReady }: Props) 
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
   const [email, setEmail] = useState("");
-  const [serverUrl, setServerUrl] = useState(DEFAULT_SERVER);
-  const [showServerUrl, setShowServerUrl] = useState(false);
+  const [serverUrl, setServerUrl] = useState(lastServerUrl);
   const addToast = useNotificationStore((s) => s.addToast);
 
   const reset = (v: View, mode?: CloudMode) => {
@@ -227,17 +226,7 @@ export default function AuthPage({ isLocked, vaultUnreadable, onReady }: Props) 
           {isSignup && (
             <Input type="password" placeholder={t("layout.auth.confirmPasswordPlaceholder")} value={confirm} onChange={setConfirm} />
           )}
-          <button
-            type="button"
-            onClick={() => setShowServerUrl((v) => !v)}
-            className="text-xs w-full text-left transition-colors text-(--t-text-dim)"
-          >
-            {showServerUrl ? "▾" : "▸"} {t("layout.auth.customServerUrl")}
-          </button>
-          {showServerUrl && (
-            <Input type="url" placeholder="https://api.voltius.app"
-              value={serverUrl} onChange={setServerUrl} />
-          )}
+          <ServerUrlField value={serverUrl} onChange={setServerUrl} inputClassName={INPUT_CLASS} />
           <ErrorMsg msg={error} />
           <SubmitBtn loading={loading} label={isSignup ? t("layout.auth.createAccount") : t("layout.auth.signIn")} />
         </form>
@@ -356,6 +345,9 @@ function ActionButton({ icon, label, sub, primary, loading, onClick }: {
   );
 }
 
+const INPUT_CLASS =
+  "form-input w-full px-3 py-2 rounded-lg text-sm outline-hidden bg-(--t-bg-input) border border-(--t-border) text-(--t-text-primary)";
+
 function Input({ type, placeholder, value, onChange, autoFocus }: {
   type: string; placeholder: string; value: string;
   onChange: (v: string) => void; autoFocus?: boolean;
@@ -367,7 +359,7 @@ function Input({ type, placeholder, value, onChange, autoFocus }: {
       value={value}
       onChange={(e) => onChange(e.target.value)}
       autoFocus={autoFocus}
-      className="form-input w-full px-3 py-2 rounded-lg text-sm outline-hidden bg-(--t-bg-input) border border-(--t-border) text-(--t-text-primary)"
+      className={INPUT_CLASS}
     />
   );
 }

--- a/src/components/layout/CloudAuthModal.tsx
+++ b/src/components/layout/CloudAuthModal.tsx
@@ -6,8 +6,11 @@ import { useUIStore, type CloudAuthMode } from "@/stores/uiStore";
 import { useSubscriptionStore } from "@/stores/subscriptionStore";
 import { getAccountMode, linkToCloud, setMasterPassword, signInToCloud } from "@/services/account";
 import { startRealtimeSync, syncOnLogin, syncOnLoginReplace } from "@/services/sync";
+import { ServerUrlField } from "@/components/shared/ServerUrlField";
+import { lastServerUrl } from "@/utils/serverInstance";
 
-const DEFAULT_SERVER = "https://api.voltius.app";
+const AUTH_INPUT_CLASS =
+  "w-full px-3 py-2.5 rounded-lg text-sm outline-hidden bg-(--t-bg-input) border border-(--t-border) text-(--t-text-primary) placeholder:text-(--t-text-muted) focus:border-(--t-accent)";
 
 export default function CloudAuthModal() {
   const { t } = useTranslation();
@@ -21,8 +24,7 @@ export default function CloudAuthModal() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
-  const [serverUrl, setServerUrl] = useState(DEFAULT_SERVER);
-  const [showServerUrl, setShowServerUrl] = useState(false);
+  const [serverUrl, setServerUrl] = useState(lastServerUrl);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
@@ -134,16 +136,7 @@ export default function CloudAuthModal() {
             </>
           )}
 
-          <button
-            type="button"
-            onClick={() => setShowServerUrl((v) => !v)}
-            className="text-xs w-full text-left transition-colors text-(--t-text-dim)"
-          >
-            {showServerUrl ? "▾" : "▸"} {t("layout.auth.customServerUrl")}
-          </button>
-          {showServerUrl && (
-            <AuthInput type="url" placeholder="https://api.voltius.app" value={serverUrl} onChange={setServerUrl} />
-          )}
+          <ServerUrlField value={serverUrl} onChange={setServerUrl} inputClassName={AUTH_INPUT_CLASS} />
 
           {error && <p className="text-xs px-1 text-(--t-status-error)">{error}</p>}
 
@@ -187,7 +180,7 @@ function AuthInput({
       value={value}
       autoFocus={autoFocus}
       onChange={(e) => onChange(e.target.value)}
-      className="w-full px-3 py-2.5 rounded-lg text-sm outline-hidden bg-(--t-bg-input) border border-(--t-border) text-(--t-text-primary) placeholder:text-(--t-text-muted) focus:border-(--t-accent)"
+      className={AUTH_INPUT_CLASS}
     />
   );
 }

--- a/src/components/layout/SidebarAccountButton.switcher.test.tsx
+++ b/src/components/layout/SidebarAccountButton.switcher.test.tsx
@@ -2,6 +2,7 @@ import { test, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { SavedAccount } from "@/services/savedAccounts";
+import { DEFAULT_SERVER_URL } from "@/utils/serverInstance";
 
 const h = vi.hoisted(() => ({
   accountMode: "server" as string,
@@ -17,7 +18,9 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (k: string) => k }),
   initReactI18next: { type: "3rdParty", init: () => {} },
 }));
-vi.mock("@iconify/react", () => ({ Icon: () => null }));
+vi.mock("@iconify/react", () => ({
+  Icon: ({ icon }: { icon: string }) => <i data-icon={icon} />,
+}));
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(async (_cmd: string, args: { key: string }) => h.keychain[args.key] ?? null),
 }));
@@ -42,10 +45,15 @@ import { useNotificationStore } from "@/stores/notificationStore";
 
 const CURRENT = {
   account_id: "current", mode: "server", master_password: ["master", "for", "current"].join("-"),
-  email: "ada@example.com", server_url: "https://srv", jwt: null, refresh_token: null,
+  email: "ada@example.com", server_url: DEFAULT_SERVER_URL, jwt: null, refresh_token: null,
 } satisfies SavedAccount;
 
 const OTHER = { ...CURRENT, account_id: "other", email: "grace@example.com" } satisfies SavedAccount;
+
+/** Same person, same email, other instance — the case the row could not tell apart. */
+const SELF_HOSTED = {
+  ...CURRENT, account_id: "self-hosted", server_url: "https://stackdome.example.tld",
+} satisfies SavedAccount;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -172,6 +180,39 @@ test("a switcher save the keychain refuses is reported", async () => {
       ),
     ).toBe(true),
   );
+});
+
+test("two accounts on different instances are told apart by their row", async () => {
+  h.getSavedAccounts.mockResolvedValue([CURRENT, OTHER, SELF_HOSTED]);
+  await openMenu();
+
+  await screen.findByText("stackdome.example.tld");
+  expect(screen.getAllByText("layout.sidebarAccount.savedAccountCloud")).toHaveLength(1);
+});
+
+test("a self-hosted row is marked with a server icon and its full URL", async () => {
+  h.getSavedAccounts.mockResolvedValue([CURRENT, SELF_HOSTED]);
+  await openMenu();
+
+  const row = (await screen.findByText("stackdome.example.tld")).closest("button");
+  expect(row?.getAttribute("title")).toBe(SELF_HOSTED.server_url);
+  expect(row?.querySelector('[data-icon="lucide:server"]')).toBeTruthy();
+});
+
+test("the header names the instance the current account is signed in to", async () => {
+  h.keychain = { ...h.keychain, server_url: SELF_HOSTED.server_url };
+  h.getSavedAccounts.mockResolvedValue([CURRENT]);
+  await openMenu();
+
+  await screen.findByText("stackdome.example.tld");
+  expect(screen.queryByText("layout.sidebarAccount.modeCloud")).toBeNull();
+});
+
+test("the header still reads Cloud account on the official instance", async () => {
+  h.keychain = { ...h.keychain, server_url: DEFAULT_SERVER_URL };
+  await openMenu();
+
+  await screen.findByText("layout.sidebarAccount.modeCloud");
 });
 
 test("adding another account stops when the current one could not be saved", async () => {

--- a/src/components/layout/SidebarAccountButton.tsx
+++ b/src/components/layout/SidebarAccountButton.tsx
@@ -13,7 +13,14 @@ import { useCopyHandle } from "@/hooks/useCopyHandle";
 import { useNotificationStore } from "@/stores/notificationStore";
 import { useSecurityStore } from "@/stores/securityStore";
 import { canLockVault } from "@/utils/accountMode";
+import { instanceLabel } from "@/utils/serverInstance";
 import { sessionTimeoutLabel, sessionTimeoutValue } from "@/utils/sessionTimeout";
+
+/**
+ * An account on the official cloud keeps the plain user icon; a self-hosted one
+ * is drawn as what it is, so two accounts sharing an email still read apart.
+ */
+const accountIcon = (instance: string | null) => (instance ? "lucide:server" : "lucide:circle-user");
 
 export function SidebarAccountButton() {
   const { t } = useTranslation();
@@ -29,20 +36,23 @@ export function SidebarAccountButton() {
   const [savedAccounts, setSavedAccounts] = useState<SavedAccount[]>([]);
   const [currentAccountId, setCurrentAccountId] = useState<string | null>(null);
   const [accountHandle, setAccountHandle] = useState<string | null>(null);
+  const [accountServerUrl, setAccountServerUrl] = useState<string | null>(null);
   const [pendingSwitch, setPendingSwitch] = useState<SavedAccount | null>(null);
   const { copied: handleCopied, copy: copyHandle } = useCopyHandle(accountHandle);
   const sessionTimeoutMinutes = useSecurityStore((s) => s.sessionTimeoutMinutes);
 
   const refreshAccountInfo = async () => {
     const { invoke: inv } = await import("@tauri-apps/api/core");
-    const [mode, email, accountId] = await Promise.all([
+    const [mode, email, accountId, serverUrl] = await Promise.all([
       getAccountMode().catch(() => null),
       inv<string | null>("keychain_get", { key: "email" }).catch(() => null),
       inv<string | null>("keychain_get", { key: "account_id" }).catch(() => null),
+      inv<string | null>("keychain_get", { key: "server_url" }).catch(() => null),
     ]);
     setAccountMode(mode);
     setAccountEmail(email);
     setCurrentAccountId(accountId);
+    setAccountServerUrl(serverUrl);
     void getMyHandle().then((handle) => setAccountHandle(handle || null)).catch(() => {});
   };
 
@@ -144,6 +154,7 @@ export function SidebarAccountButton() {
     : t("layout.sidebarAccount.autoLockAfter", { duration: sessionTimeoutLabel(t, sessionTimeoutValue(sessionTimeoutMinutes)) });
 
   const switchTargets = savedAccounts.filter((a) => a.account_id !== currentAccountId);
+  const currentInstance = accountMode === "server" ? instanceLabel(accountServerUrl) : null;
 
   const handleRemoveSavedAccount = async (e: React.MouseEvent, account_id: string) => {
     e.stopPropagation();
@@ -200,7 +211,7 @@ export function SidebarAccountButton() {
             <>
               <div className="px-3 py-2">
                 <div className="flex items-center gap-2">
-                  <Icon icon="lucide:circle-user" width={16} style={{ color: "var(--t-text-dim)" }} />
+                  <Icon icon={accountIcon(currentInstance)} width={16} style={{ color: "var(--t-text-dim)" }} />
                   <span className="text-sm font-medium truncate" style={{ color: "var(--t-text-primary)" }}>
                     {accountEmail ?? t("layout.sidebarAccount.localAccountFallback")}
                   </span>
@@ -218,8 +229,8 @@ export function SidebarAccountButton() {
                   </button>
                 )}
                 {accountMode && (
-                  <span className="text-xs mt-0.5 block" style={{ color: "var(--t-text-dim)" }}>
-                    {accountMode === "server" ? t("layout.sidebarAccount.modeCloud") : accountMode === "local" ? t("layout.sidebarAccount.modeLocalPassword") : t("layout.sidebarAccount.modeLocal")}
+                  <span className="text-xs mt-0.5 block truncate" style={{ color: "var(--t-text-dim)" }} title={currentInstance ? accountServerUrl ?? undefined : undefined}>
+                    {currentInstance ?? (accountMode === "server" ? t("layout.sidebarAccount.modeCloud") : accountMode === "local" ? t("layout.sidebarAccount.modeLocalPassword") : t("layout.sidebarAccount.modeLocal"))}
                   </span>
                 )}
               </div>
@@ -289,26 +300,30 @@ export function SidebarAccountButton() {
                   {t("layout.sidebarAccount.switchAccount")}
                 </span>
               </div>
-              {switchTargets.map((account) => (
-                <DropdownMenuItem
-                  key={account.account_id}
-                  icon="lucide:circle-user"
-                  iconSize={16}
-                  label={account.email ?? t("layout.sidebarAccount.localAccountFallback")}
-                  sublabel={account.mode === "server" ? t("layout.sidebarAccount.savedAccountCloud") : t("layout.sidebarAccount.savedAccountLocal")}
-                  onClick={() => requestSwitch(account)}
-                  trailing={
-                    <button
-                      type="button"
-                      title={t("layout.sidebarAccount.removeSavedAccount")}
-                      className="opacity-0 group-hover:opacity-100 p-0.5 rounded-sm transition-opacity text-(--t-text-dim) hover:text-(--t-status-error)"
-                      onClick={(e) => void handleRemoveSavedAccount(e, account.account_id)}
-                    >
-                      <Icon icon="lucide:x" width={12} />
-                    </button>
-                  }
-                />
-              ))}
+              {switchTargets.map((account) => {
+                const instance = instanceLabel(account.server_url);
+                return (
+                  <DropdownMenuItem
+                    key={account.account_id}
+                    icon={accountIcon(instance)}
+                    iconSize={16}
+                    label={account.email ?? t("layout.sidebarAccount.localAccountFallback")}
+                    sublabel={instance ?? (account.mode === "server" ? t("layout.sidebarAccount.savedAccountCloud") : t("layout.sidebarAccount.savedAccountLocal"))}
+                    title={instance ? account.server_url ?? undefined : undefined}
+                    onClick={() => requestSwitch(account)}
+                    trailing={
+                      <button
+                        type="button"
+                        title={t("layout.sidebarAccount.removeSavedAccount")}
+                        className="opacity-0 group-hover:opacity-100 p-0.5 rounded-sm transition-opacity text-(--t-text-dim) hover:text-(--t-status-error)"
+                        onClick={(e) => void handleRemoveSavedAccount(e, account.account_id)}
+                      >
+                        <Icon icon="lucide:x" width={12} />
+                      </button>
+                    }
+                  />
+                );
+              })}
             </>
           )}
         </div>,

--- a/src/components/shared/DropdownMenuItem.tsx
+++ b/src/components/shared/DropdownMenuItem.tsx
@@ -9,6 +9,8 @@ interface Props {
   checked?: boolean;
   iconSize?: number;
   sublabel?: string;
+  /** Native tooltip, for detail the row is too narrow to spell out. */
+  title?: string;
   /**
    * Secondary control shown at the item's right edge. Kept a sibling of the
    * button, never a child — a button inside a button is invalid DOM.
@@ -16,13 +18,14 @@ interface Props {
   trailing?: ReactNode;
 }
 
-export function DropdownMenuItem({ icon, label, onClick, checked, iconSize = 20, sublabel, trailing }: Props) {
+export function DropdownMenuItem({ icon, label, onClick, checked, iconSize = 20, sublabel, title, trailing }: Props) {
   const { createRipple, rippleEls } = useRipple();
   const item = (
     <button
       type="button"
       onClick={onClick}
       onPointerDown={createRipple}
+      title={title}
       className="w-full flex items-center gap-2.5 p-3 rounded-lg text-md font-medium-bold transition-colors whitespace-nowrap text-(--t-text-secondary) bg-transparent relative overflow-hidden"
       onMouseEnter={(e) => {
         (e.currentTarget as HTMLButtonElement).style.background = "var(--t-bg-card-hover)";
@@ -37,7 +40,7 @@ export function DropdownMenuItem({ icon, label, onClick, checked, iconSize = 20,
       {icon && <Icon icon={icon} width={iconSize} className="shrink-0" />}
       <span className="flex-1 min-w-0 text-left">
         <span className="block truncate text-(--t-text-primary)">{label}</span>
-        {sublabel && <span className="block text-[10px] text-(--t-text-dim)">{sublabel}</span>}
+        {sublabel && <span className="block truncate text-[10px] text-(--t-text-dim)">{sublabel}</span>}
       </span>
       {checked && (
         <span className="[&_path]:stroke-[2.5]">

--- a/src/components/shared/ServerUrlField.test.tsx
+++ b/src/components/shared/ServerUrlField.test.tsx
@@ -1,0 +1,46 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, vars?: Record<string, string>) =>
+      vars ? `${key}:${Object.values(vars).join(",")}` : key,
+  }),
+}));
+
+import { ServerUrlField } from "./ServerUrlField";
+import { DEFAULT_SERVER_URL } from "@/utils/serverInstance";
+
+afterEach(cleanup);
+
+const field = () => screen.queryByPlaceholderText(DEFAULT_SERVER_URL);
+
+test("stays out of the way on the official cloud", () => {
+  render(<ServerUrlField value={DEFAULT_SERVER_URL} onChange={vi.fn()} inputClassName="i" />);
+
+  expect(screen.getByText(/layout.auth.customServerUrl/)).toBeTruthy();
+  expect(field()).toBeNull();
+});
+
+/**
+ * A collapsed field that silently reads api.voltius.app is how signing in to a
+ * self-hosted instance turns into registering on the official cloud instead.
+ */
+test("opens and names the host when the account is not on the official cloud", () => {
+  render(
+    <ServerUrlField value="https://stackdome.example.tld" onChange={vi.fn()} inputClassName="i" />,
+  );
+
+  expect(screen.getByRole("button").textContent).toContain(
+    "layout.auth.serverNamed:stackdome.example.tld",
+  );
+  expect(field()).toBeTruthy();
+});
+
+test("can still be opened by hand on the official cloud", async () => {
+  render(<ServerUrlField value={DEFAULT_SERVER_URL} onChange={vi.fn()} inputClassName="i" />);
+
+  await userEvent.click(screen.getByText(/layout.auth.customServerUrl/));
+  expect(field()).toBeTruthy();
+});

--- a/src/components/shared/ServerUrlField.tsx
+++ b/src/components/shared/ServerUrlField.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { DEFAULT_SERVER_URL, instanceLabel, isDefaultServer } from "@/utils/serverInstance";
+
+/**
+ * The server URL disclosure shared by the auth page and the cloud auth modal.
+ *
+ * It starts open whenever the account is not headed for the official cloud: the
+ * field used to reset to api.voltius.app behind a collapsed row, so a
+ * self-hosted user adding a second account aimed at the wrong instance without
+ * ever seeing which one they were on.
+ *
+ * `inputClassName` is the only thing the two screens disagree about — their
+ * input styling differs — and it is cheaper to pass than to reconcile.
+ */
+export function ServerUrlField({
+  value,
+  onChange,
+  inputClassName,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  inputClassName: string;
+}) {
+  const { t } = useTranslation();
+  const [shown, setShown] = useState(() => !isDefaultServer(value));
+  const host = instanceLabel(value);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setShown((v) => !v)}
+        className="text-xs w-full text-left transition-colors text-(--t-text-dim)"
+      >
+        {shown ? "▾" : "▸"}{" "}
+        {host ? t("layout.auth.serverNamed", { host }) : t("layout.auth.customServerUrl")}
+      </button>
+      {shown && (
+        <input
+          type="url"
+          placeholder={DEFAULT_SERVER_URL}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className={inputClassName}
+        />
+      )}
+    </>
+  );
+}

--- a/src/i18n/locales/en/layout.json
+++ b/src/i18n/locales/en/layout.json
@@ -33,6 +33,7 @@
       "masterPasswordMinPlaceholder": "Master password (min 8 chars)",
       "confirmPasswordPlaceholder": "Confirm password",
       "customServerUrl": "Custom server URL",
+      "serverNamed": "Server: {{host}}",
       "errorInvalidEmail": "Invalid email",
       "errorMinLength8": "At least 8 characters",
       "errorPasswordMismatch": "Passwords don't match",

--- a/src/i18n/locales/fr/layout.json
+++ b/src/i18n/locales/fr/layout.json
@@ -33,6 +33,7 @@
       "masterPasswordMinPlaceholder": "Mot de passe principal (8 caractères min.)",
       "confirmPasswordPlaceholder": "Confirmer le mot de passe",
       "customServerUrl": "URL de serveur personnalisée",
+      "serverNamed": "Serveur : {{host}}",
       "errorInvalidEmail": "E-mail invalide",
       "errorMinLength8": "Au moins 8 caractères",
       "errorPasswordMismatch": "Les mots de passe ne correspondent pas",

--- a/src/i18n/locales/ru/layout.json
+++ b/src/i18n/locales/ru/layout.json
@@ -33,6 +33,7 @@
       "masterPasswordMinPlaceholder": "Мастер-пароль (мин. 8 символов)",
       "confirmPasswordPlaceholder": "Подтвердите пароль",
       "customServerUrl": "Пользовательский URL сервера",
+      "serverNamed": "Сервер: {{host}}",
       "errorInvalidEmail": "Некорректный email",
       "errorMinLength8": "Не менее 8 символов",
       "errorPasswordMismatch": "Пароли не совпадают",

--- a/src/i18n/locales/zh/layout.json
+++ b/src/i18n/locales/zh/layout.json
@@ -33,6 +33,7 @@
       "masterPasswordMinPlaceholder": "主密码（至少 8 个字符）",
       "confirmPasswordPlaceholder": "确认密码",
       "customServerUrl": "自定义服务器地址",
+      "serverNamed": "服务器：{{host}}",
       "errorInvalidEmail": "邮箱无效",
       "errorMinLength8": "至少 8 个字符",
       "errorPasswordMismatch": "密码不匹配",

--- a/src/services/account.serverAuth.test.ts
+++ b/src/services/account.serverAuth.test.ts
@@ -52,6 +52,7 @@ import {
   resendVerificationEmail,
 } from "./account";
 import { VaultUnreadableError } from "./vaultErrors";
+import { DEFAULT_SERVER_URL, lastServerUrl } from "@/utils/serverInstance";
 
 const S = "https://srv";
 const TOKENS = { jwt_token: "JWT", refresh_token: "RT" };
@@ -119,6 +120,7 @@ beforeEach(() => {
   h.rekeyError = null;
   h.store = {};
   h.http = {};
+  localStorage.clear();
   h.dek = null;
   h.x25519 = null;
   h.emailVerified = false;
@@ -170,6 +172,23 @@ test("createServerAccount persists tokens, sets the vault key, and reloads subsc
   expect(h.store.email).toBe("a@b.co");
   expect(h.setVaultKey).toHaveBeenCalledWith([1, 1, 1]); // dek
   expect(h.load).toHaveBeenCalled();
+});
+
+/**
+ * Adding a second account clears `server_url` with every other account-scoped
+ * key, so without a device-scoped record the auth screen sends a self-hosted
+ * user back to the official cloud.
+ */
+test("createServerAccount remembers the instance for the next auth screen", async () => {
+  h.http["/auth/register"] = ok(TOKENS);
+  await createServerAccount("a@b.co", "pw", S);
+  expect(lastServerUrl()).toBe(S);
+});
+
+test("a failed registration leaves the remembered instance alone", async () => {
+  h.http["/auth/register"] = err(500);
+  await expect(createServerAccount("a@b.co", "pw", S)).rejects.toThrow();
+  expect(lastServerUrl()).toBe(DEFAULT_SERVER_URL);
 });
 
 // ─── login ───────────────────────────────────────────────────────────────────

--- a/src/services/account.ts
+++ b/src/services/account.ts
@@ -5,6 +5,7 @@ import { useSubscriptionStore } from "@/stores/subscriptionStore";
 import { useVaultKeysStore } from "@/stores/vaultKeysStore";
 import { appFetch, isAbortError } from "@/services/http";
 import { VaultUnreadableError } from "./vaultErrors";
+import { rememberServer } from "@/utils/serverInstance";
 
 function reloadSubscription() {
   useSubscriptionStore.getState().load().catch(() => {});
@@ -130,6 +131,30 @@ async function keychainDelete(key: string): Promise<void> {
   return invoke("keychain_delete", { key });
 }
 
+/**
+ * Write the keychain entries that make a server session, for every route into
+ * one: register, sign-in, re-auth and link-to-cloud all wrote this same list by
+ * hand. It is also the single place that records the instance for the auth
+ * screen, which a fifth route would otherwise forget.
+ */
+async function persistServerSession(session: {
+  serverUrl: string;
+  email: string;
+  accountId?: string;
+  password?: string;
+  jwt?: string;
+  refreshToken?: string;
+}): Promise<void> {
+  if (session.password) await keychainSet("master_password", session.password);
+  if (session.accountId) await keychainSet("account_id", session.accountId);
+  await keychainSet("mode", "server");
+  await keychainSet("email", session.email);
+  if (session.jwt) await keychainSet("jwt", session.jwt);
+  if (session.refreshToken) await keychainSet("refresh_token", session.refreshToken);
+  await keychainSet("server_url", session.serverUrl);
+  rememberServer(session.serverUrl);
+}
+
 function setForceLockFlag(): void {
   if (typeof window === "undefined") return;
   try {
@@ -224,13 +249,10 @@ export async function createServerAccount(
   useVaultKeysStore.getState().set({ dek: secrets.dek, x25519Private: secrets.x25519_private, kek: enc_key });
   setVaultKey(secrets.dek);
 
-  await keychainSet("master_password", password);
-  await keychainSet("account_id", accountId);
-  await keychainSet("mode", "server");
-  await keychainSet("email", email);
-  await keychainSet("jwt", data.jwt_token);
-  await keychainSet("refresh_token", data.refresh_token);
-  await keychainSet("server_url", serverUrl);
+  await persistServerSession({
+    serverUrl, email, accountId, password,
+    jwt: data.jwt_token, refreshToken: data.refresh_token,
+  });
   await keychainSet("wrapped_user_secrets", wrapped_user_secrets);
   reloadSubscription();
 }
@@ -290,11 +312,10 @@ export async function login(password: string, email?: string, serverUrl?: string
     });
     if (!res.ok) throw new Error(i18n.t("common.error.serverLoginFailed"));
     const data = await res.json();
-    await keychainSet("jwt", data.jwt_token);
-    await keychainSet("refresh_token", data.refresh_token);
-    await keychainSet("mode", "server");
-    await keychainSet("email", reauth.email);
-    await keychainSet("server_url", reauth.serverUrl);
+    await persistServerSession({
+      serverUrl: reauth.serverUrl, email: reauth.email,
+      jwt: data.jwt_token, refreshToken: data.refresh_token,
+    });
 
     if (data.wrapped_user_secrets) {
       const unwrapped = await unwrapUserSecrets(kek, data.wrapped_user_secrets);
@@ -577,13 +598,10 @@ export async function signInToCloud(
 
   setVaultKey(vaultKey);
 
-  await keychainSet("master_password", password);
-  await keychainSet("account_id", accountId);
-  await keychainSet("mode", "server");
-  await keychainSet("email", email);
-  await keychainSet("jwt", data.jwt_token);
-  await keychainSet("refresh_token", data.refresh_token);
-  await keychainSet("server_url", serverUrl);
+  await persistServerSession({
+    serverUrl, email, accountId, password,
+    jwt: data.jwt_token, refreshToken: data.refresh_token,
+  });
   reloadSubscription();
 
   // Delete the old secrets.enc (encrypted with the previous account's key — the new
@@ -634,11 +652,9 @@ export async function linkToCloud(
 
   useVaultKeysStore.getState().set({ dek: secrets.dek, x25519Private: secrets.x25519_private, kek });
 
-  await keychainSet("mode", "server");
-  await keychainSet("email", email);
-  await keychainSet("server_url", serverUrl);
-  await keychainSet("jwt", data.jwt_token);
-  await keychainSet("refresh_token", data.refresh_token);
+  await persistServerSession({
+    serverUrl, email, jwt: data.jwt_token, refreshToken: data.refresh_token,
+  });
   await keychainSet("wrapped_user_secrets", wrapped_user_secrets);
   reloadSubscription();
 }

--- a/src/utils/serverInstance.test.ts
+++ b/src/utils/serverInstance.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_SERVER_URL,
+  instanceLabel,
+  isDefaultServer,
+  lastServerUrl,
+  rememberServer,
+} from "./serverInstance";
+
+describe("isDefaultServer", () => {
+  it("accepts the official cloud", () => {
+    expect(isDefaultServer(DEFAULT_SERVER_URL)).toBe(true);
+  });
+
+  it("ignores trailing slashes and case", () => {
+    expect(isDefaultServer("HTTPS://API.VOLTIUS.APP//")).toBe(true);
+  });
+
+  it("rejects a self-hosted instance", () => {
+    expect(isDefaultServer("https://stackdome.example.tld")).toBe(false);
+  });
+
+  it("treats a missing URL as the default, so nothing gets marked on a guess", () => {
+    expect(isDefaultServer(null)).toBe(true);
+  });
+});
+
+describe("instanceLabel", () => {
+  it("leaves the official cloud unlabelled", () => {
+    expect(instanceLabel(DEFAULT_SERVER_URL)).toBeNull();
+  });
+
+  it("labels a self-hosted instance with its host", () => {
+    expect(instanceLabel("https://stackdome.example.tld")).toBe("stackdome.example.tld");
+  });
+
+  it("drops an api. or www. prefix that carries no information", () => {
+    expect(instanceLabel("https://api.stackdome.example.tld")).toBe("stackdome.example.tld");
+    expect(instanceLabel("https://www.stackdome.example.tld")).toBe("stackdome.example.tld");
+  });
+
+  it("keeps the prefix when dropping it would leave a bare name", () => {
+    expect(instanceLabel("https://api.local")).toBe("api.local");
+  });
+
+  it("keeps a non-default port, which is what distinguishes two instances on one host", () => {
+    expect(instanceLabel("http://192.168.1.40:8443")).toBe("192.168.1.40:8443");
+  });
+
+  it("drops the port when it is the scheme's own", () => {
+    expect(instanceLabel("https://stackdome.example.tld:443")).toBe("stackdome.example.tld");
+  });
+
+  it("returns null for a URL it cannot parse, so the caller falls back to Cloud", () => {
+    expect(instanceLabel("not a url")).toBeNull();
+    expect(instanceLabel(null)).toBeNull();
+    expect(instanceLabel("")).toBeNull();
+  });
+});
+
+describe("the last server signed in to", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("is the official cloud until something else is used", () => {
+    expect(lastServerUrl()).toBe(DEFAULT_SERVER_URL);
+  });
+
+  it("is remembered across the sign-out that adding an account performs", () => {
+    rememberServer("https://stackdome.example.tld");
+    expect(lastServerUrl()).toBe("https://stackdome.example.tld");
+  });
+
+  it("ignores a value it could not parse rather than seeding a broken field", () => {
+    rememberServer("not a url");
+    expect(lastServerUrl()).toBe(DEFAULT_SERVER_URL);
+  });
+});

--- a/src/utils/serverInstance.ts
+++ b/src/utils/serverInstance.ts
@@ -1,0 +1,55 @@
+/**
+ * Which Voltius instance an account lives on.
+ *
+ * Only a non-default instance is ever named in the UI: an account on the
+ * official cloud reads exactly as it did before, and the host appears only when
+ * it is the thing that tells two otherwise identical accounts apart.
+ */
+export const DEFAULT_SERVER_URL = "https://api.voltius.app";
+
+function parse(url: string | null | undefined): URL | null {
+  if (!url) return null;
+  try {
+    return new URL(url.trim());
+  } catch {
+    return null;
+  }
+}
+
+const DEFAULT_HOST = new URL(DEFAULT_SERVER_URL).host;
+
+/** A URL we cannot read counts as the default — better unmarked than mislabelled. */
+export function isDefaultServer(url: string | null | undefined): boolean {
+  const parsed = parse(url);
+  return !parsed || parsed.host.toLowerCase() === DEFAULT_HOST;
+}
+
+/** Host to show for a self-hosted instance, or null when there is nothing to say. */
+export function instanceLabel(url: string | null | undefined): string | null {
+  const parsed = parse(url);
+  if (!parsed || isDefaultServer(url)) return null;
+
+  const hostname = parsed.hostname.toLowerCase();
+  const stripped = hostname.replace(/^(?:api|www)\./, "");
+  const name = stripped.includes(".") ? stripped : hostname;
+  return parsed.port ? `${name}:${parsed.port}` : name;
+}
+
+/**
+ * The instance this machine last signed in to.
+ *
+ * Device-scoped on purpose: adding a second account clears every account-scoped
+ * keychain entry, `server_url` among them, so without this the auth screen
+ * silently aims a self-hosted user back at the official cloud.
+ */
+const LAST_SERVER_KEY = "voltius.last-server-url";
+
+export function rememberServer(url: string): void {
+  if (!parse(url)) return;
+  globalThis.localStorage?.setItem(LAST_SERVER_KEY, url);
+}
+
+export function lastServerUrl(): string {
+  const stored = globalThis.localStorage?.getItem(LAST_SERVER_KEY);
+  return parse(stored) ? stored! : DEFAULT_SERVER_URL;
+}


### PR DESCRIPTION
Every switch-target row read "Cloud", so an account on the official cloud and one on a self-hosted instance were indistinguishable — same email, same icon, same sublabel. `SavedAccount` already carried `server_url`; only the design was missing.

## The rule

Mark **only** what is not the default, in slots that already exist. No new row, no new line, no extra width. An official-cloud account is byte-for-byte unchanged.

| Surface | Official cloud | Self-hosted |
| --- | --- | --- |
| Switch row | `circle-user` + "Cloud" | `lucide:server` + `stackdome.example.tld`, full URL in the hover title |
| Account header | `circle-user` + "Cloud account" | `lucide:server` + the host |
| Auth server field | collapsed, "Custom server URL" | open, "Server: `<host>`" |

Considered and rejected: the hostname on every row (pushes a URL at people who only ever use one instance), an icon swap with no text (two self-hosted instances stay ambiguous), and user-assigned nicknames (a whole editing surface; deliberately deferred).

## How the label is derived

`src/utils/serverInstance.ts` — hostname, a leading `api.`/`www.` dropped only when the rest still contains a dot, a non-default port kept because it is what distinguishes two instances on one host. Anything absent or unparseable counts as the default: better unmarked than mislabelled.

| `server_url` | Label |
| --- | --- |
| `https://api.voltius.app` | "Cloud" — never marked |
| `https://stackdome.example.tld` | `stackdome.example.tld` |
| `https://api.stackdome.example.tld` | `stackdome.example.tld` |
| `http://192.168.1.40:8443` | `192.168.1.40:8443` |
| `https://api.local` | `api.local` — stripping would leave a bare name |
| `null` / unparseable | "Cloud" |

## The auth screen, and why it needed a device-scoped record

"Add another account…" landed on the auth screen with the server field collapsed and reset to `https://api.voltius.app`, so aiming at a self-hosted instance was one un-clicked disclosure away from silently registering on the official cloud.

Auto-expanding on a non-default value is not reachable on its own: adding an account clears `server_url` along with every other `ACCOUNT_CACHE_KEYS` entry, so the screen has nothing non-default to open on. The field now seeds from `voltius.last-server-url` — device-scoped localStorage, written on a successful sign-in, surviving teardown because `clearPersistedAccountUiState` removes only its explicit key list.

## Duplications collapsed on the way

- `DEFAULT_SERVER` lived in both `AuthPage.tsx` and `CloudAuthModal.tsx`, as did the disclosure block. Both now use `ServerUrlField`; the screens disagreed only about input styling, which is one `inputClassName` prop.
- Four routes into a server session — register, login re-auth, `signInToCloud`, `linkToCloud` — each wrote the same keychain list by hand. `persistServerSession` is now the single place that writes it, and the single place that records the instance, which a fifth route would otherwise forget.

## Testing

Suite 3758/3758 across 483 files; `tsc --noEmit` exit 0. New: 14 tests for the label rules and the remembered instance, 3 for `ServerUrlField`, 4 in `SidebarAccountButton.switcher.test.tsx` (two accounts sharing an email on different instances, the server icon and title, and both header cases), 2 in `account.serverAuth.test.ts` (a successful registration remembers the instance, a failed one leaves it alone).

⚠️ **Not live-clicked.** Unit tests only — proving the two-instance case end to end needs a real self-hosted server.
