### PR TITLE
fix(snippets): prompt for choice variables instead of taking the first option

### DIFF
--- a/src/components/terminal/SnippetVariableModal.spec.tsx
+++ b/src/components/terminal/SnippetVariableModal.spec.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+import { SnippetVariableModal } from "./SnippetVariableModal";
+import { parseVariables, buildDefaultValues } from "@/services/snippetParser";
+
+const template = "echo {{environment:choice:development,staging,production}}";
+const userVars = parseVariables(template);
+
+function renderModal(onInject = vi.fn()) {
+  render(
+    <SnippetVariableModal
+      snippetName="deploy"
+      partialTemplate={template}
+      userVars={userVars}
+      initialValues={buildDefaultValues(userVars)}
+      onInject={onInject}
+      onClose={vi.fn()}
+    />,
+  );
+  return { onInject, select: screen.getByRole("combobox") as HTMLSelectElement };
+}
+
+afterEach(cleanup);
+
+describe("SnippetVariableModal choice variables", () => {
+  it("offers every option with the first one pre-selected", () => {
+    const { select } = renderModal();
+    expect([...select.options].map((o) => o.value)).toEqual([
+      "development", "staging", "production",
+    ]);
+    expect(select.value).toBe("development");
+  });
+
+  it("substitutes the picked option", () => {
+    const { onInject, select } = renderModal();
+    fireEvent.change(select, { target: { value: "staging" } });
+    fireEvent.click(screen.getByText("terminal.snippetVariableModal.execute"));
+    expect(onInject).toHaveBeenCalledWith("echo staging", true);
+  });
+});

--- a/src/services/snippetParser.spec.ts
+++ b/src/services/snippetParser.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { parseVariables, needsUserInput, buildDefaultValues } from "./snippetParser";
+
+describe("snippetParser choice variables", () => {
+  const [choiceVar] = parseVariables("echo {{environment:choice:development,staging,production}}");
+
+  it("parses the option list and defaults to the first option", () => {
+    expect(choiceVar.type).toBe("choice");
+    expect(choiceVar.choices).toEqual(["development", "staging", "production"]);
+    expect(choiceVar.default).toBe("development");
+  });
+
+  it("prompts even though the first option pre-fills the picker", () => {
+    expect(needsUserInput(choiceVar)).toBe(true);
+    expect(buildDefaultValues([choiceVar])).toEqual({ environment: "development" });
+  });
+
+  it("still prompts when no options are declared", () => {
+    const [v] = parseVariables("echo {{environment:choice}}");
+    expect(needsUserInput(v)).toBe(true);
+  });
+
+  it("leaves other typed variables with a default resolved", () => {
+    const vars = parseVariables("echo {{port:number:22}} {{flag:boolean:true}} {{name:text:web}}");
+    expect(vars.map(needsUserInput)).toEqual([false, false, false]);
+  });
+});

--- a/src/services/snippetParser.ts
+++ b/src/services/snippetParser.ts
@@ -88,12 +88,13 @@ export function parseVariables(template: string): ParsedVariable[] {
 }
 
 /**
- * Returns true if the variable requires explicit user input
- * (no resolvable default, or is a password which should never be auto-injected).
+ * Returns true if the variable requires explicit user input: no resolvable
+ * default, a password (never auto-injected), or a choice — whose first option
+ * is a pre-selection to confirm, not an answer (#195).
  */
 export function needsUserInput(v: ParsedVariable): boolean {
   if (v.dynamic) return false;
-  if (v.type === "password") return true;
+  if (v.type === "password" || v.type === "choice") return true;
   return v.default === undefined;
 }
 


### PR DESCRIPTION
Closes #195

## Problem

`echo {{environment:choice:development,staging,production}}` ran as `echo development` — the variable modal never opened, so `staging` and `production` were unreachable.

Root cause: `parseVariables` assigns a choice variable's first option as its `default`, and `needsUserInput` treats any variable that has a default as already resolved. Every call site (`SnippetsPanel`, `SnippetPickerPanel`, `OmniSearch`, `snippetRunCore`, `snippetSequenceCore`) gates the modal on `needsUserInput`, so choice variables silently resolved themselves.

## Fix

`needsUserInput` now returns `true` for `choice`, the same way it already does for `password`. The first option still pre-fills the select via `buildDefaultValues`, so the picker opens on it and the user only confirms — as the issue asked for.

## Verification

- New `snippetParser.spec.ts`: choice prompts (with and without an option list), other typed variables with a default still resolve without prompting.
- New `SnippetVariableModal.spec.tsx`: the select carries all three options with the first pre-selected, and picking `staging` injects `echo staging`.
- Live run in a headless container on this branch: created the snippet from the issue, ran it from the snippets panel — modal opened on `development`, picked `staging`, preview read `echo staging`, and the local shell executed `echo staging`.
- `tsc --noEmit` clean; 140 test files / 1232 tests green across `src/services`, `src/components/terminal`, `src/components/snippets` and `hostCommandVarsStore`.