### PR TITLE
ci: re-run verify-packaging when publish-msix.yml changes

### DIFF
--- a/.github/workflows/verify-packaging.yml
+++ b/.github/workflows/verify-packaging.yml
@@ -17,6 +17,7 @@ on:
       - 'scripts/*msix*'
       - 'scripts/lib/**'
       - '.github/workflows/verify-packaging.yml'
+      - '.github/workflows/publish-msix.yml'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
`verify-packaging.yml` is the only caller of `publish-msix.yml`, but its `push.paths` filter listed `verify-packaging.yml` and not the reusable workflow it calls. So an edit to `publish-msix.yml` never re-ran the check that proves the MSIX still packs on Windows.

Surfaced by #197, which bumped `upload-artifact` v4→v7 and `download-artifact` v4→v8 inside `publish-msix.yml`: none of that PR's green checks executed a single changed line.

One line added to the paths filter.