### PR TITLE
Stop pluginBundleBuild's stylesheet test timing out

### DIFF
--- a/tests/pluginBundleBuild.test.ts
+++ b/tests/pluginBundleBuild.test.ts
@@ -52,7 +52,14 @@ describe("plugin bundle build (webview compatibility)", () => {
     expect(ids).toContain("process-manager");
   });
 
+  // A plugin build takes ~5s, and the stylesheet test below wants the same
+  // artifact the webview-safety test already built. Cache by id so a full run
+  // pays for each build once, whatever order the tests run in.
+  const built = new Map<string, string>();
+
   function buildAndRead(id: string): string {
+    const cached = built.get(id);
+    if (cached !== undefined) return cached;
     const outDir = path.join(outRoot, id);
     execFileSync(
       "pnpm",
@@ -68,7 +75,9 @@ describe("plugin bundle build (webview compatibility)", () => {
         env: { ...process.env, VOLTIUS_PLUGIN_ID: id },
       },
     );
-    return readFileSync(path.join(outDir, "index.js"), "utf8");
+    const code = readFileSync(path.join(outDir, "index.js"), "utf8");
+    built.set(id, code);
+    return code;
   }
 
   test.each(ids)("%s bundle is webview-safe", async (id) => {
@@ -118,5 +127,7 @@ describe("plugin bundle build (webview compatibility)", () => {
     const css = readFileSync(cssPath, "utf8");
     expect(css.length).toBeGreaterThan(0);
     expect(css).toContain(".uplot");
-  });
+    // Same allowance as the build test above: run on its own, this test does the
+    // build itself, and one build is already close to vitest's 5s default.
+  }, 30000);
 });


### PR DESCRIPTION
`tests/pluginBundleBuild.test.ts > monitoring bundle emits its stylesheet as voltius.css` fails on a clean `origin/dev` checkout, with nothing else running on the machine.

Every `%s bundle is webview-safe` case already carries an explicit `30000` timeout, because a plugin build takes ~5 s. The stylesheet test runs the same `buildAndRead("monitoring")` but was left on vitest's 5000 ms default, so it fails whenever that build lands a fraction over — measured here at 5013–5384 ms across runs, i.e. on the line rather than under load.

## Change

- Same 30 s allowance as its neighbours.
- `buildAndRead` caches by plugin id, so the stylesheet test reuses the artifact the webview-safety case already built rather than building `monitoring` a second time. The cache makes it order-independent: run alone, the test still does its own build.

## Verification

| run | result |
|---|---|
| whole file, ×3 | 8 passed (~30.5 s, down from ~36 s) |
| `-t "stylesheet"` alone | 1 passed, 5374 ms — the case that used to fail |

Baselined first: the same test fails on a clean `origin/dev` worktree at the default timeout, so this is not a regression from any branch in flight.