### PR TITLE
fix(snippets): run palette snippets in the focused tab

### DIFF
--- a/src/components/omni/OmniSearch.tsx
+++ b/src/components/omni/OmniSearch.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/services/snippetParser";
 import { broadcastSnippetInject } from "@/services/snippets";
 import { runSnippetSequence, reportSequenceResult } from "@/services/snippetSequence";
+import { getActiveRunnableSession } from "@/services/snippetRun";
 import { snippetScriptText, snippetSearchText } from "@/services/snippetSteps";
 import type { Connection, TerminalSession, SshKey, Identity, Snippet } from "@/types";
 import { ConnectionAvatar } from "@/components/shared/ConnectionAvatar";
@@ -417,9 +418,7 @@ export default function OmniSearch({ onClose }: OmniSearchProps) {
         }
         onClose();
       } else if (item.kind === "snippet") {
-        const activeSession = sessions.find(
-          (s) => s.status === "connected" && s.type !== "multiplayer",
-        );
+        const activeSession = getActiveRunnableSession();
         if (!activeSession) { onClose(); return; }
 
         if (item.snippet.steps.some((s) => s.kind !== "script")) {
@@ -514,7 +513,7 @@ export default function OmniSearch({ onClose }: OmniSearchProps) {
     },
     [setActive, setActiveNav, onClose, setSidebarOpen,
      openSettings, setHomePendingAction, setKeychainPendingAction, pluginCommands,
-     sessions, connections, trackUsed, setGlobalPendingInject],
+     connections, trackUsed, setGlobalPendingInject],
   );
 
   useEffect(() => {

--- a/src/services/snippetRun.activeSession.spec.ts
+++ b/src/services/snippetRun.activeSession.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { TerminalSession } from "@/types";
+
+let sessions: TerminalSession[] = [];
+let activeSessionId: string | null = null;
+vi.mock("@/stores/sessionStore", () => ({
+  useSessionStore: { getState: () => ({ sessions, activeSessionId }) },
+}));
+
+import { getActiveRunnableSession } from "./snippetRun";
+
+function mkSession(over: Partial<TerminalSession>): TerminalSession {
+  return {
+    id: "sess1", type: "ssh", status: "connected", connectionId: "c1",
+    connectionName: "web01", ...over,
+  } as TerminalSession;
+}
+
+describe("getActiveRunnableSession", () => {
+  beforeEach(() => {
+    sessions = [];
+    activeSessionId = null;
+  });
+
+  it("returns the focused session, not the first connected one", () => {
+    sessions = [
+      mkSession({ id: "sess1" }),
+      mkSession({ id: "sess2", connectionId: "c2", connectionName: "db01" }),
+      mkSession({ id: "sess5", type: "local", connectionId: "", connectionName: "Local Shell" }),
+    ];
+    activeSessionId = "sess5";
+    expect(getActiveRunnableSession()?.id).toBe("sess5");
+  });
+
+  it("returns null when the focused session is a multiplayer mirror", () => {
+    sessions = [mkSession({ id: "sess1" }), mkSession({ id: "sess2", type: "multiplayer" })];
+    activeSessionId = "sess2";
+    expect(getActiveRunnableSession()).toBeNull();
+  });
+
+  it("returns null when the focused session is not connected", () => {
+    sessions = [mkSession({ id: "sess1" }), mkSession({ id: "sess2", status: "connecting" })];
+    activeSessionId = "sess2";
+    expect(getActiveRunnableSession()).toBeNull();
+  });
+
+  it("returns null when nothing is focused", () => {
+    sessions = [mkSession({ id: "sess1" })];
+    expect(getActiveRunnableSession()).toBeNull();
+  });
+});

--- a/src/services/snippetRun.ts
+++ b/src/services/snippetRun.ts
@@ -15,6 +15,14 @@ export function isRunnableSession(s: Pick<TerminalSession, "status" | "type">): 
   return s.status === "connected" && s.type !== "multiplayer";
 }
 
+/** The focused tab, when it can take an injection. No fallback to another tab:
+ *  injecting into a terminal the user is not looking at is worse than nothing. */
+export function getActiveRunnableSession(): TerminalSession | null {
+  const { sessions, activeSessionId } = useSessionStore.getState();
+  const s = sessions.find((x) => x.id === activeSessionId);
+  return s && isRunnableSession(s) ? s : null;
+}
+
 export interface RunOpts {
   /** Called when the snippet has unfilled user variables; the surface shows a modal. */
   onNeedVars: (pending: SnippetPendingInject) => void;
@@ -72,7 +80,7 @@ export function runSnippetIntoActiveSession(snippet: Snippet, sessionId?: string
   const sessions = useSessionStore.getState().sessions;
   const active = sessionId
     ? sessions.find((s) => s.id === sessionId && isRunnableSession(s))
-    : sessions.find(isRunnableSession);
+    : getActiveRunnableSession();
   if (!active) return false;
   void runSnippetIntoSessions(snippet, [active.id], true, {
     onNeedVars: (p) => useSnippetStore.getState().setGlobalPendingInject(p),


### PR DESCRIPTION
## Bug

With several terminal tabs open, opening the command palette (F1) and picking a snippet inserted it into **tab 1**, not the focused tab.

## Root cause

`OmniSearch.tsx` resolved the snippet target as the first connected, non-multiplayer session in tab order and never read `activeSessionId`:

```ts
const activeSession = sessions.find(
  (s) => s.status === "connected" && s.type !== "multiplayer",
);
```

The right-panel SnippetsPanel resolves by `activeSessionId` and was always correct — the palette was the odd one out.

## Fix

One shared resolver in `services/snippetRun.ts`:

```ts
export function getActiveRunnableSession(): TerminalSession | null {
  const { sessions, activeSessionId } = useSessionStore.getState();
  const s = sessions.find((x) => x.id === activeSessionId);
  return s && isRunnableSession(s) ? s : null;
}
```

Used by the palette and by `runSnippetIntoActiveSession()`, which carried the same first-match lookup (no callers today, so it was a latent trap rather than a second symptom). Pane splits are covered: focusing a pane calls `setActive(session.id)`.

Behavior note: if the focused session is a multiplayer mirror or not connected, the palette snippet now does nothing instead of injecting into an unrelated tab.

## Verification

- New unit test `snippetRun.activeSession.spec.ts` (red before the fix), plus the snippet/omni specs: 53 tests / 6 files green. `tsc --noEmit` clean.
- Live run in a headless dev build, 3 local shells each `cd`'d to a distinct dir, snippet `pwd >> /tmp/zz.log`:
  - focused tab 3, F1 + snippet → `/tmp/tab3`
  - same run with the old code restored (control) → `/tmp/tab1` (bug reproduced)
  - focused tab 2 → `/tmp/tab2`
  - right panel Insert & execute on tab 1 → `/tmp/tab1`, on tab 3 → `/tmp/tab3`; plain Insert put the text at tab 3's prompt without running it