### PR TITLE
test: stop Iconify's API query from firing into a torn-down jsdom

### DIFF
--- a/src/utils/iconifyTestApi.test.tsx
+++ b/src/utils/iconifyTestApi.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { render } from "@testing-library/react";
+import { Icon } from "@iconify/react";
+
+// Guards vitest.setup.ts. Without the inert API module, Iconify batches the icon on a
+// 0ms tick and only then arms its query retry/timeout timers (750ms, 499ms, 4000ms).
+// The 4s one outlives short test files and fires into a torn-down jsdom, failing the
+// run with zero test failures — so this has to look *after* the batching tick.
+describe("iconify in tests", () => {
+  test("rendering an icon arms no timer that can outlive the test file", async () => {
+    const realTimeout = globalThis.setTimeout;
+    const wait = (ms: number) =>
+      new Promise((resolve) => (realTimeout as unknown as (...a: unknown[]) => number)(resolve, ms));
+    const delays: number[] = [];
+    (globalThis as unknown as { setTimeout: unknown }).setTimeout = (
+      fn: () => void,
+      ms?: number,
+      ...rest: unknown[]
+    ) => {
+      delays.push(ms ?? 0);
+      return (realTimeout as unknown as (...a: unknown[]) => number)(fn, ms, ...rest);
+    };
+
+    try {
+      render(<Icon icon="lucide:chevron-down" width={12} />);
+      await wait(50);
+    } finally {
+      (globalThis as unknown as { setTimeout: unknown }).setTimeout = realTimeout;
+    }
+
+    expect(delays.filter((ms) => ms > 0)).toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     // `navigator.onLine`) and rely on a fresh module registry + globals per file. Do not
     // disable isolation without giving those tests explicit cross-file resets.
     environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
     include: [
       "src/**/*.{test,spec}.{ts,tsx}",
       "tests/**/*.{test,spec}.ts",

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,15 @@
+import { _api } from "@iconify/react";
+
+// Iconify resolves an unknown icon by querying its public API, and that query arms
+// retry/timeout timers — 750ms, 499ms and 4000ms for a single <Icon> render. A test
+// file that finishes sooner leaves them armed; when the 4s one fires, jsdom is gone,
+// so Iconify's setState reaches react-dom, which touches `window` and throws
+// `ReferenceError: window is not defined`. Vitest reports that as an unhandled error
+// and fails the run with every test passing — a CI-only flake that depends on how
+// long the run takes.
+//
+// The app never queries the API either: `preloadIcons()` registers every collection
+// from bundled packages. An inert API module makes tests match, and stops the suite
+// reaching the network at all. Icons render as an empty <span>, exactly as they do
+// today when the query never resolves in time.
+_api.setAPIModule("", { prepare: () => [], send: () => {} });


### PR DESCRIPTION
## The failure

CI has been failing intermittently with every test passing:

```
Test Files  519 passed (519)
Tests       3977 passed (3977)
Errors      1 error

ReferenceError: window is not defined
 ❯ resolveUpdatePriority  react-dom/cjs/react-dom-client.development.js:1308:7
 ❯ dispatchSetState       react-dom/cjs/react-dom-client.development.js:9126:14
 ❯ cleanup                @iconify/react/dist/iconify.js:1833:13
 ❯ Timeout._onTimeout     @iconify/react/dist/iconify.js:845:10
```

Most recently on #199, where a re-run cleared it with no code change.

## Root cause

Rendering an `<Icon>` whose icon is not already in a loaded collection makes Iconify query its public API. That query arms retry/timeout timers — measured in this repo as **750ms, 499ms and 4000ms** — and it arms them one tick *after* the render, not during it.

A test file that finishes inside 4s leaves the last timer live. When it fires, jsdom has been torn down, so Iconify's `setState` reaches react-dom, which touches `window` and throws. Vitest counts that as an unhandled error and fails the run even though nothing actually failed.

Whether it happens depends only on how long the run takes, which is why it never reproduced on a single file — `src/plugins/docker/components/PortChips.test.tsx`, the file CI blamed, passes cleanly five runs in a row on its own. The blamed file is just whichever one happened to be running when a stray timer fired.

A side effect worth noting: the suite has been reaching `api.iconify.design` on every icon render.

## Fix

A new `vitest.setup.ts` installs an inert Iconify API module, so no query is ever created, no timers are armed, and nothing leaves the machine.

This matches the app: `preloadIcons()` registers every collection from bundled packages, and the API is never used in production either. Rendered output does not change — icons already came out as an empty `<span>` in tests, because the query never resolved in time anyway.

`src/utils/iconifyTestApi.test.tsx` guards it.

## Verification

- The guard test is red before green. Without the setup file it fails with `expected [ 750, 499, 4000 ] to deeply equal []`; with it, it passes.
- `tsc --noEmit` clean.
- Full suite green: **521 files, 3985 tests, 0 errors**, exit 0.

## Note

This does not make icons *render* in tests — it makes them deterministically not render, which is what they already did. Loading the real collections in the setup file would render them for real, but it changes the DOM every icon-bearing test sees, so it is deliberately not part of this change.