### PR TITLE
fix(plugins): activate externally installed plugins regardless of defaultEnabled

### DIFF
--- a/src/stores/marketplaceStore.externalActivation.test.ts
+++ b/src/stores/marketplaceStore.externalActivation.test.ts
@@ -1,0 +1,116 @@
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Uses the REAL plugin runtime and the REAL pluginRegistryStore: the bug being
+// covered is that an externally installed plugin lands inactive, which only shows
+// up through api.isActive() gating a real register() — a mocked loadPlugin cannot
+// prove it.
+const h = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  getVersion: vi.fn(async () => "2.5.0"),
+}));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: h.invoke }));
+vi.mock("@tauri-apps/api/app", () => ({ getVersion: h.getVersion }));
+vi.mock("@/i18n", () => ({ default: { t: (k: string) => k } }));
+vi.mock("@/services/http", () => ({ appFetch: vi.fn() }));
+vi.mock("@/plugins/importPluginModule", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/plugins/importPluginModule")>();
+  return { ...actual, importPluginModule: async () => ({ default: themeRegister }) };
+});
+
+import { useMarketplaceStore, loadInstalledPlugins, type MarketplacePlugin } from "./marketplaceStore";
+import { usePluginRegistryStore } from "./pluginRegistryStore";
+import { usePluginStore } from "./pluginStore";
+import { unloadPlugin } from "@/plugins/runtime";
+import type { PluginRegisterFn, PluginTheme } from "@/plugins/api";
+
+const PLUGIN_ID = "theme-plugin";
+const THEME_ID = "cool-theme";
+
+/** Mirrors the marketplace theme bundles byte for byte in the part that matters:
+ *  they open with an isActive() guard, so an inactive plugin registers nothing. */
+const themeRegister: PluginRegisterFn = (api) => {
+  if (!api.isActive()) return;
+  api.themes.register({ id: THEME_ID, name: "Cool Theme" } as PluginTheme);
+  return () => api.themes.unregister(THEME_ID);
+};
+
+/** A theme manifest as the marketplace actually ships it. */
+const MANIFEST = JSON.stringify({
+  id: PLUGIN_ID,
+  name: "Theme Plugin",
+  version: "1.0.0",
+  permissions: ["themes"],
+  defaultEnabled: false,
+});
+
+function themePlugin(): MarketplacePlugin {
+  return {
+    id: PLUGIN_ID, name: "Theme Plugin", author: "a", description: "d",
+    repo: "https://example.com/theme-plugin", version: "1.0.0",
+    tags: [], theme: true, sourceId: "voltius",
+  };
+}
+
+const registeredTheme = () => usePluginStore.getState().pluginThemes.get(THEME_ID);
+
+beforeEach(() => {
+  h.invoke.mockReset();
+  h.invoke.mockImplementation(async (cmd: string, args: Record<string, string> = {}) => {
+    if (cmd === "plugin_fetch_url") {
+      return args.url!.endsWith("manifest.json") ? MANIFEST : "js-text";
+    }
+    if (cmd === "plugins_list_installed") return [];
+    if (cmd === "plugin_read_file") {
+      if (args.filename === "manifest.json") return MANIFEST;
+      if (args.filename === "index.js") return "js-text";
+      throw new Error("no such file");
+    }
+    return undefined;
+  });
+  usePluginRegistryStore.setState({ overrides: {} });
+  usePluginStore.setState({ pluginThemes: new Map() });
+  useMarketplaceStore.setState({ installedMeta: [], installing: new Set(), catalog: [] });
+});
+
+afterEach(() => {
+  try { unloadPlugin(PLUGIN_ID); } catch { /* noop */ }
+});
+
+test("installing a theme plugin registers its theme even though the manifest sets defaultEnabled false", async () => {
+  await useMarketplaceStore.getState().installPlugin(themePlugin());
+
+  expect(registeredTheme()).toBeDefined();
+});
+
+test("a theme plugin installed with defaultEnabled false still registers its theme on the next boot", async () => {
+  h.invoke.mockImplementation(async (cmd: string, args: Record<string, string> = {}) => {
+    if (cmd === "plugins_list_installed") return [PLUGIN_ID];
+    if (cmd === "plugin_read_file") {
+      if (args.filename === "manifest.json") return MANIFEST;
+      if (args.filename === "index.js") return "js-text";
+      throw new Error("no such file");
+    }
+    return undefined;
+  });
+
+  await loadInstalledPlugins();
+
+  expect(registeredTheme()).toBeDefined();
+});
+
+test("an explicit disable override still keeps an installed plugin inactive", async () => {
+  usePluginRegistryStore.setState({ overrides: { [PLUGIN_ID]: false } });
+
+  await useMarketplaceStore.getState().installPlugin(themePlugin());
+
+  expect(registeredTheme()).toBeUndefined();
+});
+
+test("reloading a plugin the user disabled does not silently re-enable it", async () => {
+  usePluginRegistryStore.setState({ overrides: { [PLUGIN_ID]: false } });
+  await useMarketplaceStore.getState().installPlugin(themePlugin());
+
+  await useMarketplaceStore.getState().reloadPlugin(PLUGIN_ID);
+
+  expect(registeredTheme()).toBeUndefined();
+});

--- a/src/stores/marketplaceStore.ts
+++ b/src/stores/marketplaceStore.ts
@@ -178,6 +178,19 @@ async function takesFloorPath(plugin: MarketplacePlugin): Promise<boolean> {
     && useSeededTombstoneStore.getState().isRemoved(plugin.id);
 }
 
+/**
+ * Activation for an EXTERNALLY installed plugin.
+ *
+ * `defaultEnabled` is a seeded concept — "ships with the app, off until asked for".
+ * A catalogue plugin is on disk because the user installed it, so the install is
+ * the opt-in and the manifest flag must not gate it: honouring it left themes
+ * loaded-but-inactive, registering nothing, with no way back — the enable toggle
+ * exists only on seeded rows. An explicit stored override still wins.
+ */
+function externalPluginActive(manifestId: string): boolean {
+  return usePluginRegistryStore.getState().isEnabled(manifestId, true);
+}
+
 let appVersionPromise: Promise<string | null> | null = null;
 
 /** Resolves the running app's version once and caches it for the session. Falls
@@ -420,9 +433,7 @@ export const useMarketplaceStore = create<MarketplaceState>((set, get) => ({
       const mod = (await importPluginModule(jsText, cssText, plugin.id)) as PluginModule;
       // Honour a stored enable/disable override: reinstalling — or restoring on
       // another device — must not silently re-enable something the user turned off.
-      const active = usePluginRegistryStore
-        .getState()
-        .isEnabled(manifest.id, manifest.defaultEnabled ?? true);
+      const active = externalPluginActive(manifest.id);
       // An update over an id that's still registered must tear down the OLD code
       // first — loadPlugin silently no-ops on an id it already has, which would
       // leave the previous version running for the rest of the session while the
@@ -515,7 +526,7 @@ export const useMarketplaceStore = create<MarketplaceState>((set, get) => ({
     const jsText = await invoke<string>("plugin_read_file", { id, filename: "index.js" });
     const css = await readLocalCss(id);
     const mod = (await importPluginModule(jsText, css, id)) as PluginModule;
-    loadPlugin(manifest, pluginRegisterOf(mod), true, false, css);
+    loadPlugin(manifest, pluginRegisterOf(mod), externalPluginActive(manifest.id), false, css);
   },
 
   // ── Scan local ────────────────────────────────────────────────────────
@@ -533,7 +544,7 @@ export const useMarketplaceStore = create<MarketplaceState>((set, get) => ({
         const jsText = await invoke<string>("plugin_read_file", { id, filename: "index.js" });
         const css = await readLocalCss(id);
         const mod = (await importPluginModule(jsText, css, id)) as PluginModule;
-        loadPlugin(manifest, pluginRegisterOf(mod), true, false, css);
+        loadPlugin(manifest, pluginRegisterOf(mod), externalPluginActive(manifest.id), false, css);
         const newMeta: InstalledPluginMeta[] = [
           ...installedMeta,
           { id, version: manifest.version, sourceId: "local", hash: null },
@@ -722,9 +733,7 @@ export async function loadInstalledPlugins(): Promise<void> {
       const jsText = await invoke<string>("plugin_read_file", { id, filename: "index.js" });
       const css = await readLocalCss(id);
       const mod = (await importPluginModule(jsText, css, id)) as PluginModule;
-      const { isEnabled } = usePluginRegistryStore.getState();
-      const active = isEnabled(manifest.id, manifest.defaultEnabled ?? true);
-      loadPlugin(manifest, pluginRegisterOf(mod), active, false, css);
+      loadPlugin(manifest, pluginRegisterOf(mod), externalPluginActive(manifest.id), false, css);
     } catch (e) {
       console.warn(`[marketplace] Failed to load installed plugin "${id}":`, e);
     }


### PR DESCRIPTION
## The bug

Installing a theme from the marketplace added no theme to Settings → Appearance, and restarting did not help.

Both marketplace themes ship `"defaultEnabled": false` in their manifest. Install and boot both computed activation as `isEnabled(manifest.id, manifest.defaultEnabled ?? true)`, so with no stored override the plugin loaded **inactive**. Its `register()` opens with `if (!api.isActive()) return;`, so it contributed nothing, and boot recomputed the same inactive state — hence the restart doing nothing.

There was no way to recover from the UI: the enable/disable toggle renders only on seeded rows (`PluginsSection.tsx:487`), never on externally installed ones. The only escape was the Reload button, which happened to hardcode `active = true`.

## The fix

`defaultEnabled` means "ships with the app, off until asked for" — a seeded concept. A catalogue plugin is on disk because the user installed it, so the install is itself the opt-in and the manifest flag must not gate it.

One helper replaces four call sites (install, boot, reload, local scan):

```ts
function externalPluginActive(manifestId: string): boolean {
  return usePluginRegistryStore.getState().isEnabled(manifestId, true);
}
```

An explicit stored override still wins. That also fixes a second bug in passing: reload and local scan previously forced `active = true`, silently re-enabling a plugin the user had disabled.

Seeded plugins are untouched — `defaultEnabled` still means what it means for something that ships preinstalled.

## Tests

`src/stores/marketplaceStore.externalActivation.test.ts` — four tests. The fake bundle mirrors the real theme bundles' `isActive()` guard and asserts on `pluginThemes`, the store the Appearance list actually reads.

Written first; three failed for the expected reason before the change (no theme registered on install, none after boot, and reload re-enabling a disabled plugin), the fourth is a guard that passed throughout.

- 141 files / 1241 tests pass across the marketplace, plugin-registry, plugin-store and plugins suites
- `tsc --noEmit` clean

## Live verification

Driven through the real app in the headless container, on this branch:

- Installed **Emerald Night** from the live catalogue via the Browse tab, permission sheet and all
- Theme appears in the COLOR THEME grid; selecting it sets `--t-bg-terminal` to `#141729`, the bundle's own `bgTerminal`
- Survives an app restart, still selected

Negative control: reverting just this commit's change to `marketplaceStore.ts` in the same running build makes the theme vanish from the list and the terminal background fall back to `#0b1220`; restoring it brings both back.

## Follow-ups, deliberately not in this PR

- Externally installed plugins still have no enable/disable toggle at all, so disabling one without uninstalling is impossible. Worth deciding separately.
- Both marketplace theme manifests still carry `"defaultEnabled": false`. Harmless now that nothing reads it on this path, but misleading — a cleanup for the marketplace repo.
