### PR TITLE
docs(packaging): explain what keeps the core cask variant apart

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -177,6 +177,11 @@ Developer account. `brew style` and the rest of the audit are clean, so this is
 the only thing standing in the way.
 
 `scripts/gen-homebrew-cask.sh <tag> --core` emits the variant for that PR, kept
-ready for the day notarization exists: core rejects casks whose caveats tell the
-user to reinstall with `--no-quarantine`, so that hint is dropped, leaving the
-right-click-Open instructions.
+ready for the day notarization exists: core is hostile to caveats that talk the
+user out of Gatekeeper, so the quarantine-clearing `xattr` command the tap
+caveat carries is dropped there, leaving the right-click-Open instructions.
+
+Never put `brew install --no-quarantine` in either variant. Homebrew 6 removed
+the flag, so the hint fails with `Error: invalid option: --no-quarantine` for
+tap users, and core rejected it before that. `brew audit` does not catch it, so
+the `cask-audit` action greps the generated cask and fails the run (#176).


### PR DESCRIPTION
Follow-up to #177, which is the change that fixes #176 in this repo. Merge that one first — this only touches prose #177 leaves stale.

`packaging/README.md` explains the `--core` variant by saying core rejects caveats that tell the user to reinstall with `--no-quarantine`. After #177 the tap caveat carries `xattr -dr com.apple.quarantine` instead, so that sentence describes a hint that no longer exists. Reworded to the actual reason core drops it — core is hostile to caveats that talk the user out of Gatekeeper — plus a line recording why the new `cask-audit` grep guard is there, since `brew audit` does not catch the flag.

Docs only. The other surfaces the issue lists are covered separately:

- VoltiusApp/homebrew-voltius#2 — published cask caveat + tap README (fixes existing users now, not at the next release)
- VoltiusApp/web#15 — landing page download card
- VoltiusApp/docs#17 — docs site install page