### PR TITLE
fix(ssh): stop reconnecting after the remote shell exits on purpose

### DIFF
--- a/src-tauri/src/ssh/channel_io.rs
+++ b/src-tauri/src/ssh/channel_io.rs
@@ -13,9 +13,21 @@ pub struct ChannelIo {
     pub shutdown_tx: mpsc::Sender<()>,
 }
 
+/// The far side reported how the remote command ended before closing the
+/// channel. Only a command that ran to completion — the user typing `exit`, a
+/// one-shot command finishing, a signal killing it — gets an exit-status or
+/// exit-signal; a dropped link closes the channel with neither. The frontend
+/// reconnects on a drop and must not on a deliberate exit (#180).
+fn is_remote_exit(msg: &ChannelMsg) -> bool {
+    matches!(
+        msg,
+        ChannelMsg::ExitStatus { .. } | ChannelMsg::ExitSignal { .. }
+    )
+}
+
 /// Spawn the I/O loop for an opened channel: forward input and resizes, emit the
 /// channel's output as `ssh-output-<session_id>`, and emit `ssh-closed-<id>` when
-/// the far side ends it.
+/// the far side ends it, carrying whether the remote command exited on its own.
 pub fn spawn_channel_io(
     app: AppHandle,
     session_id: &str,
@@ -42,6 +54,7 @@ pub fn spawn_channel_io_split(
     let mut writer = write_half.make_writer();
 
     tokio::spawn(async move {
+        let mut remote_exit = false;
         loop {
             tokio::select! {
                 _ = shutdown_rx.recv() => break,
@@ -62,9 +75,12 @@ pub fn spawn_channel_io_split(
                             let _ = app.emit(&event_name, data.as_ref());
                         }
                         Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => {
-                            let _ = app.emit(&close_event, ());
+                            let _ = app.emit(&close_event, remote_exit);
                             break;
                         }
+                        // Sent just before Eof/Close, so the flag is set by the
+                        // time the close event goes out.
+                        Some(ref m) if is_remote_exit(m) => remote_exit = true,
                         _ => {}
                     }
                 }
@@ -124,4 +140,27 @@ pub async fn open_exec_session(
         .await;
 
     Ok(new_session_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_a_reported_exit_counts_as_a_remote_exit() {
+        // A shell the user quit, or a command that finished, is reported.
+        assert!(is_remote_exit(&ChannelMsg::ExitStatus { exit_status: 0 }));
+        assert!(is_remote_exit(&ChannelMsg::ExitSignal {
+            signal_name: russh::Sig::TERM,
+            core_dumped: false,
+            error_message: String::new(),
+            lang_tag: String::new(),
+        }));
+        // A dropped link only ever produces these, and must stay reconnectable.
+        assert!(!is_remote_exit(&ChannelMsg::Eof));
+        assert!(!is_remote_exit(&ChannelMsg::Close));
+        assert!(!is_remote_exit(&ChannelMsg::WindowAdjusted {
+            new_size: 4096
+        }));
+    }
 }

--- a/src/components/layout/MainPanel.tsx
+++ b/src/components/layout/MainPanel.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/sessionStore";
-import { reconnectWithBackoff } from "@/stores/reconnectBackoff";
-import { handleSessionClosed } from "@/stores/reconnectBackoffCore";
+import { sessionClosed } from "@/stores/reconnectBackoff";
 import { useUIStore } from "@/stores/uiStore";
 import { useVaultStore } from "@/stores/vaultStore";
 import { useTeamStore } from "@/stores/teamStore";
@@ -170,7 +169,6 @@ function useSelectedTeamId(): string | null {
 
 export default function MainPanel() {
   const { sessions, activeSessionId } = useSessionStore();
-  const markDisconnected = useSessionStore((s) => s.markDisconnected);
   const reconnect = useSessionStore((s) => s.reconnect);
   const reconnectWithPassphrase = useSessionStore((s) => s.reconnectWithPassphrase);
   const retryConnect = useSessionStore((s) => s.retryConnect);
@@ -287,13 +285,7 @@ export default function MainPanel() {
                       <HostAwareTerminalView
                         session={session}
                         active={session.id === activeSessionId && session.status === "connected" && !overlayContent}
-                        onClosed={() =>
-                          handleSessionClosed(session.type, session.id, {
-                            status: (id) => useSessionStore.getState().sessions.find((s) => s.id === id)?.status,
-                            markDisconnected,
-                            reconnectWithBackoff,
-                          })
-                        }
+                        onClosed={(remoteExit) => sessionClosed(session.type, session.id, remoteExit)}
                       />
                     )}
                     {session.id === activeSessionId && !overlayContent && (

--- a/src/components/mobile/MobileSessionView.tsx
+++ b/src/components/mobile/MobileSessionView.tsx
@@ -1,13 +1,11 @@
 import { useSessionStore } from "@/stores/sessionStore";
-import { reconnectWithBackoff } from "@/stores/reconnectBackoff";
-import { handleSessionClosed } from "@/stores/reconnectBackoffCore";
+import { sessionClosed } from "@/stores/reconnectBackoff";
 import { HostAwareTerminalView, SessionConnectionOverlay } from "@/components/terminal/SessionView";
 import MobileTerminalGestures from "./MobileTerminalGestures";
 import type { TerminalSession } from "@/types";
 
 /** Mobile-only wrapper: renders the shared terminal compact inside a hard-clipped box. */
 export default function MobileSessionView({ session, active }: { session: TerminalSession; active: boolean }) {
-  const markDisconnected = useSessionStore((s) => s.markDisconnected);
   const reconnect = useSessionStore((s) => s.reconnect);
   const reconnectWithPassphrase = useSessionStore((s) => s.reconnectWithPassphrase);
   const retryConnect = useSessionStore((s) => s.retryConnect);
@@ -28,13 +26,7 @@ export default function MobileSessionView({ session, active }: { session: Termin
         session={session}
         active={active}
         compact
-        onClosed={() =>
-          handleSessionClosed(session.type, session.id, {
-            status: (id) => useSessionStore.getState().sessions.find((s) => s.id === id)?.status,
-            markDisconnected,
-            reconnectWithBackoff,
-          })
-        }
+        onClosed={(remoteExit) => sessionClosed(session.type, session.id, remoteExit)}
       />
       {session.status === "connected" && <MobileTerminalGestures sessionId={session.id} active={active} />}
     </div>

--- a/src/components/panes/PaneTerminal.tsx
+++ b/src/components/panes/PaneTerminal.tsx
@@ -4,12 +4,10 @@ import MultiplayerTerminalView from "@/components/terminal/MultiplayerTerminalVi
 import { MultiplayerBar } from "@/components/terminal/MultiplayerBar";
 import { HostAwareTerminalView, SessionConnectionOverlay } from "@/components/terminal/SessionView";
 import { useSessionStore } from "@/stores/sessionStore";
-import { reconnectWithBackoff } from "@/stores/reconnectBackoff";
-import { handleSessionClosed } from "@/stores/reconnectBackoffCore";
+import { sessionClosed } from "@/stores/reconnectBackoff";
 import type { TerminalSession } from "@/types";
 
 export function PaneTerminal({ session, active }: { session: TerminalSession; active: boolean }) {
-  const markDisconnected = useSessionStore((s) => s.markDisconnected);
   const reconnect = useSessionStore((s) => s.reconnect);
   const removeSession = useSessionStore((s) => s.removeSession);
   const reconnectWithPassphrase = useSessionStore((s) => s.reconnectWithPassphrase);
@@ -39,13 +37,7 @@ export function PaneTerminal({ session, active }: { session: TerminalSession; ac
         session={session}
         active={active && session.status === "connected"}
         statusBar={false}
-        onClosed={() =>
-          handleSessionClosed(session.type, session.id, {
-            status: (id) => useSessionStore.getState().sessions.find((s) => s.id === id)?.status,
-            markDisconnected,
-            reconnectWithBackoff,
-          })
-        }
+        onClosed={(remoteExit) => sessionClosed(session.type, session.id, remoteExit)}
       />
     </div>
   );

--- a/src/components/terminal/SessionView.tsx
+++ b/src/components/terminal/SessionView.tsx
@@ -22,7 +22,7 @@ export function HostAwareTerminalView({
 }: {
   session: TerminalSession;
   active: boolean;
-  onClosed: () => void;
+  onClosed: (remoteExit: boolean) => void;
   /** Mobile: render the terminal compact (no minimap) and suppress the status-bar footer. */
   compact?: boolean;
   /** Split panes carry no status bar of their own. */

--- a/src/components/terminal/Terminal.tsx
+++ b/src/components/terminal/Terminal.tsx
@@ -9,7 +9,7 @@ import "@xterm/xterm/css/xterm.css";
 interface Props {
   sessionId: string;
   sessionType: "ssh" | "local" | "serial";
-  onClosed?: () => void;
+  onClosed?: (remoteExit: boolean) => void;
   active?: boolean;
   inputGate?: React.RefObject<() => boolean>;
   encoding?: string;

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -35,7 +35,7 @@ import { getPlatform } from "@/utils/platform";
 interface UseTerminalOptions {
   sessionId: string;
   sessionType: "ssh" | "local" | "serial";
-  onClosed?: () => void;
+  onClosed?: (remoteExit: boolean) => void;
   /** If provided, input is only sent to the process when this returns true. */
   inputGate?: React.RefObject<() => boolean>;
   encoding?: string;
@@ -169,7 +169,7 @@ type CacheEntry = {
   /** Mirror of the useTerminal `inputGate` so module-level senders (writeToSession)
    *  honor the same multiplayer control-holder gate as the onData handler. */
   inputGateRef: { current: (() => boolean) | undefined };
-  onClosedRef: { current: (() => void) | undefined };
+  onClosedRef: { current: ((remoteExit: boolean) => void) | undefined };
   onResizeRef: { current: ((cols: number, rows: number) => void) | undefined };
   dispose: () => void; // full teardown, called only when the session is deleted
 };
@@ -1071,7 +1071,7 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
           onLocalOutput(sessionId, (data) => { term.write(decoder ? decoder.decode(data) : data, () => scheduleMinimapNotify(entry)); }),
           onLocalClosed(sessionId, () => {
             term.write("\r\n\x1b[90m--- Session closed ---\x1b[0m\r\n");
-            entry.onClosedRef.current?.();
+            entry.onClosedRef.current?.(false);
           }),
         ];
         unlistenPromises.push(...localListeners);
@@ -1089,7 +1089,7 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
         unlistenPromises.push(
           onSerialClosed(sessionId, () => {
             term.write("\r\n\x1b[90m--- Serial connection closed ---\x1b[0m\r\n");
-            entry.onClosedRef.current?.();
+            entry.onClosedRef.current?.(false);
           }),
         );
       } else {
@@ -1100,8 +1100,8 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
           }),
         );
         unlistenPromises.push(
-          onSshClosed(sessionId, () => {
-            entry.onClosedRef.current?.();
+          onSshClosed(sessionId, (remoteExit) => {
+            entry.onClosedRef.current?.(remoteExit);
           }),
         );
         // Persistent sessions (tmux/screen) hide the shell's OSC 7 from the

--- a/src/services/ssh.ts
+++ b/src/services/ssh.ts
@@ -171,12 +171,14 @@ export async function onSshOutput(
   });
 }
 
+/** `remoteExit` is true when the far side sent an exit-status/exit-signal
+ * before closing — the remote command ended on its own, it was not a drop. */
 export async function onSshClosed(
   sessionId: string,
-  callback: () => void,
+  callback: (remoteExit: boolean) => void,
 ): Promise<UnlistenFn> {
-  return listen(`ssh-closed-${sessionId}`, () => {
-    callback();
+  return listen<boolean>(`ssh-closed-${sessionId}`, (event) => {
+    callback(event.payload === true);
   });
 }
 

--- a/src/stores/reconnectBackoff.test.ts
+++ b/src/stores/reconnectBackoff.test.ts
@@ -160,10 +160,12 @@ globalThis.setTimeout = realSetTimeout;
 // --- handleSessionClosed: start reconnect only on an unexpected close ---
 (() => {
   const calls: string[] = [];
-  const deps = (status: SessionStatus) => ({
+  const deps = (status: SessionStatus, persist = false) => ({
     status: () => status,
+    persist: () => persist,
     markDisconnected: () => calls.push("disconnect"),
     reconnectWithBackoff: () => calls.push("backoff"),
+    endSession: () => calls.push("end"),
   });
 
   calls.length = 0;
@@ -185,5 +187,24 @@ globalThis.setTimeout = realSetTimeout;
   calls.length = 0;
   handleSessionClosed("local", "s1", deps("connected"));
   assertEqual(calls, ["disconnect"], "local close marks disconnected without reconnecting");
+
+  // The remote shell exited on purpose (`exit`): the channel carried an
+  // exit-status, so this is not a drop and reconnecting would resurrect a
+  // session the user just closed (#180).
+  calls.length = 0;
+  handleSessionClosed("ssh", "s1", deps("connected"), true);
+  assertEqual(calls, ["end"], "a clean remote exit ends the session instead of reconnecting");
+
+  // Persistent sessions run inside tmux/screen: the wrapper exiting can also
+  // mean a detach, so the attach probe stays the judge of whether it ended.
+  calls.length = 0;
+  handleSessionClosed("ssh", "s1", deps("connected", true), true);
+  assertEqual(calls, ["backoff"], "a persistent session still reconnects on a clean wrapper exit");
+
+  // A dropped link carries no exit-status.
+  calls.length = 0;
+  handleSessionClosed("ssh", "s1", deps("connected"), false);
+  assertEqual(calls, ["backoff"], "a drop with no exit-status still reconnects");
 })();
+
 });

--- a/src/stores/reconnectBackoff.ts
+++ b/src/stores/reconnectBackoff.ts
@@ -1,5 +1,5 @@
 import { useSessionStore } from "./sessionStore";
-import { type BackoffStore, runBackoff } from "./reconnectBackoffCore";
+import { type BackoffStore, handleSessionClosed, runBackoff } from "./reconnectBackoffCore";
 
 const liveStore: BackoffStore = {
   status: (id) => useSessionStore.getState().sessions.find((s) => s.id === id)?.status,
@@ -21,4 +21,24 @@ export function reconnectWithBackoff(sessionId: string): Promise<boolean> {
     void import("@/services/sync").then(({ syncNow }) => syncNow().catch(() => {}));
   }
   return runBackoff(sessionId, liveStore);
+}
+
+/** `handleSessionClosed` bound to the live stores — every terminal view routes
+ * its channel-closed event through this. */
+export function sessionClosed(sessionType: string, sessionId: string, remoteExit: boolean): void {
+  handleSessionClosed(
+    sessionType,
+    sessionId,
+    {
+      status: (id) => useSessionStore.getState().sessions.find((s) => s.id === id)?.status,
+      persist: (id) => !!useSessionStore.getState().sessions.find((s) => s.id === id)?.persist,
+      markDisconnected: (id) => useSessionStore.getState().markDisconnected(id),
+      reconnectWithBackoff,
+      endSession: (id) => {
+        // The shell is already gone; this drops the transport and the tab.
+        void import("@/services/closeSession").then(({ closeSession }) => closeSession(id));
+      },
+    },
+    remoteExit,
+  );
 }

--- a/src/stores/reconnectBackoffCore.ts
+++ b/src/stores/reconnectBackoffCore.ts
@@ -98,20 +98,33 @@ export async function runBackoff(sessionId: string, store: BackoffStore): Promis
  * so the steady overlay never flickers and no second loop spawns. The loop owns
  * the 'reconnecting' (connecting) state, so we don't set it here.
  *
+ * `remoteExit` means the far side sent an exit-status/exit-signal before the
+ * close: the shell ended on purpose (the user typed `exit`), not a dropped
+ * link, so the session is over and reconnecting would resurrect it (#180).
+ * Persistent sessions are excluded: their wrapper also exits on a tmux/screen
+ * detach, so there the attach probe (SESSION_ENDED) stays the judge.
+ *
  * local: just mark disconnected (no reconnect). */
 export function handleSessionClosed(
   sessionType: string,
   sessionId: string,
   deps: {
     status: (id: string) => SessionStatus;
+    persist: (id: string) => boolean;
     markDisconnected: (id: string) => void;
     reconnectWithBackoff: (id: string) => void;
+    endSession: (id: string) => void;
   },
+  remoteExit = false,
 ): void {
   if (sessionType !== "ssh" && sessionType !== "serial") {
     deps.markDisconnected(sessionId);
     return;
   }
   if (deps.status(sessionId) !== "connected") return;
+  if (remoteExit && !deps.persist(sessionId)) {
+    deps.endSession(sessionId);
+    return;
+  }
   deps.reconnectWithBackoff(sessionId);
 }


### PR DESCRIPTION
Fixes #180.

## The bug

With **Settings → Hosts → Persistent sessions** off, typing `exit` in an SSH terminal disconnected and then immediately reconnected to the same host. With persistent sessions on, `exit` behaved correctly.

## Root cause

`ssh-closed-<id>` carried no reason for the close, so `handleSessionClosed` treated a deliberate `exit` exactly like a dropped link and started the reconnect backoff. Persistent sessions escaped it only by accident: their attach-only probe fails with `SESSION_ENDED`, which tears the tab down.

A deliberate exit and a dropped link are distinguishable on the wire. Verified against a local sshd:

- `exit` from an interactive shell → `client_input_channel_req: channel 0 rtype exit-status`
- transport killed mid-session → zero exit-status messages

## The fix

- `channel_io.rs` records an `ExitStatus` / `ExitSignal` seen before Eof/Close and ships that flag as the `ssh-closed-<id>` payload.
- `handleSessionClosed` ends the session (disconnect + drop the tab, via `closeSession`) instead of reconnecting when the flag is set — matching what persistent sessions already do when their session ends on the host.
- Persistent sessions keep the old path: their tmux/screen wrapper also exits on a detach, so the attach probe stays the judge there.
- The three terminal views (`MainPanel`, `PaneTerminal`, `MobileSessionView`) each built the same deps object; they now share one `sessionClosed` helper.

## Tests

- `channel_io::tests::only_a_reported_exit_counts_as_a_remote_exit` — exit-status/exit-signal count, Eof/Close/other messages do not.
- `reconnectBackoff.test.ts` — clean exit ends the session; clean exit on a persistent session still reconnects; a drop with no exit-status still reconnects.
- `tsc --noEmit` clean.

## Live run

Headless container on this branch, persistent sessions toggled **off**, real SSH host (`ssh-host-1`):

- Typed `exit` → the connected session left the store within 1 s and stayed gone for the 13 s watched; its tab disappeared from the tab bar. No reconnect.
- Control, same build: `kill -9` on the remote `sshd-session` pids (a drop, no exit-status) → session went `connecting` at 2 s and back to `connected` at 4 s. Reconnect still works.