### PR TITLE
fix(terminal): terminate custom font stacks with a monospace generic (#196)

### DIFF
--- a/src/components/terminal/MultiplayerTerminalView.tsx
+++ b/src/components/terminal/MultiplayerTerminalView.tsx
@@ -7,7 +7,7 @@ import { useThemeStore } from "@/stores/themeStore";
 import { useTerminalSettingsStore } from "@/stores/terminalSettingsStore";
 import { getToggle } from "@/stores/toggleSettingsStore";
 import { useTeamSessionStore } from "@/stores/teamSessionStore";
-import { withFlagEmojiFallback } from "@/utils/emojiFont";
+import { terminalFontStack } from "@/utils/fontStack";
 import { clampTerminalLineHeight, subscribeTerminalCursor, subscribeTerminalTheme } from "@/utils/terminalTheme";
 import "@xterm/xterm/css/xterm.css";
 
@@ -35,7 +35,7 @@ export default function MultiplayerTerminalView({ localSessionId, active }: Prop
         cursorStyle,
         fontSize: activeTheme.terminalFontSize,
         lineHeight: clampTerminalLineHeight(activeTheme.terminalLineHeight),
-        fontFamily: withFlagEmojiFallback(activeTheme.terminalFontFamily),
+        fontFamily: terminalFontStack(activeTheme.terminalFontFamily),
         scrollback,
         theme: activeTheme.terminal,
         allowProposedApi: true,

--- a/src/hooks/useApplyTheme.ts
+++ b/src/hooks/useApplyTheme.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useThemeStore } from "@/stores/themeStore";
 import { useUIStore } from "@/stores/uiStore";
 import type { AppTheme } from "@/themes/types";
-import { withFlagEmojiFallback } from "@/utils/emojiFont";
+import { terminalFontStack, withFlagEmojiFallback } from "@/utils/fontStack";
 import { appearanceFromColor, luminanceFromHex } from "@/utils/appearance";
 
 export function applyThemeToDom(theme: AppTheme) {
@@ -59,7 +59,7 @@ export function applyThemeToDom(theme: AppTheme) {
   root.style.setProperty("--t-terminal-green", theme.terminal.green);
   root.style.setProperty("--t-terminal-cyan", theme.terminal.cyan);
   root.style.setProperty("--t-terminal-yellow", theme.terminal.yellow);
-  root.style.setProperty("--t-terminal-font-family", withFlagEmojiFallback(theme.terminalFontFamily));
+  root.style.setProperty("--t-terminal-font-family", terminalFontStack(theme.terminalFontFamily));
   root.style.setProperty("--t-terminal-font-size", `${theme.terminalFontSize}px`);
   // Derive light/dark from the base bg so globals.css can override the
   // dark-baked shadow/ring/highlight tokens under :root[data-appearance="light"].

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -28,7 +28,7 @@ import { keyToBytes } from "@/services/terminalKeyCore";
 import { handleDuplicateShortcut } from "@/services/duplicateSession";
 import type { TerminalTheme } from "@/themes/types";
 import type { UnlistenFn } from "@tauri-apps/api/event";
-import { withFlagEmojiFallback } from "@/utils/emojiFont";
+import { terminalFontStack } from "@/utils/fontStack";
 import { applyTerminalTheme, clampTerminalLineHeight, subscribeTerminalCursor, subscribeTerminalTheme } from "@/utils/terminalTheme";
 import { getPlatform } from "@/utils/platform";
 
@@ -742,7 +742,7 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
         cursorStyle,
         fontSize: activeTheme.terminalFontSize,
         lineHeight: clampTerminalLineHeight(activeTheme.terminalLineHeight),
-        fontFamily: withFlagEmojiFallback(activeTheme.terminalFontFamily),
+        fontFamily: terminalFontStack(activeTheme.terminalFontFamily),
         scrollback,
         theme: activeTheme.terminal,
         overviewRuler: { width: 4 },
@@ -783,7 +783,7 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
             background: "var(--t-bg-card)",
             border: "1px solid var(--t-border)",
             color: "var(--t-text)",
-            fontFamily: withFlagEmojiFallback(activeTheme.terminalFontFamily),
+            fontFamily: terminalFontStack(activeTheme.terminalFontFamily),
             fontSize: "12px",
             boxShadow: "0 8px 24px rgba(0, 0, 0, 0.28)",
             opacity: "0",

--- a/src/utils/emojiFont.ts
+++ b/src/utils/emojiFont.ts
@@ -1,9 +1,0 @@
-// Chromium/WebView2 on Windows can't render country flag emoji natively
-// (regional indicator pairs show as letter codes, e.g. "DE" for 🇩🇪).
-// `country-flag-emoji-polyfill` (wired up in app/main.tsx) registers a
-// "Twemoji Country Flags" @font-face scoped to just those codepoints via
-// unicode-range, but only browsers/fonts that actually need it will use it —
-// so it's safe to prepend everywhere a font stack is set.
-export function withFlagEmojiFallback(fontFamily: string): string {
-  return `"Twemoji Country Flags", ${fontFamily}`;
-}

--- a/src/utils/fontStack.test.ts
+++ b/src/utils/fontStack.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { terminalFontStack, withFlagEmojiFallback } from "./fontStack";
+
+describe("withFlagEmojiFallback", () => {
+  it("prepends the polyfill family without adding a generic", () => {
+    expect(withFlagEmojiFallback("Inter Variable, system-ui")).toBe(
+      '"Twemoji Country Flags", Inter Variable, system-ui',
+    );
+  });
+});
+
+describe("terminalFontStack", () => {
+  it("leaves a preset stack that already ends in a generic alone", () => {
+    expect(terminalFontStack("'JetBrains Mono', monospace")).toBe(
+      '"Twemoji Country Flags", \'JetBrains Mono\', monospace',
+    );
+  });
+
+  it("appends monospace to a custom family with no generic (#196)", () => {
+    expect(terminalFontStack("MesloLGS Nerd Font Mono")).toBe(
+      '"Twemoji Country Flags", MesloLGS Nerd Font Mono, monospace',
+    );
+  });
+
+  it("does not treat a quoted family named like a generic as one", () => {
+    expect(terminalFontStack("'monospace'")).toBe(
+      '"Twemoji Country Flags", \'monospace\', monospace',
+    );
+  });
+
+  it("recognises a generic that is not last", () => {
+    expect(terminalFontStack("Fira Code, monospace, Menlo")).toBe(
+      '"Twemoji Country Flags", Fira Code, monospace, Menlo',
+    );
+  });
+
+  it("recognises the ui-monospace generic", () => {
+    expect(terminalFontStack("SF Mono, ui-monospace")).toBe(
+      '"Twemoji Country Flags", SF Mono, ui-monospace',
+    );
+  });
+
+  it("ignores surrounding whitespace and case", () => {
+    expect(terminalFontStack("Fira Code ,  MONOSPACE ")).toBe(
+      '"Twemoji Country Flags", Fira Code ,  MONOSPACE ',
+    );
+  });
+});

--- a/src/utils/fontStack.ts
+++ b/src/utils/fontStack.ts
@@ -1,0 +1,49 @@
+// Chromium/WebView2 on Windows can't render country flag emoji natively
+// (regional indicator pairs show as letter codes, e.g. "DE" for 🇩🇪).
+// `country-flag-emoji-polyfill` (wired up in app/main.tsx) registers a
+// "Twemoji Country Flags" @font-face scoped to just those codepoints via
+// unicode-range, but only browsers/fonts that actually need it will use it —
+// so it's safe to prepend everywhere a font stack is set.
+export function withFlagEmojiFallback(fontFamily: string): string {
+  return `"Twemoji Country Flags", ${fontFamily}`;
+}
+
+// https://drafts.csswg.org/css-fonts/#generic-family-value
+const GENERIC_FAMILIES = new Set([
+  "serif",
+  "sans-serif",
+  "monospace",
+  "cursive",
+  "fantasy",
+  "system-ui",
+  "ui-serif",
+  "ui-sans-serif",
+  "ui-monospace",
+  "ui-rounded",
+  "math",
+  "emoji",
+  "fangsong",
+]);
+
+/** A quoted entry is a family *name*, never the generic keyword of the same spelling. */
+function hasGenericFamily(fontFamily: string): boolean {
+  return fontFamily
+    .split(",")
+    .map((entry) => entry.trim())
+    .some((entry) => GENERIC_FAMILIES.has(entry.toLowerCase()));
+}
+
+/** Terminal font stacks must end in a generic, and it must be `monospace` (#196).
+ *
+ *  xterm measures the cell from `ctx.font` on a canvas. When every family in the
+ *  stack fails to resolve there — a webfont still loading, or a locally installed
+ *  font the canvas doesn't see yet, as with "MesloLGS Nerd Font Mono" on macOS —
+ *  the canvas falls back to its own default, which is *proportional*: cells come
+ *  out ~1.6x too wide while the glyphs still paint at the right size. Terminating
+ *  the stack with `monospace` bounds that miss to a monospace advance instead.
+ *  The presets already end in `monospace`; a custom family typed into the theme
+ *  editor's font picker does not. */
+export function terminalFontStack(fontFamily: string): string {
+  const stack = withFlagEmojiFallback(fontFamily);
+  return hasGenericFamily(stack) ? stack : `${stack}, monospace`;
+}

--- a/src/utils/terminalTheme.ts
+++ b/src/utils/terminalTheme.ts
@@ -1,7 +1,7 @@
 import type { Terminal } from "@xterm/xterm";
 import type { FitAddon } from "@xterm/addon-fit";
 import type { AppTheme } from "@/themes/types";
-import { withFlagEmojiFallback } from "@/utils/emojiFont";
+import { terminalFontStack } from "@/utils/fontStack";
 import { useTerminalSettingsStore } from "@/stores/terminalSettingsStore";
 import { getToggle, useToggleSettingsStore } from "@/stores/toggleSettingsStore";
 import { useThemeStore } from "@/stores/themeStore";
@@ -21,7 +21,7 @@ export function clampTerminalLineHeight(value: number | undefined | null): numbe
 /** Applies a theme to a live terminal, refitting only when cell metrics change. */
 export function applyTerminalTheme(term: Terminal, fit: FitAddon | null | undefined, theme: AppTheme): void {
   term.options.theme = theme.terminal;
-  term.options.fontFamily = withFlagEmojiFallback(theme.terminalFontFamily);
+  term.options.fontFamily = terminalFontStack(theme.terminalFontFamily);
   const lineHeight = clampTerminalLineHeight(theme.terminalLineHeight);
   if (term.options.fontSize !== theme.terminalFontSize || term.options.lineHeight !== lineHeight) {
     term.options.fontSize = theme.terminalFontSize;


### PR DESCRIPTION
Fixes #196.

## Symptom

With the terminal font set to a custom family such as `MesloLGS Nerd Font Mono`, the terminal renders in a proportional serif face laid out on cells about 1.6x too wide — letters float in the middle of their cells with large gaps.

## Root cause

The configured family never resolves in the webview at all. xterm 6 both measures the cell (`ctx.font` + `measureText`, via `TextMetricsMeasureStrategy`) and rasterizes glyphs (the WebGL texture atlas) on a canvas, using the same font stack. When no family in that stack resolves, the canvas falls back to the engine default, which is *proportional* — Times on macOS.

Both halves of the reported screenshot confirm it:

- **Cells.** The cursor block measures exactly 26 x 34 device px. At font size 14 / dpr 2 that is 0.93 em wide, matching Times' `W` advance of 0.944 em, against 0.602 em for Meslo (the font file confirms an advance of 1233/2048).
- **Glyphs.** The letters carry bracket serifs, and their ink widths are proportional, not monospace: `w` 15 px vs `s` 8 px, a ratio of 1.88, which matches Times (0.66 em / 0.35 em = 1.89). A monospace face would put those two near 1.4.

The Nerd Font glyphs that *do* look right — the powerline separators, the Apple logo, the clock — come from macOS's per-codepoint fallback, which finds the installed Nerd Font for characters Times has no glyph for. That is what made the failure look font-specific rather than total.

Measured at 100px inside the app's own webview:

| font stack | `measureText("W").width` |
| --- | --- |
| `"Twemoji Country Flags", <unresolvable family>` | **0.99 em** |
| `"Twemoji Country Flags", <unresolvable family>, monospace` | **0.60 em** |
| MesloLGS Nerd Font Mono, resolved | 0.602 em |

The built-in themes use stacks like `'JetBrains Mono', monospace`. That trailing generic means a failed lookup still lands on a monospace advance, so measurement and rendering stay in agreement and nothing looks wrong. A family typed into the theme editor's custom-font box was stored verbatim, with no generic family at the end, so a failed lookup fell all the way through to the proportional default.

## Change

`src/utils/emojiFont.ts` becomes `src/utils/fontStack.ts` and gains `terminalFontStack()`: the flag-emoji prepend plus a `monospace` tail, unless the stack already contains a generic family. A quoted `'monospace'` counts as a family name rather than the keyword. Six call sites move over; the UI font path (`--t-font-family`) keeps plain `withFlagEmojiFallback`, where a `monospace` tail would be wrong.

## Scope — what this does and does not fix

This makes an unresolvable terminal font degrade to a monospace face with correctly sized cells, instead of a proportional serif in over-wide cells. It does **not** make the user's font resolve — if the family name does not match anything installed, they still will not get the font they asked for, they just get a sane-looking fallback.

Surfacing that (detecting an unresolvable family and telling the user in the font picker, or enumerating installed families from the Rust side to populate it) is a separate change and is not in this PR.

## Verification

- `tsc --noEmit` clean.
- Full suite green: 517 files, 3971 tests.
- New unit tests in `src/utils/fontStack.test.ts` cover the preset stack, the custom-family case from #196, a quoted generic-lookalike, a non-final generic, `ui-monospace`, and whitespace/case handling.

## Not covered

No live before/after screenshot: the family resolves fine in WebKitGTK, so the bug does not reproduce on Linux. The evidence is the metrics table above plus the screenshot geometry and letterforms.