### PR TITLE
fix(ssh): give up the wrapper's escape key on screen hosts

### DIFF
--- a/src-tauri/src/shell_integration.rs
+++ b/src-tauri/src/shell_integration.rs
@@ -341,6 +341,17 @@ pub fn tmux_session_key(session_id: &str) -> String {
 /// never meet a session another device is attached to. Re-attach and
 /// cross-device join go through `persistent_attach_command`.
 ///
+/// The screen branch gives up its escape key the same way the tmux branch gives
+/// up its prefix, so a user's own screen inside ours keeps `C-a` (#159 follow-up:
+/// a bare `C-a d` used to detach *our* wrapper, which the app then silently
+/// reconnected). screen has no `prefix None` equivalent — `escape` always names
+/// some key — so it is pointed at `\377`, a byte no key produces in a UTF-8
+/// terminal. The one theoretical cost is a latin-1 session where 0xFF is `ÿ`;
+/// that is worth trading for a wrapper the user's own screen can nest inside.
+/// Unlike the tmux prefix this needs no version gate: `escape` and octal escapes
+/// long predate any screen still in use, and a screen that did reject the line
+/// would simply keep its default key.
+///
 /// Both multiplexer configs override the outer terminal's `cnorm` (cursor
 /// normal) capability to plain `\E[?25h`. xterm-256color's stock cnorm is
 /// `\E[?12l\E[?25h`, and the `?12l` half is "stop cursor blinking" — xterm.js
@@ -404,6 +415,7 @@ msgwait 0
 msgminwait 0
 vbell off
 defscrollback 50000
+escape \377\377
 termcapinfo xterm* ti@:te@:ve=\E[?25h
 EOF
     case "$(screen --version 2>/dev/null)" in
@@ -755,6 +767,9 @@ mod tests {
         assert!(script.contains(r#"tmux -L voltius set -g prefix None"#));
         assert!(script.contains(r#"echo "set -g prefix None" >> "$TMUX_CONF""#));
         assert!(script.contains(r#"*"tmux "2.[1-9]*"#));
+        // #159 follow-up: screen's escape key belongs to whatever runs inside,
+        // pointed at a byte no key produces rather than a real chord.
+        assert!(script.contains(r"escape \377\377"));
         // Self-heal: wipe dead entries and collapse same-named duplicates so
         // -D -R can't fail into the "several suitable screens" reconnect loop.
         assert!(script.contains("screen -wipe"));


### PR DESCRIPTION
Follow-up to #170 / #159, found while verifying the GNU screen half of that fix end to end.

## The gap

#170 made the tmux wrapper transparent — `unset TMUX`, and `prefix None` so `C-b` belongs to whatever the user runs inside. The screen fallback got the environment half but not the key half: our screen rc sets no `escape`, so the wrapper kept screen's default `C-a` and intercepted it.

Observed on a screen-only host, driving the app and polling the host while sending `C-a d` from inside a nested `screen -r`:

```
9616.mine (Attached)   voltius_… (Attached)
9616.mine (Attached)   voltius_… (Detached)   ← our wrapper took the key
```

The SSH channel then closed and the app reconnected under the user — their own screen never saw `C-a`.

## The fix

screen has no `prefix None` equivalent: `escape` always names some key. It is pointed at `\377` instead — a byte no key produces in a UTF-8 terminal — which is as close to "no escape key" as screen offers. The only theoretical cost is a latin-1 session where 0xFF is `ÿ`.

No version gate: `escape` and octal escapes long predate any screen still in use, and a screen that rejected the line would simply keep its default key. `screen -x` (the attach path) joins the running server, which keeps the setting this rc gave it at create time — same reasoning as the existing `truecolor` line.

## Verification

Same host (GNU screen 5.0.2), same gesture, through the app:

```
9616.mine (Attached)   voltius_… (Attached)
9616.mine (Detached)   voltius_… (Attached)   ← the user's session took the key
```

The pane prints `[detached from 9616.mine]` and returns to the wrapper's shell, with the session timer running continuously — no reconnect. `cargo test --lib shell_integration`: 22/22, `cargo fmt --check` clean.
