### PR TITLE
fix(terminal): paste into the terminal that got the key, not the mount's last session

### DIFF
--- a/src/hooks/useTerminal.clipboard.test.tsx
+++ b/src/hooks/useTerminal.clipboard.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { useTerminal } from "@/hooks/useTerminal";
+
+const keyHandlers = new Map<string, (e: KeyboardEvent) => boolean>();
+
+vi.mock("@xterm/xterm", () => {
+  let seq = 0;
+  class FakeTerminal {
+    id = `term-${(seq += 1)}`;
+    element: HTMLElement | null = null;
+    options: Record<string, unknown> = {};
+    cols = 80;
+    rows = 24;
+    modes = { applicationCursorKeysMode: false, mouseTrackingMode: "none" };
+    buffer = {
+      active: { length: 0, viewportY: 0, baseY: 0, cursorY: 0, type: "normal", getLine: () => null },
+      onBufferChange: () => ({ dispose() {} }),
+    };
+    open(container: HTMLElement) {
+      this.element = document.createElement("div");
+      container.appendChild(this.element);
+    }
+    parser = { registerOscHandler: () => ({ dispose() {} }) };
+    loadAddon() {}
+    write() {}
+    focus() {}
+    dispose() {}
+    attachCustomKeyEventHandler(fn: (e: KeyboardEvent) => boolean) { keyHandlers.set(this.id, fn); }
+    attachCustomWheelEventHandler() {}
+    onData() { return { dispose() {} }; }
+    onBinary() { return { dispose() {} }; }
+    onResize() { return { dispose() {} }; }
+    onScroll() { return { dispose() {} }; }
+    onLineFeed() { return { dispose() {} }; }
+    onRender() { return { dispose() {} }; }
+    onWriteParsed() { return { dispose() {} }; }
+    registerLinkProvider() { return { dispose() {} }; }
+    registerDecoration() { return null; }
+  }
+  return { Terminal: FakeTerminal };
+});
+vi.mock("@xterm/addon-fit", () => ({ FitAddon: class { fit() {} proposeDimensions() { return { cols: 80, rows: 24 }; } } }));
+vi.mock("@xterm/addon-webgl", () => ({ WebglAddon: class { onContextLoss() { return { dispose() {} }; } dispose() {} } }));
+vi.mock("@xterm/addon-web-links", () => ({ WebLinksAddon: class {} }));
+vi.mock("@xterm/addon-search", () => ({
+  SearchAddon: class {
+    findNext() { return false; }
+    findPrevious() { return false; }
+    clearDecorations() {}
+    onDidChangeResults() { return { dispose() {} }; }
+  },
+}));
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn() }));
+vi.mock("@/services/ssh", () => ({
+  sshSendInput: vi.fn(), sshResize: vi.fn(),
+  onSshOutput: vi.fn(async () => () => {}), onSshClosed: vi.fn(async () => () => {}), onSshCwd: vi.fn(async () => () => {}),
+}));
+vi.mock("@/services/local", () => ({
+  localSendInput: vi.fn(), localResize: vi.fn(), localReady: vi.fn(async () => {}),
+  onLocalOutput: vi.fn(async () => () => {}), onLocalClosed: vi.fn(async () => () => {}),
+}));
+vi.mock("@/services/serial", () => ({
+  serialWrite: vi.fn(), onSerialOutput: vi.fn(async () => () => {}), onSerialClosed: vi.fn(async () => () => {}),
+}));
+
+const clips: { termId: string; handleKeyEvent: ReturnType<typeof vi.fn> }[] = [];
+vi.mock("@/components/terminal/terminalClipboard", () => ({
+  attachTerminalClipboard: (term: { id: string }) => {
+    const clip = { termId: term.id, handleKeyEvent: vi.fn(() => false), dispose() {} };
+    clips.push(clip);
+    return clip;
+  },
+}));
+
+globalThis.ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+function Harness({ sessionId }: { sessionId: string }) {
+  const { attach } = useTerminal({ sessionId, sessionType: "local" });
+  return <div data-testid="host" ref={attach} />;
+}
+
+describe("terminal clipboard routing", () => {
+  it("routes Ctrl+V to the terminal that received the key, not the mount's last session", () => {
+    // A pane creates session-a's terminal, then switches to session-b.
+    const first = render(<Harness sessionId="session-a" />);
+    first.rerender(<Harness sessionId="session-b" />);
+    // session-a re-mounts elsewhere (dragged back out to its own tab).
+    render(<Harness sessionId="session-a" />);
+
+    const last = (termId: string) => {
+      const matches = clips.filter((c) => c.termId === termId);
+      return matches[matches.length - 1];
+    };
+    const clipA = last("term-1");
+    const clipB = last("term-2");
+
+    const paste = new KeyboardEvent("keydown", { key: "v", ctrlKey: true });
+    keyHandlers.get("term-1")!(paste);
+
+    expect(clipA.handleKeyEvent).toHaveBeenCalledTimes(1);
+    expect(clipB.handleKeyEvent).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -162,6 +162,10 @@ type CacheEntry = {
   minimap: MinimapState;
   sessionType: "ssh" | "local" | "serial";
   connectedRef: { current: boolean };
+  /** Clipboard handle of the mount this terminal is currently attached to. Lives
+   *  on the entry, not on the hook: a mount that switches session keeps its refs,
+   *  so a hook-owned handle would send this terminal's Ctrl+V to the new session. */
+  clip: TerminalClipboardHandle | null;
   /** Mirror of the useTerminal `inputGate` so module-level senders (writeToSession)
    *  honor the same multiplayer control-holder gate as the onData handler. */
   inputGateRef: { current: (() => boolean) | undefined };
@@ -661,7 +665,6 @@ useSessionStore.subscribe((state) => {
 
 export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encoding, onResize }: UseTerminalOptions) {
   const mountCleanupRef = useRef<(() => void) | null>(null);
-  const clipRef = useRef<TerminalClipboardHandle | null>(null);
 
   // Keep the cached entry's callback refs current on every render
   useEffect(() => {
@@ -677,9 +680,10 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
   // the ref detaches. The teardown also pulls the terminal element out of the
   // container: a pane that switches session keeps the same container node, so
   // leaving the old element behind would show the previous session's buffer.
-  const bindContainer = useCallback((terminal: Terminal, fitAddon: FitAddon, container: HTMLDivElement) => {
+  const bindContainer = useCallback((entry: CacheEntry, container: HTMLDivElement) => {
+    const { terminal, fitAddon } = entry;
     const clip = attachTerminalClipboard(terminal, container, { osc52: true });
-    clipRef.current = clip;
+    entry.clip = clip;
 
     const handleWindowResize = () => fitAddon.fit();
     window.addEventListener("resize", handleWindowResize);
@@ -693,7 +697,7 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
 
     mountCleanupRef.current = () => {
       clip.dispose();
-      if (clipRef.current === clip) clipRef.current = null;
+      if (entry.clip === clip) entry.clip = null;
       window.removeEventListener("resize", handleWindowResize);
       resizeObserver.disconnect();
       if (fitTimer !== null) clearTimeout(fitTimer);
@@ -725,7 +729,7 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
 
         fitAddon.fit();
 
-        bindContainer(terminal, fitAddon, container);
+        bindContainer(existing, container);
         return;
       }
 
@@ -836,6 +840,7 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
         // connected before the terminal mounts); ssh and local flip in the
         // store subscription above, once the backend owns the session.
         connectedRef: { current: sessionType === "serial" },
+        clip: null,
         inputGateRef: { current: inputGate?.current },
         onClosedRef: { current: onClosed },
         onResizeRef: { current: onResize },
@@ -881,7 +886,7 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
           if (e.type === "keydown") useUIStore.getState().setOmniOpen(true);
           return false;
         }
-        const clipResult = clipRef.current?.handleKeyEvent(e);
+        const clipResult = entry.clip?.handleKeyEvent(e);
         if (clipResult != null) return clipResult;
         if (matchShortcut("terminal-search", e)) {
           if (e.type === "keydown") {
@@ -1133,7 +1138,7 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
         term.dispose();
       };
 
-      bindContainer(term, fitAddon, container);
+      bindContainer(entry, container);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [sessionId, sessionType, encoding],


### PR DESCRIPTION
## Bug

With 5 tabs — 1: Host A, 2: Host B, 3+4 grouped in a split, 5: Host B — pasting into tab 2 landed in tab 3.

## Root cause

The clipboard handle from `attachTerminalClipboard` (Ctrl+V, Ctrl+Shift+V, right-click paste) was stored in `clipRef`, a ref owned by the `useTerminal` **hook instance**. The xterm handler that reads it, `term.attachCustomKeyEventHandler`, is registered **once when the terminal is created** and lives as long as the cached terminal — cached terminals outlive their mounts by design.

A mount that switches session — a pane re-targeted, a tab dragged in or out of a split, the path `useTerminal.reattach.test.tsx` already covers — rebinds that ref to the new session's terminal. From then on the old terminal's Ctrl+V did `readClipboard()` and `term.paste()` on the *new* session's terminal.

Instrumented run before the fix, showing terminal 1's key handler firing terminal 2's clipboard handle:

```
DIAG { clips: [ [ 'term-1', 0 ], [ 'term-2', 1 ], [ 'term-1', 0 ] ] }
```

## Fix

The handle moves onto the cache entry as `CacheEntry.clip`, next to the other per-terminal mirrors (`inputGateRef`, `onClosedRef`, `onResizeRef`), and `bindContainer` now takes the entry it is binding. A terminal's key handler can only reach its own clipboard.

## Verification

- New regression test `src/hooks/useTerminal.clipboard.test.tsx` — fails on `dev`, passes here.
- `vitest run src/hooks src/components/terminal`: 41 files, 266 tests passed.
- `tsc --noEmit`: clean.

Not yet exercised by hand in a live build.