### PR TITLE
fix(team): stop reading a role restriction as a revoked team vault (#187)

### DIFF
--- a/src/services/teamVaultSync.data.test.ts
+++ b/src/services/teamVaultSync.data.test.ts
@@ -33,6 +33,7 @@ import { useSnippetStore } from "@/stores/snippetStore";
 import { useSnippetFolderStore } from "@/stores/snippetFolderStore";
 import { usePortForwardingStore } from "@/stores/portForwardingStore";
 import { useTeamVaultStateStore } from "@/stores/teamVaultStateStore";
+import { useTeamStore } from "@/stores/teamStore";
 
 function futureJwt(): string {
   const exp = Math.floor(Date.now() / 1000) + 3600;
@@ -230,4 +231,40 @@ test("fetchTeamData decrypts the legacy blob and populates the seven store slice
   expect(useSnippetFolderStore.getState().teamSnippetFolders[teamId]).toEqual([{ id: "sf1" }]);
   expect(usePortForwardingStore.getState().teamRules[teamId]).toEqual([{ id: "pf1" }]);
   expect(useTeamVaultStateStore.getState().statusByTeamId[teamId]).toBe("loaded");
+});
+
+
+/**
+ * connect-only members hold no VIEW_SECRETS, so `GET /vault-key` 403s for them.
+ * On an empty team vault — the one a joiner meets right after conversion — that
+ * used to surface as "Access revoked" (issue #187). They were never revoked:
+ * their view of the vault is the object route, which returned nothing.
+ */
+test("fetchTeamData shows an empty vault, not a revocation, when the key route 403s a listed member", async () => {
+  const teamId = "t-connect-only";
+  useTeamStore.setState({ teams: [{ id: teamId, role_ids: [] }] as never });
+  keychain({ server_url: "https://s", jwt: futureJwt() });
+  h.appFetch.mockImplementation(async (url: string) => {
+    if (url.endsWith("/vault-key")) return res(403);
+    throw new Error(`unexpected fetch ${url}`);
+  });
+
+  await fetchTeamData(teamId);
+
+  expect(useTeamVaultStateStore.getState().statusByTeamId[teamId]).toBe("loaded");
+  expect(useConnectionStore.getState().teamConnections[teamId] ?? []).toEqual([]);
+});
+
+test("fetchTeamData still reports a revocation when the 403'd team is no longer listed", async () => {
+  const teamId = "t-revoked";
+  useTeamStore.setState({ teams: [] as never });
+  keychain({ server_url: "https://s", jwt: futureJwt() });
+  h.appFetch.mockImplementation(async (url: string) => {
+    if (url.endsWith("/vault-key")) return res(403);
+    throw new Error(`unexpected fetch ${url}`);
+  });
+
+  await fetchTeamData(teamId);
+
+  expect(useTeamVaultStateStore.getState().statusByTeamId[teamId]).toBe("forbidden");
 });

--- a/src/services/teamVaultSync.ts
+++ b/src/services/teamVaultSync.ts
@@ -93,7 +93,9 @@ async function fetchWithAuth(url: string, init: RequestInit): Promise<Response> 
  *
  * Throws typed string errors for callers to route to the right UX state:
  *   "offline"          — network error or navigator.onLine === false
- *   "forbidden"        — server returned 403 (membership revoked)
+ *   "forbidden"        — server returned 403 (removed from the team, or the
+ *                        caller's role lacks VIEW_SECRETS — callers that can
+ *                        tell the two apart should; see fetchTeamData)
  *   "payment_required" — server returned 402 (subscription lapsed)
  *   "awaiting_key"     — server returned 404 (no wrapped key for this member yet)
  *   "error"            — anything else
@@ -316,10 +318,20 @@ async function _fetchTeamData(teamId: string, options: TeamVaultRefreshOptions):
   try {
     key = await getTeamVaultKey(teamId);
   } catch (err) {
-    const validStatuses = ["offline", "forbidden", "payment_required", "awaiting_key", "error"] as const;
-    type S = typeof validStatuses[number];
-    const status: S = validStatuses.includes(err as S) ? (err as S) : "error";
     if (options.background) return;
+    const validStatuses = ["offline", "forbidden", "payment_required", "awaiting_key", "error"] as const;
+    type Thrown = typeof validStatuses[number];
+    let status: Thrown | "loaded" = validStatuses.includes(err as Thrown) ? (err as Thrown) : "error";
+    // A 403 here means one of two very different things: the caller was removed
+    // from the team, or their role simply lacks VIEW_SECRETS (connect-only,
+    // issue #187). The route cannot tell them apart, but the client can — a
+    // revoked member no longer has the team in their own team list. A 403 while
+    // the team is still listed is a role restriction, and such a member reads
+    // this vault through the object routes only: the empty list they just got
+    // IS their view of the vault, so show it rather than a false revocation.
+    if (status === "forbidden" && (await _isStillATeamMember(teamId))) {
+      status = "loaded";
+    }
     // Clear team store slices so stale data doesn't linger
     await _clearTeamStores(teamId);
     stateStore.setStatus(teamId, status);
@@ -374,6 +386,16 @@ async function _fetchTeamData(teamId: string, options: TeamVaultRefreshOptions):
   }
 
   stateStore.setStatus(teamId, "loaded");
+}
+
+/**
+ * True when the client still lists `teamId` among the caller's teams. The
+ * server drops revoked teams from that list and `onTeamRemoved` clears the
+ * store, so this separates "your role can't do that" from "you were removed".
+ */
+async function _isStillATeamMember(teamId: string): Promise<boolean> {
+  const { useTeamStore } = await import("@/stores/teamStore");
+  return useTeamStore.getState().teams.some((t) => t.id === teamId);
 }
 
 async function _hydrateTeamObjectStores(teamId: string, objects: TeamObjectRecord[]): Promise<void> {


### PR DESCRIPTION
Closes #187. Also answers the "what a connect-only invitee should see first" half of #70.

## The bug

A member holding only the built-in `connect-only` role opens the team vault they were just invited to and sees **"Access revoked — You no longer have access to this team vault."** They were never revoked.

`connect-only` is `28676` = `CONNECT | START_TERMINAL_SESSION | JOIN_TERMINAL_SESSION | VIEW_TERMINAL_SESSIONS`. No `VIEW_SECRETS`, so `GET /v1/teams/:team_id/vault-key` returns 403 and `getTeamVaultKey` maps 403 to `"forbidden"` — the revocation state.

It bites at exactly one moment. `fetchTeamData` tries `listTeamObjects` first; that route is membership-gated and returns plaintext metadata, so once the vault holds anything it opens for a connect-only member without the key ever being needed. It is the **empty** vault — the one a joiner meets right after the owner converts a private vault — that falls through to the key route and 403s.

## The fix

The route cannot separate "removed from the team" from "your role lacks `VIEW_SECRETS`" — both are 403. The client can: the server drops revoked teams from the caller's team list, and `onTeamRemoved` clears the store. So a 403 while the team is **still listed** is a role restriction.

Such a member reads this vault through the object routes only, which means the empty list they just got *is* their view of the vault. Show it, rather than a false revocation.

Genuine revocation is unaffected — it arrives through `onTeamRemoved` and through a 403 on `list_objects` itself (membership-gated), both of which still land on `forbidden`.

## What this deliberately does not do

It does not widen `get_my_vault_key` to `PERM_CONNECT || PERM_VIEW_SECRETS`, the "Yes" option in #187. That buys nothing for hosts — they never needed the key — and it is unsafe until VoltiusApp/server#11 lands, because `GET /sync-blob` is membership-only today and the pair would hand a connect-only member the whole vault in plaintext.

It also does not fix the deeper problem the investigation turned up: a connect-only member can never fetch any credential ciphertext (`list_secrets` requires `VIEW_SECRETS`) nor the key to decrypt it, so the role cannot connect to any host with a stored password or key passphrase. Filed as #190 — it needs a design decision about what `PERM_CONNECT` means.

## Tests

Two new tests in `teamVaultSync.data.test.ts`: a 403 on the key route resolves to an empty loaded vault when the team is still listed, and still resolves to `forbidden` when it is not. Verified against a negative baseline — the first test fails on `dev`.

```
npx tsc --noEmit → clean
vitest run → 186 files, 1505 tests, 0 failures
```

Server side: VoltiusApp/server#11