### PR TITLE
fix(plugins): give installed plugins the same enable toggle as bundled ones

### DIFF
--- a/src/components/settings/sections/PluginsSection.enableToggle.test.tsx
+++ b/src/components/settings/sections/PluginsSection.enableToggle.test.tsx
@@ -1,0 +1,120 @@
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import type { PluginManifest } from "@/plugins/api";
+
+const manifest = (id: string, permissions: string[]): PluginManifest =>
+  ({ id, name: id, version: "1.0.0", description: "", permissions } as PluginManifest);
+
+const DOCKER = manifest("plugin-docker", ["docker:read"]);
+const THEME = manifest("emerald-night", ["themes"]);
+
+const loaded = vi.hoisted(() => ({ list: [] as PluginManifest[] }));
+const runtime = vi.hoisted(() => ({ setPluginActive: vi.fn() }));
+vi.mock("@/plugins/runtime", () => ({
+  getLoadedPlugins: () => loaded.list,
+  setPluginActive: runtime.setPluginActive,
+  pluginStorageGet: vi.fn(async () => null),
+  pluginStorageSet: vi.fn(async () => {}),
+}));
+const marketplaceState = {
+  installedMeta: [] as unknown[], catalog: [] as unknown[],
+  installing: new Set<string>(),
+  uninstallPlugin: vi.fn(async () => {}),
+  uninstallSeededPlugin: vi.fn(async () => {}),
+  reloadPlugin: vi.fn(async () => {}),
+  scanLocal: vi.fn(async () => {}),
+  installPlugin: vi.fn(async () => {}),
+  fetchManifest: vi.fn(async () => ({ manifest: { permissions: [] }, manifestText: "" })),
+  appVersion: null as string | null,
+  loadAppVersion: vi.fn(async () => {}),
+};
+const FIRST_PARTY_SOURCE = vi.hoisted(() => ({ id: "voltius", name: "Voltius Marketplace", url: "", enabled: true, deletable: false }));
+vi.mock("@/stores/marketplaceStore", () => ({
+  useMarketplaceStore: (selector?: (s: typeof marketplaceState) => unknown) =>
+    selector ? selector(marketplaceState) : marketplaceState,
+  FIRST_PARTY_SOURCE,
+}));
+vi.mock("@/stores/notificationStore", () => ({
+  useNotificationStore: Object.assign(() => ({ push: vi.fn() }), { getState: () => ({ push: vi.fn() }) }),
+}));
+vi.mock("@/stores/toggleSettingsStore", () => ({ getToggle: () => false, useToggle: () => false }));
+vi.mock("@/components/shared/ToolbarViewControls", () => ({ useFilterShortcut: () => {} }));
+vi.mock("@/components/shared/Toggle", () => ({
+  Toggle: ({ checked, onChange }: { checked: boolean; onChange: () => void }) => (
+    <button data-testid="enable-toggle" data-checked={String(checked)} onClick={onChange} />
+  ),
+}));
+vi.mock("@/components/settings/sections/PluginPermissionModal", () => ({ PluginPermissionModal: () => null }));
+vi.mock("@/utils/platform", () => ({ useIsAndroid: () => false }));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
+}));
+vi.mock("@iconify/react", () => ({ Icon: () => null }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn(async () => {}) }));
+vi.mock("@/stores/seededTombstoneStore", () => ({
+  useSeededTombstoneStore: Object.assign((sel?: (s: { removed: string[] }) => unknown) => sel ? sel({ removed: [] }) : { removed: [] }, {
+    getState: () => ({ removed: [], isRemoved: () => false }),
+  }),
+  loadSeededEntries: vi.fn(async () => new Map()),
+}));
+
+import { InstalledTab } from "@/components/settings/sections/PluginsSection";
+import { usePluginStore } from "@/stores/pluginStore";
+import { usePluginRegistryStore } from "@/stores/pluginRegistryStore";
+
+/** Puts a plugin in the EXTERNAL list — the shape `installPlugin` writes. */
+function asInstalled(m: PluginManifest) {
+  loaded.list = [m];
+  marketplaceState.installedMeta = [
+    { id: m.id, version: m.version, sourceId: "voltius", hash: "h", repo: "https://example.com/x" },
+  ];
+}
+
+/** Puts a plugin in the BUNDLED list — loaded, with no installedMeta entry. */
+function asBundled(m: PluginManifest) {
+  loaded.list = [m];
+  marketplaceState.installedMeta = [];
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  runtime.setPluginActive.mockClear();
+  usePluginRegistryStore.setState({ overrides: {} });
+  usePluginStore.setState({ settingsPages: new Map() });
+  marketplaceState.catalog = [];
+  marketplaceState.appVersion = null;
+});
+afterEach(cleanup);
+
+test("an installed non-theme plugin can be disabled, exactly like the bundled copy", () => {
+  asInstalled(DOCKER);
+  render(<InstalledTab />);
+  expect(screen.queryByTestId("enable-toggle")).not.toBeNull();
+});
+
+test("the same plugin bundled with the app also shows the toggle", () => {
+  asBundled(DOCKER);
+  render(<InstalledTab />);
+  expect(screen.queryByTestId("enable-toggle")).not.toBeNull();
+});
+
+test("a theme plugin is installed-or-not, so it shows no enable toggle when installed", () => {
+  asInstalled(THEME);
+  render(<InstalledTab />);
+  expect(screen.queryByTestId("enable-toggle")).toBeNull();
+});
+
+test("a theme plugin shows no enable toggle when bundled either", () => {
+  asBundled(THEME);
+  render(<InstalledTab />);
+  expect(screen.queryByTestId("enable-toggle")).toBeNull();
+});
+
+test("toggling an installed plugin off deactivates it and persists the override", () => {
+  asInstalled(DOCKER);
+  render(<InstalledTab />);
+  fireEvent.click(screen.getByTestId("enable-toggle"));
+  expect(runtime.setPluginActive).toHaveBeenCalledWith("plugin-docker", false);
+  expect(usePluginRegistryStore.getState().overrides["plugin-docker"]).toBe(false);
+});

--- a/src/components/settings/sections/PluginsSection.tsx
+++ b/src/components/settings/sections/PluginsSection.tsx
@@ -252,6 +252,25 @@ function usePluginInstaller() {
 // ─── Installed tab ─────────────────────────────────────────────────────────
 
 /**
+ * The enable/disable control, and the one rule for whether a plugin gets one.
+ *
+ * A theme plugin contributes nothing but themes, so "disabled" and "not installed"
+ * would mean the same thing to the user — it is installed or it isn't. Everything
+ * else can be turned off without losing it. This is a property of the PLUGIN, not
+ * of how it reached the disk: the same plugin must offer the same control whether
+ * it shipped with the app or was installed from a catalogue.
+ */
+function EnableToggle({ manifest, enabled, onToggle }: {
+  manifest: PluginManifest;
+  enabled: boolean;
+  onToggle: (id: string, enabled: boolean) => void;
+}) {
+  const themeOnly = manifest.permissions.length === 1 && manifest.permissions[0] === "themes";
+  if (themeOnly) return null;
+  return <Toggle checked={enabled} onChange={() => onToggle(manifest.id, enabled)} />;
+}
+
+/**
  * Seeded first-party plugins have no static entry anywhere — the runtime registry
  * is the only place that knows they exist. `excludeIds` strips out externally-installed
  * ids so a plugin is never listed twice.
@@ -484,7 +503,7 @@ export function InstalledTab() {
                 >
                   <Icon icon={isUninstalling ? "lucide:loader" : "lucide:trash-2"} width={14} className={isUninstalling ? "animate-spin" : ""} />
                 </button>
-                <Toggle checked={enabled} onChange={() => handleToggle(manifest.id, enabled)} />
+                <EnableToggle manifest={manifest} enabled={enabled} onToggle={handleToggle} />
               </div>
               {manifest.permissions.length > 0 && (
                 <div className="flex flex-wrap gap-1 px-4 py-2 border-t border-t-(--t-border)">
@@ -501,6 +520,11 @@ export function InstalledTab() {
         {filteredExternal.map((meta) => {
           const manifest = externalManifests.find((m) => m.id === meta.id);
           const isLoaded = loadedIds.has(meta.id);
+          // `true` mirrors marketplaceStore's externalPluginActive: installing IS the
+          // opt-in, so an installed plugin is on unless the user turned it off. Kept
+          // as a literal rather than imported because that helper reads the store via
+          // getState(), which would not re-render this row when the override changes.
+          const enabled = isLoaded && isEnabled(meta.id, true);
           const isReloading = reloading.has(meta.id);
           const isUninstalling = uninstalling.has(meta.id);
           const update = availableUpdate(meta, catalog);
@@ -511,11 +535,11 @@ export function InstalledTab() {
             <div
               key={meta.id}
               className="rounded-xl overflow-hidden bg-(--t-bg-card)"
-              style={{ border: `1px solid ${isLoaded ? "var(--t-border-hover)" : "var(--t-border)"}`, opacity: isLoaded ? 1 : 0.7 }}
+              style={{ border: `1px solid ${enabled ? "var(--t-border-hover)" : "var(--t-border)"}`, opacity: enabled ? 1 : 0.7 }}
             >
               <div className="flex items-center gap-3 px-4 py-3">
                 <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 bg-(--t-bg-elevated) border border-(--t-border)">
-                  <Icon icon="lucide:puzzle" width={15} style={{ color: isLoaded ? "var(--t-accent)" : "var(--t-text-dim)" }} />
+                  <Icon icon="lucide:puzzle" width={15} style={{ color: enabled ? "var(--t-accent)" : "var(--t-text-dim)" }} />
                 </div>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">
@@ -580,6 +604,7 @@ export function InstalledTab() {
                 >
                   <Icon icon={isUninstalling ? "lucide:loader" : "lucide:trash-2"} width={14} className={isUninstalling ? "animate-spin" : ""} />
                 </button>
+                {manifest && <EnableToggle manifest={manifest} enabled={enabled} onToggle={handleToggle} />}
               </div>
               {manifest && manifest.permissions.length > 0 && (
                 <div className="flex flex-wrap gap-1 px-4 py-2 border-t border-t-(--t-border)">


### PR DESCRIPTION
## The bug

Whether a plugin could be disabled depended on **how it reached the disk**, not on what it is.

The Installed tab builds its first list from `seededPluginManifests(externalPluginIds)`, which despite the name returns *every loaded plugin that isn't in `installedMeta`* — i.e. the app-bundled ones. Only those rows rendered a `<Toggle>`. Rows built from `installedMeta` — anything installed from a catalogue, a URL, or a local scan — rendered Update / Reload / Uninstall and no toggle.

Consequences:

- Installing a first-party plugin from Browse instead of using the bundled copy moved its id into `installedMeta`, so `loadSeededPlugins` then skipped it and it appeared in the external list — **the same plugin, silently losing the toggle it had while bundled**.
- Themes, which are only ever installed, never had one at all.

## The fix

The rule becomes a property of the plugin rather than of its provenance, in one place both row types call:

```tsx
function EnableToggle({ manifest, enabled, onToggle }) {
  const themeOnly = manifest.permissions.length === 1 && manifest.permissions[0] === "themes";
  if (themeOnly) return null;
  return <Toggle checked={enabled} onChange={() => onToggle(manifest.id, enabled)} />;
}
```

A theme-only plugin contributes nothing but themes, so "disabled" and "not installed" would mean the same thing to the user — it stays installed-or-not, which is the behaviour that was already there and worth keeping. Everything else can be turned off without losing it, bundled or installed.

Installed rows compute `enabled` as `isLoaded && isEnabled(meta.id, true)`, mirroring `externalPluginActive` from #181, and now dim when disabled the way bundled rows already did.

## Tests

`PluginsSection.enableToggle.test.tsx` — five tests covering the matrix (non-theme installed / non-theme bundled / theme installed / theme bundled) plus one that the toggle actually deactivates the plugin and persists the override.

Written first; three failed for the expected reasons: installed non-theme had no toggle, bundled theme had one it shouldn't, and there was nothing to click. 16 tests across the three `PluginsSection` files pass now, `tsc --noEmit` clean.

## Live verification

In the headless container on this branch, both installed from the live catalogue:

| Installed row | Toggle |
|---|---|
| SSH Config Sync | yes |
| Emerald Night | no |

Toggling SSH Config Sync off flips `aria-checked` to `false`, dims the row to `opacity: 0.7`, and **survives a restart** — the override persists and #181's boot path honours it. Toggling back on restores it.

Negative control: reverting just this commit's change to `PluginsSection.tsx` in the same running build drops SSH Config Sync's toggle count from 1 to 0; restoring brings it back.

## Note

`seededPluginManifests` is misleadingly named — it returns loaded-minus-installed, not "seeded". It misled me into an incorrect claim earlier in this work. Renaming it is not in this PR, but it should probably be `unmanagedPluginManifests` or similar.
