### PR TITLE
feat(theme): pick terminal and UI fonts from the installed families (#196)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2126,6 +2126,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "fontdb"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2660c5e9157bf76d2db1294e4a9feba604ef610819a3b591088d0d8392a3290f"
+dependencies = [
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3620,6 +3632,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -6204,6 +6225,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7692,6 +7722,7 @@ dependencies = [
  "crypto_secretbox",
  "dbus-secret-service-keyring-store",
  "dirs",
+ "fontdb",
  "futures-util",
  "gio",
  "hkdf 0.12.4",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,10 @@ portable-pty = "0.9"
 ssh-key = { version = "0.6", features = ["ed25519", "p256", "p384", "p521", "rsa", "encryption"] }
 rsa = { version = "0.9", features = ["getrandom"] }
 sysinfo = "0.39"
+# Pure-Rust font enumeration for the theme editor's font pickers. `fontdb` scans the
+# OS font directories itself, so it needs no fontconfig/CoreText/DirectWrite linkage
+# and stays out of the cross-compile images' way.
+fontdb = { version = "0.24", default-features = false, features = ["fs", "memmap", "std"] }
 bollard = "0.21"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }

--- a/src-tauri/src/commands/fonts.rs
+++ b/src-tauri/src/commands/fonts.rs
@@ -46,7 +46,7 @@ fn dedupe_families(faces: impl Iterator<Item = (String, bool)>) -> Vec<SystemFon
         }
     }
 
-    families.sort_by(|a, b| a.family.to_lowercase().cmp(&b.family.to_lowercase()));
+    families.sort_by_key(|f| f.family.to_lowercase());
     families
 }
 

--- a/src-tauri/src/commands/fonts.rs
+++ b/src-tauri/src/commands/fonts.rs
@@ -1,0 +1,162 @@
+use fontdb::{Database, Language};
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct SystemFont {
+    /// Family name as CSS will match it (the English `name` record).
+    pub family: String,
+    pub monospace: bool,
+}
+
+/// CSS matches the English family name, so prefer it over the localized records
+/// `fontdb` also carries. Falls back to whatever the face lists first.
+fn english_family(families: &[(String, Language)]) -> Option<&str> {
+    families
+        .iter()
+        .find(|(_, lang)| *lang == Language::English_UnitedStates)
+        .or_else(|| families.iter().find(|(_, lang)| is_english(*lang)))
+        .or_else(|| families.first())
+        .map(|(name, _)| name.as_str())
+}
+
+fn is_english(lang: Language) -> bool {
+    format!("{lang:?}").starts_with("English")
+}
+
+/// One entry per family, sorted, monospace if any face in it claims to be.
+/// `fontdb` reports per *face*, so "MesloLGS Nerd Font Mono" arrives four times
+/// (Regular/Bold/Italic/BoldItalic) and has to be collapsed.
+fn dedupe_families(faces: impl Iterator<Item = (String, bool)>) -> Vec<SystemFont> {
+    let mut families: Vec<SystemFont> = Vec::new();
+    let mut seen: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+
+    for (family, monospace) in faces {
+        let family = family.trim();
+        if family.is_empty() {
+            continue;
+        }
+        match seen.get(family) {
+            Some(&index) => families[index].monospace |= monospace,
+            None => {
+                seen.insert(family.to_string(), families.len());
+                families.push(SystemFont {
+                    family: family.to_string(),
+                    monospace,
+                });
+            }
+        }
+    }
+
+    families.sort_by(|a, b| a.family.to_lowercase().cmp(&b.family.to_lowercase()));
+    families
+}
+
+/// Families installed on this machine, for the theme editor's font pickers.
+/// Bundled webfonts (JetBrains Mono, Source Code Pro) are *not* here — they ship
+/// inside the app rather than being installed, so the frontend pins them itself.
+#[tauri::command]
+pub async fn list_system_fonts() -> Result<Vec<SystemFont>, String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        let mut db = Database::new();
+        db.load_system_fonts();
+        dedupe_families(db.faces().filter_map(|face| {
+            english_family(&face.families).map(|name| (name.to_string(), face.monospaced))
+        }))
+    })
+    .await
+    .map_err(|e| format!("Font enumeration failed: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn font(family: &str, monospace: bool) -> (String, bool) {
+        (family.to_string(), monospace)
+    }
+
+    #[test]
+    fn collapses_a_family_that_has_several_faces() {
+        let families = dedupe_families(
+            [
+                font("MesloLGS Nerd Font Mono", true),
+                font("MesloLGS Nerd Font Mono", true),
+            ]
+            .into_iter(),
+        );
+
+        assert_eq!(
+            families,
+            vec![SystemFont {
+                family: "MesloLGS Nerd Font Mono".to_string(),
+                monospace: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn one_monospace_face_marks_the_whole_family() {
+        let families = dedupe_families(
+            [font("Patched Family", false), font("Patched Family", true)].into_iter(),
+        );
+
+        assert!(families[0].monospace);
+    }
+
+    #[test]
+    fn sorts_case_insensitively() {
+        let families: Vec<String> = dedupe_families(
+            [
+                font("iosevka", true),
+                font("Courier New", true),
+                font("Andale Mono", true),
+            ]
+            .into_iter(),
+        )
+        .into_iter()
+        .map(|f| f.family)
+        .collect();
+
+        assert_eq!(families, vec!["Andale Mono", "Courier New", "iosevka"]);
+    }
+
+    #[test]
+    fn trims_and_drops_blank_family_names() {
+        let families =
+            dedupe_families([font("  Fira Code  ", true), font("   ", true)].into_iter());
+
+        assert_eq!(
+            families,
+            vec![SystemFont {
+                family: "Fira Code".to_string(),
+                monospace: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn prefers_the_english_family_record() {
+        let records = vec![
+            ("ヒラギノ角ゴ".to_string(), Language::Japanese_Japan),
+            ("Hiragino Sans".to_string(), Language::English_UnitedStates),
+        ];
+
+        assert_eq!(english_family(&records), Some("Hiragino Sans"));
+    }
+
+    #[test]
+    fn falls_back_to_the_first_record_when_no_english_one_exists() {
+        let records = vec![("ヒラギノ角ゴ".to_string(), Language::Japanese_Japan)];
+
+        assert_eq!(english_family(&records), Some("ヒラギノ角ゴ"));
+    }
+
+    #[test]
+    fn accepts_a_non_us_english_record() {
+        let records = vec![
+            ("Zapfino".to_string(), Language::English_UnitedKingdom),
+            ("Zapfino JP".to_string(), Language::Japanese_Japan),
+        ];
+
+        assert_eq!(english_family(&records), Some("Zapfino"));
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod diagnostics;
 pub mod docker;
 pub mod downloads;
 pub mod folders;
+pub mod fonts;
 pub mod fs;
 pub mod host_command;
 pub mod http;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -758,6 +758,7 @@ pub fn run() {
             commands::processes::process_kill,
             commands::sysinfo::get_system_info,
             commands::sysinfo::get_connected_system_info,
+            commands::fonts::list_system_fonts,
             commands::docker::docker_list_containers,
             commands::docker::docker_list_images,
             commands::docker::docker_list_volumes,

--- a/src/components/theme-creator/ThemeCreator.tsx
+++ b/src/components/theme-creator/ThemeCreator.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/utils/terminalTheme";
 import { getUiGroups, getTerminalGroups, getFieldLabels } from "./colorGroups";
 import { ColorPicker } from "./ColorPicker";
+import { primaryFamily, toFontStack, useSystemFonts } from "@/utils/systemFonts";
 
 // ── CSS variable inspector ────────────────────────────────────────────────────
 
@@ -108,18 +109,38 @@ function FontPicker({
   value,
   onChange,
   options,
+  generic,
+  monospaceOnly = false,
 }: {
   value: string;
   onChange: (v: string) => void;
   options: { label: string; value: string }[];
+  /** Generic family appended to a pick from the installed list (#196). */
+  generic: string;
+  /** Hide families whose faces don't claim fixed pitch, until "show all". */
+  monospaceOnly?: boolean;
 }) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [custom, setCustom] = useState(false);
+  const [query, setQuery] = useState("");
+  const [showAll, setShowAll] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const systemFonts = useSystemFonts();
 
   const isPreset = options.some((o) => o.value === value);
-  const displayLabel = options.find((o) => o.value === value)?.label ?? value.split(",")[0].replace(/'/g, "").trim();
+  const selected = primaryFamily(value);
+  const displayLabel = options.find((o) => o.value === value)?.label ?? selected;
+
+  // Bundled presets ship inside the app, so they never appear in the installed
+  // list and must not be reported missing.
+  const installed = systemFonts?.some((f) => f.family.toLowerCase() === selected.toLowerCase());
+  const missing = systemFonts !== null && !isPreset && !installed;
+
+  const listed = (systemFonts ?? []).filter((f) => {
+    if (monospaceOnly && !showAll && !f.monospace) return false;
+    return f.family.toLowerCase().includes(query.trim().toLowerCase());
+  });
 
   useEffect(() => {
     if (!open) return;
@@ -133,20 +154,51 @@ function FontPicker({
     return () => document.removeEventListener("mousedown", handler);
   }, [open]);
 
+  const close = () => { setOpen(false); setCustom(false); setQuery(""); };
+  const rowBackground = (active: boolean) =>
+    active ? "color-mix(in srgb, var(--t-accent) 12%, transparent)" : "transparent";
+
+  const Row = ({ label, stack, active, onPick }: {
+    label: string; stack: string; active: boolean; onPick: () => void;
+  }) => (
+    <button
+      type="button"
+      onClick={() => { onPick(); close(); }}
+      className="w-full flex items-center justify-between px-3 py-2 text-left cursor-pointer transition-colors"
+      style={{ background: rowBackground(active) }}
+      onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "var(--t-bg-elevated)"; }}
+      onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = rowBackground(active); }}
+    >
+      <span style={{ fontFamily: stack, fontSize: 13, color: "var(--t-text-primary)" }}>{label}</span>
+      {active && <Icon icon="lucide:check" width={12} className="text-(--t-accent) shrink-0" />}
+    </button>
+  );
+
   return (
     <div ref={ref} className="relative mt-1">
       {/* Trigger */}
       <button
         type="button"
         onClick={() => { setOpen((o) => !o); setCustom(false); }}
-        className="w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-sm bg-(--t-bg-input) border border-(--t-border) text-(--t-text-primary) cursor-pointer"
+        className="w-full flex items-center justify-between gap-2 px-2.5 py-1.5 rounded-md text-sm bg-(--t-bg-input) border border-(--t-border) text-(--t-text-primary) cursor-pointer"
         onMouseEnter={(e) => (e.currentTarget.style.borderColor = "var(--t-border-hover)")}
         onMouseLeave={(e) => (e.currentTarget.style.borderColor = open ? "var(--t-accent)" : "var(--t-border)")}
         style={{ borderColor: open ? "var(--t-accent)" : undefined }}
       >
-        <span style={{ fontFamily: value, fontSize: 13 }}>{displayLabel}</span>
-        <Icon icon={open ? "lucide:chevron-up" : "lucide:chevron-down"} width={12} className="text-(--t-text-dim) shrink-0" />
+        <span className="truncate" style={{ fontFamily: value, fontSize: 13 }}>{displayLabel}</span>
+        <span className="flex items-center gap-1.5 shrink-0">
+          {missing && (
+            <Icon icon="lucide:triangle-alert" width={12} className="text-(--t-status-warning)" />
+          )}
+          <Icon icon={open ? "lucide:chevron-up" : "lucide:chevron-down"} width={12} className="text-(--t-text-dim)" />
+        </span>
       </button>
+
+      {missing && (
+        <p className="text-[10px] mt-1 text-(--t-status-warning)">
+          {t("themeCreator.font.notInstalled", { family: selected })}
+        </p>
+      )}
 
       {/* Dropdown */}
       {open && (
@@ -155,19 +207,59 @@ function FontPicker({
           style={{ boxShadow: "var(--t-ring), var(--t-elev-2)" }}
         >
           {options.map((opt) => (
-            <button
+            <Row
               key={opt.value}
-              type="button"
-              onClick={() => { onChange(opt.value); setOpen(false); setCustom(false); }}
-              className="w-full flex items-center justify-between px-3 py-2 text-left cursor-pointer transition-colors"
-              style={{ background: value === opt.value ? "color-mix(in srgb, var(--t-accent) 12%, transparent)" : "transparent" }}
-              onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "var(--t-bg-elevated)"; }}
-              onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = value === opt.value ? "color-mix(in srgb, var(--t-accent) 12%, transparent)" : "transparent"; }}
-            >
-              <span style={{ fontFamily: opt.value, fontSize: 13, color: "var(--t-text-primary)" }}>{opt.label}</span>
-              {value === opt.value && <Icon icon="lucide:check" width={12} className="text-(--t-accent) shrink-0" />}
-            </button>
+              label={opt.label}
+              stack={opt.value}
+              active={value === opt.value}
+              onPick={() => onChange(opt.value)}
+            />
           ))}
+
+          <div className="border-t border-(--t-border)" />
+
+          {systemFonts === null ? (
+            <p className="px-3 py-2 text-xs text-(--t-text-dim)">{t("themeCreator.font.loading")}</p>
+          ) : systemFonts.length === 0 ? (
+            <p className="px-3 py-2 text-xs text-(--t-text-dim)">{t("themeCreator.font.noneInstalled")}</p>
+          ) : (
+            <>
+              <div className="px-3 pt-2">
+                <input
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder={t("themeCreator.font.searchPlaceholder")}
+                  className="w-full px-2 py-1 rounded-sm text-xs outline-hidden bg-(--t-bg-input) border border-(--t-border) text-(--t-text-primary)"
+                />
+              </div>
+              <div className="max-h-56 overflow-y-auto mt-1">
+                {listed.length === 0 ? (
+                  <p className="px-3 py-2 text-xs text-(--t-text-dim)">{t("themeCreator.font.noMatches")}</p>
+                ) : (
+                  listed.map((f) => (
+                    <Row
+                      key={f.family}
+                      label={f.family}
+                      stack={toFontStack(f.family, generic)}
+                      active={f.family.toLowerCase() === selected.toLowerCase()}
+                      onPick={() => onChange(toFontStack(f.family, generic))}
+                    />
+                  ))
+                )}
+              </div>
+              {monospaceOnly && (
+                <button
+                  type="button"
+                  onClick={() => setShowAll((s) => !s)}
+                  className="w-full px-3 py-2 text-left text-xs text-(--t-text-muted) cursor-pointer transition-colors border-t border-(--t-border)"
+                  onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.color = "var(--t-text-primary)"; }}
+                  onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.color = "var(--t-text-muted)"; }}
+                >
+                  {showAll ? t("themeCreator.font.showMonospaceOnly") : t("themeCreator.font.showAll")}
+                </button>
+              )}
+            </>
+          )}
 
           {/* Custom divider */}
           <div className="border-t border-(--t-border)" />
@@ -189,7 +281,7 @@ function FontPicker({
                 placeholder={t("themeCreator.font.customPlaceholder")}
                 className="w-full px-2 py-1 rounded-sm text-xs outline-hidden font-mono bg-(--t-bg-input) border border-(--t-accent) text-(--t-text-primary)"
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") { onChange(e.currentTarget.value); setOpen(false); setCustom(false); }
+                  if (e.key === "Enter") { onChange(e.currentTarget.value); close(); }
                   if (e.key === "Escape") { setCustom(false); }
                 }}
               />
@@ -318,6 +410,7 @@ function ColorEditor({
             value={draft.uiFontFamily}
             onChange={(v) => setDraft((d) => ({ ...d, uiFontFamily: v }))}
             options={UI_FONT_OPTIONS}
+            generic="sans-serif"
           />
         </div>
         <label className="block">
@@ -377,6 +470,8 @@ function ColorEditor({
             value={draft.terminalFontFamily}
             onChange={(v) => setDraft((d) => ({ ...d, terminalFontFamily: v }))}
             options={TERMINAL_FONT_OPTIONS}
+            generic="monospace"
+            monospaceOnly
           />
         </div>
         <label className="block">

--- a/src/i18n/locales/en/themeCreator.json
+++ b/src/i18n/locales/en/themeCreator.json
@@ -8,7 +8,14 @@
     "font": {
       "customLabel": "Custom font…",
       "customPlaceholder": "'My Font', monospace",
-      "customHint": "Press Enter to apply"
+      "customHint": "Press Enter to apply",
+      "searchPlaceholder": "Search installed fonts…",
+      "loading": "Reading installed fonts…",
+      "noneInstalled": "No installed fonts found",
+      "noMatches": "No matching font",
+      "showAll": "Show all fonts",
+      "showMonospaceOnly": "Show monospace fonts only",
+      "notInstalled": "\"{{family}}\" isn't installed — the terminal will fall back to another font"
     },
     "varSearch": {
       "usage_one": "{{count}} element uses",

--- a/src/i18n/locales/fr/themeCreator.json
+++ b/src/i18n/locales/fr/themeCreator.json
@@ -8,7 +8,14 @@
     "font": {
       "customLabel": "Police personnalisée…",
       "customPlaceholder": "'Ma Police', monospace",
-      "customHint": "Appuyez sur Entrée pour appliquer"
+      "customHint": "Appuyez sur Entrée pour appliquer",
+      "searchPlaceholder": "Rechercher une police installée…",
+      "loading": "Lecture des polices installées…",
+      "noneInstalled": "Aucune police installée trouvée",
+      "noMatches": "Aucune police correspondante",
+      "showAll": "Afficher toutes les polices",
+      "showMonospaceOnly": "N'afficher que les polices à chasse fixe",
+      "notInstalled": "« {{family}} » n'est pas installée — le terminal utilisera une autre police"
     },
     "varSearch": {
       "usage_one": "{{count}} élément utilise",

--- a/src/i18n/locales/ru/themeCreator.json
+++ b/src/i18n/locales/ru/themeCreator.json
@@ -8,7 +8,14 @@
     "font": {
       "customLabel": "Свой шрифт…",
       "customPlaceholder": "'My Font', monospace",
-      "customHint": "Нажмите Enter, чтобы применить"
+      "customHint": "Нажмите Enter, чтобы применить",
+      "searchPlaceholder": "Поиск установленных шрифтов…",
+      "loading": "Чтение установленных шрифтов…",
+      "noneInstalled": "Установленные шрифты не найдены",
+      "noMatches": "Подходящий шрифт не найден",
+      "showAll": "Показать все шрифты",
+      "showMonospaceOnly": "Показывать только моноширинные шрифты",
+      "notInstalled": "«{{family}}» не установлен — терминал использует другой шрифт"
     },
     "varSearch": {
       "usage_one": "{{count}} элемент использует",

--- a/src/i18n/locales/zh/themeCreator.json
+++ b/src/i18n/locales/zh/themeCreator.json
@@ -8,7 +8,14 @@
     "font": {
       "customLabel": "自定义字体…",
       "customPlaceholder": "'我的字体', monospace",
-      "customHint": "按 Enter 应用"
+      "customHint": "按 Enter 应用",
+      "searchPlaceholder": "搜索已安装字体…",
+      "loading": "正在读取已安装字体…",
+      "noneInstalled": "未找到已安装的字体",
+      "noMatches": "没有匹配的字体",
+      "showAll": "显示全部字体",
+      "showMonospaceOnly": "仅显示等宽字体",
+      "notInstalled": "未安装“{{family}}”——终端将回退到其他字体"
     },
     "varSearch": {
       "usage_one": "{{count}} 个元素使用",

--- a/src/utils/systemFonts.test.ts
+++ b/src/utils/systemFonts.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { primaryFamily, toFontStack } from "./systemFonts";
+
+describe("primaryFamily", () => {
+  it("unwraps the first family of a preset stack", () => {
+    expect(primaryFamily("'JetBrains Mono', monospace")).toBe("JetBrains Mono");
+  });
+
+  it("handles a bare unquoted family", () => {
+    expect(primaryFamily("MesloLGS Nerd Font Mono")).toBe("MesloLGS Nerd Font Mono");
+  });
+
+  it("handles double quotes", () => {
+    expect(primaryFamily('"Fira Code", monospace')).toBe("Fira Code");
+  });
+
+  it("returns an empty string for an empty stack", () => {
+    expect(primaryFamily("")).toBe("");
+  });
+});
+
+describe("toFontStack", () => {
+  it("quotes the family and appends the generic", () => {
+    expect(toFontStack("MesloLGS Nerd Font Mono", "monospace")).toBe(
+      "'MesloLGS Nerd Font Mono', monospace",
+    );
+  });
+
+  it("escapes a quote inside the family name", () => {
+    expect(toFontStack("Bob's Mono", "monospace")).toBe("'Bob\\'s Mono', monospace");
+  });
+
+  it("round-trips through primaryFamily", () => {
+    const family = "MesloLGS NF";
+    expect(primaryFamily(toFontStack(family, "monospace"))).toBe(family);
+  });
+});

--- a/src/utils/systemFonts.ts
+++ b/src/utils/systemFonts.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+export interface SystemFont {
+  family: string;
+  monospace: boolean;
+}
+
+/** Families installed on this machine, from `list_system_fonts`. Enumerating
+ *  parses every font on disk, so it is resolved once and cached for the session.
+ *  Failure yields an empty list — the pickers still offer their bundled presets
+ *  and the free-text entry. */
+let cached: Promise<SystemFont[]> | null = null;
+
+export function getSystemFonts(): Promise<SystemFont[]> {
+  if (!cached) cached = invoke<SystemFont[]>("list_system_fonts").catch(() => []);
+  return cached;
+}
+
+/** React hook: installed families, or `null` until they resolve. */
+export function useSystemFonts(): SystemFont[] | null {
+  const [fonts, setFonts] = useState<SystemFont[] | null>(null);
+  useEffect(() => {
+    let alive = true;
+    getSystemFonts().then((f) => alive && setFonts(f));
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return fonts;
+}
+
+/** The first family in a CSS font stack, unquoted — what the picker shows as the
+ *  current selection and what it matches against the installed list. */
+export function primaryFamily(fontFamily: string): string {
+  return (fontFamily.split(",")[0] ?? "").trim().replace(/^['"]|['"]$/g, "");
+}
+
+/** Always quotes the family, matching the preset stacks (`'JetBrains Mono', monospace`)
+ *  so a system pick and its preset twin compare equal. The generic tail is what keeps
+ *  an unresolvable family from falling through to a proportional default (#196). */
+export function toFontStack(family: string, generic: string): string {
+  return `'${family.replace(/'/g, "\\'")}', ${generic}`;
+}


### PR DESCRIPTION
Follows #199. Together they close #196.

## Why

The font pickers offered two bundled presets and a free-text box. A family typed into that box was accepted whether or not it existed on the machine, and an unresolvable family silently falls through to the engine's proportional default — cells measured from a serif face, letters painted in it. That is exactly what #196 looks like, and nothing in the UI ever said the font had not been found.

#199 makes that failure degrade to a monospace face instead of a proportional one. This PR stops it happening in the first place.

## What

**Backend.** A new `list_system_fonts` command enumerates installed families with `fontdb`. It scans the OS font directories in pure Rust, so it needs no fontconfig, CoreText or DirectWrite linkage and stays out of the cross-compile images' way. Faces are deduplicated into one row per family, reported under the English `name` record because that is what CSS matches on, and flagged monospace if any face in the family claims fixed pitch.

**Frontend.** The picker keeps the bundled presets pinned at the top, then lists the installed families with a search box, each row previewed in its own face. The terminal picker filters to monospaced families, with a **Show all fonts** toggle — some fonts misreport fixed pitch, and Nerd Fonts' non-`Mono` variants legitimately report proportional. Picking a family stores `'Family', monospace` (or `sans-serif` for the UI picker), so the generic tail from #199 is present from the start. The free-text box stays as an escape hatch and now warns when the family it holds is not installed.

Bundled webfonts (JetBrains Mono, Source Code Pro) ship inside the app rather than being installed, so `fontdb` cannot see them — they stay pinned as presets and are never reported missing.

Strings added to all four locales (en/fr/ru/zh); the locale diffs are additive only.

## Verification

Driven live in the headless container with the Meslo Nerd Fonts installed:

| step | result |
| --- | --- |
| Picker open | Presets on top, then installed families, each row previewed in its own font |
| Monospace filter | Only `DejaVu Sans Mono` and the Meslo **Mono** variants; `DejaVu Sans`/`Serif` and the non-`Mono` Meslo variants hidden |
| Show all fonts | Proportional families appear; toggle flips to "Show monospace fonts only" |
| Pick `MesloLGS Nerd Font Mono` | Stored as `'MesloLGS Nerd Font Mono', monospace` |
| Custom `MesloLGS NF` | Warns: *"MesloLGS NF" isn't installed — the terminal will fall back to another font* |

That last case is the likely shape of the original report: powerlevel10k's installer ships the family as `MesloLGS NF`, not the Nerd Fonts v3 name `MesloLGS Nerd Font Mono`.

- `tsc --noEmit` clean.
- Frontend suite green: 519 files, 3977 tests.
- Rust `--lib` green: 349 passed, 0 failed. (A fresh worktree fails 3 `commands::plugins` tests until `pnpm build:plugins` has run — unrelated to this change.)
- `cargo fmt --check` clean.

## Notes for review

- The `monospaced` flag comes from `post.isFixedPitch` and PANOSE, which is why the escape hatch exists rather than a hard filter.
- Enumeration parses every font on disk, so the result is cached for the session and resolved off the UI thread; a failure yields an empty list and the picker still offers presets plus free text.