### PR TITLE
refactor(theme): build the font picker from the shared picker parts

### DIFF
--- a/src/components/connections/DistroIconPicker.tsx
+++ b/src/components/connections/DistroIconPicker.tsx
@@ -3,7 +3,7 @@ import { Icon } from "@iconify/react";
 import { useTranslation } from "react-i18next";
 import { PickerSurface } from "@/components/shared/PickerSurface";
 import { filterIconOptions, getConnectionIcon, getConnectionIconColor, getConnectionIconLabel, glossyTileStyle } from "@/utils/icons";
-import { formInputClass, formInputStyle } from "@/components/shared/Panel";
+import { PickerSearch } from "@/components/shared/pickerParts";
 
 /** Distro/icon chooser body: search + grid of CONNECTION_ICON_OPTIONS, hosted in a
  *  PickerSurface (anchored float on desktop, bottom sheet on mobile). Caller owns the
@@ -38,21 +38,11 @@ export function DistroIconPicker({
   return (
     <PickerSurface open={open} onClose={onClose} anchorRef={anchorRef} title={t("connections.distroIconPicker.title")}>
       <div className="p-1.5 space-y-3">
-        <div className="relative">
-          <Icon
-            icon="lucide:search"
-            width={13}
-            className="absolute left-2.5 top-1/2 -translate-y-1/2 text-(--t-text-dim) pointer-events-none"
-          />
-          <input
-            className={`${formInputClass} pl-7 text-xs`}
-            style={formInputStyle}
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder={t("connections.distroIconPicker.searchPlaceholder")}
-            autoFocus
-          />
-        </div>
+        <PickerSearch
+          value={search}
+          onChange={setSearch}
+          placeholder={t("connections.distroIconPicker.searchPlaceholder")}
+        />
         <div className="grid grid-cols-4 gap-2 max-h-52 overflow-y-auto pr-1">
           {results.map((option) => {
             const selected = selectedIcon === option.id;

--- a/src/components/connections/HostCommandField.tsx
+++ b/src/components/connections/HostCommandField.tsx
@@ -4,7 +4,7 @@ import { Icon } from "@iconify/react";
 import { useAllSnippets } from "@/hooks/useAllSnippets";
 import { SnippetChooserList } from "@/components/snippets/SnippetChooserList";
 import { PickerSurface } from "@/components/shared/PickerSurface";
-import { formInputClass, formInputStyle } from "@/components/shared/Panel";
+import { PickerSearch } from "@/components/shared/pickerParts";
 
 export interface HostCommandFieldProps {
   slot: "pre" | "post";
@@ -72,21 +72,11 @@ export function HostCommandField({ slot, text, snippetId, onChangeText, onChange
         title={t("connections.common.hostCommand.pickerTitle")}
       >
         <div className="p-1.5 space-y-2">
-          <div className="relative">
-            <Icon
-              icon="lucide:search"
-              width={13}
-              className="absolute left-2.5 top-1/2 -translate-y-1/2 text-(--t-text-dim) pointer-events-none"
-            />
-            <input
-              className={`${formInputClass} pl-7 text-xs`}
-              style={formInputStyle}
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder={t("connections.common.hostCommand.searchPlaceholder")}
-              autoFocus
-            />
-          </div>
+          <PickerSearch
+            value={search}
+            onChange={setSearch}
+            placeholder={t("connections.common.hostCommand.searchPlaceholder")}
+          />
           <div className="max-h-52 overflow-y-auto -mx-1.5">
             <SnippetChooserList
               search={search}

--- a/src/components/shared/pickerParts.tsx
+++ b/src/components/shared/pickerParts.tsx
@@ -1,11 +1,13 @@
 import type { ReactNode, RefObject } from "react";
 import { Icon } from "@iconify/react";
+import { formInputClass, formInputStyle } from "./Panel";
 
 /** The field-shaped button every picker opens its surface from. */
 export function PickerTrigger({
   buttonRef,
   icon,
   label,
+  labelFont,
   filled,
   open,
   onToggle,
@@ -14,6 +16,8 @@ export function PickerTrigger({
   buttonRef: RefObject<HTMLButtonElement | null>;
   icon: string;
   label: string;
+  /** Font stack the label previews itself in, for a trigger that picks a font. */
+  labelFont?: string;
   /** Something is selected: the label takes the primary colour. */
   filled: boolean;
   open: boolean;
@@ -34,7 +38,9 @@ export function PickerTrigger({
       }}
     >
       <Icon icon={icon} width={14} className="text-(--t-text-dim) shrink-0" />
-      <span className="flex-1 text-left truncate text-xs">{label}</span>
+      <span className="flex-1 text-left truncate text-xs" style={labelFont ? { fontFamily: labelFont } : undefined}>
+        {label}
+      </span>
       {trailing}
       <span className="[&_path]:stroke-[2.5]">
         <Icon
@@ -52,14 +58,18 @@ export function PickerTrigger({
 export function PickerOption({
   icon,
   label,
+  labelFont,
   sublabel,
   badge,
   active,
   onClick,
   labelTone = "inherit",
 }: {
-  icon: string;
+  /** Omitted for rows whose label already carries the meaning (a font preview). */
+  icon?: string;
   label: string;
+  /** Font stack the label previews itself in. */
+  labelFont?: string;
   sublabel?: string;
   badge?: ReactNode;
   active: boolean;
@@ -76,9 +86,14 @@ export function PickerOption({
       onMouseEnter={(e) => { e.currentTarget.style.background = "var(--t-bg-card-hover)"; }}
       onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
     >
-      <Icon icon={icon} width={13} className="shrink-0" />
+      {icon && <Icon icon={icon} width={13} className="shrink-0" />}
       <div className="flex-1 text-left min-w-0">
-        <p className={`truncate${labelTone === "primary" ? " text-(--t-text-primary)" : ""}`}>{label}</p>
+        <p
+          className={`truncate${labelTone === "primary" ? " text-(--t-text-primary)" : ""}`}
+          style={labelFont ? { fontFamily: labelFont } : undefined}
+        >
+          {label}
+        </p>
         {sublabel && <p className="truncate text-(--t-text-dim)">{sublabel}</p>}
       </div>
       {badge}
@@ -126,5 +141,36 @@ export function PickerFooterAction({
       <span className="flex-1 text-left">{label}</span>
       {trailingIcon && <Icon icon={trailingIcon} width={13} />}
     </button>
+  );
+}
+
+/** The filter box a long picker opens with. */
+export function PickerSearch({
+  value,
+  onChange,
+  placeholder,
+  autoFocus = true,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  autoFocus?: boolean;
+}) {
+  return (
+    <div className="relative">
+      <Icon
+        icon="lucide:search"
+        width={13}
+        className="absolute left-2.5 top-1/2 -translate-y-1/2 text-(--t-text-dim) pointer-events-none"
+      />
+      <input
+        className={`${formInputClass} pl-7 text-xs`}
+        style={formInputStyle}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+      />
+    </div>
   );
 }

--- a/src/components/theme-creator/ThemeCreator.tsx
+++ b/src/components/theme-creator/ThemeCreator.tsx
@@ -16,6 +16,15 @@ import {
 import { getUiGroups, getTerminalGroups, getFieldLabels } from "./colorGroups";
 import { ColorPicker } from "./ColorPicker";
 import { primaryFamily, toFontStack, useSystemFonts } from "@/utils/systemFonts";
+import { PickerSurface } from "@/components/shared/PickerSurface";
+import {
+  PickerDivider,
+  PickerFooterAction,
+  PickerOption,
+  PickerSearch,
+  PickerTrigger,
+} from "@/components/shared/pickerParts";
+import { formInputClass, formInputStyle } from "@/components/shared/Panel";
 
 // ── CSS variable inspector ────────────────────────────────────────────────────
 
@@ -125,7 +134,7 @@ function FontPicker({
   const [custom, setCustom] = useState(false);
   const [query, setQuery] = useState("");
   const [showAll, setShowAll] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const systemFonts = useSystemFonts();
 
   const isPreset = options.some((o) => o.value === value);
@@ -142,57 +151,24 @@ function FontPicker({
     return f.family.toLowerCase().includes(query.trim().toLowerCase());
   });
 
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-        setCustom(false);
-      }
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open]);
-
   const close = () => { setOpen(false); setCustom(false); setQuery(""); };
-  const rowBackground = (active: boolean) =>
-    active ? "color-mix(in srgb, var(--t-accent) 12%, transparent)" : "transparent";
-
-  const Row = ({ label, stack, active, onPick }: {
-    label: string; stack: string; active: boolean; onPick: () => void;
-  }) => (
-    <button
-      type="button"
-      onClick={() => { onPick(); close(); }}
-      className="w-full flex items-center justify-between px-3 py-2 text-left cursor-pointer transition-colors"
-      style={{ background: rowBackground(active) }}
-      onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "var(--t-bg-elevated)"; }}
-      onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = rowBackground(active); }}
-    >
-      <span style={{ fontFamily: stack, fontSize: 13, color: "var(--t-text-primary)" }}>{label}</span>
-      {active && <Icon icon="lucide:check" width={12} className="text-(--t-accent) shrink-0" />}
-    </button>
-  );
+  const pick = (stack: string) => { onChange(stack); close(); };
+  const note = (text: string) => <p className="px-3 py-2 text-xs text-(--t-text-dim)">{text}</p>;
 
   return (
-    <div ref={ref} className="relative mt-1">
-      {/* Trigger */}
-      <button
-        type="button"
-        onClick={() => { setOpen((o) => !o); setCustom(false); }}
-        className="w-full flex items-center justify-between gap-2 px-2.5 py-1.5 rounded-md text-sm bg-(--t-bg-input) border border-(--t-border) text-(--t-text-primary) cursor-pointer"
-        onMouseEnter={(e) => (e.currentTarget.style.borderColor = "var(--t-border-hover)")}
-        onMouseLeave={(e) => (e.currentTarget.style.borderColor = open ? "var(--t-accent)" : "var(--t-border)")}
-        style={{ borderColor: open ? "var(--t-accent)" : undefined }}
-      >
-        <span className="truncate" style={{ fontFamily: value, fontSize: 13 }}>{displayLabel}</span>
-        <span className="flex items-center gap-1.5 shrink-0">
-          {missing && (
-            <Icon icon="lucide:triangle-alert" width={12} className="text-(--t-status-warning)" />
-          )}
-          <Icon icon={open ? "lucide:chevron-up" : "lucide:chevron-down"} width={12} className="text-(--t-text-dim)" />
-        </span>
-      </button>
+    <div className="mt-1">
+      <PickerTrigger
+        buttonRef={triggerRef}
+        icon="lucide:type"
+        label={displayLabel}
+        labelFont={value}
+        filled
+        open={open}
+        onToggle={() => { setOpen((o) => !o); setCustom(false); }}
+        trailing={missing
+          ? <Icon icon="lucide:triangle-alert" width={13} className="text-(--t-status-warning) shrink-0" />
+          : undefined}
+      />
 
       {missing && (
         <p className="text-[10px] mt-1 text-(--t-status-warning)">
@@ -200,96 +176,83 @@ function FontPicker({
         </p>
       )}
 
-      {/* Dropdown */}
-      {open && (
-        <div
-          className="absolute left-0 right-0 z-50 mt-1 rounded-md bg-(--t-bg-modal) overflow-hidden"
-          style={{ boxShadow: "var(--t-ring), var(--t-elev-2)" }}
-        >
-          {options.map((opt) => (
-            <Row
-              key={opt.value}
-              label={opt.label}
-              stack={opt.value}
-              active={value === opt.value}
-              onPick={() => onChange(opt.value)}
-            />
-          ))}
+      <PickerSurface open={open} onClose={close} anchorRef={triggerRef} title={t("themeCreator.editor.family")}>
+        {options.map((opt) => (
+          <PickerOption
+            key={opt.value}
+            label={opt.label}
+            labelFont={opt.value}
+            labelTone="primary"
+            active={value === opt.value}
+            onClick={() => pick(opt.value)}
+          />
+        ))}
 
-          <div className="border-t border-(--t-border)" />
+        <PickerDivider />
 
-          {systemFonts === null ? (
-            <p className="px-3 py-2 text-xs text-(--t-text-dim)">{t("themeCreator.font.loading")}</p>
-          ) : systemFonts.length === 0 ? (
-            <p className="px-3 py-2 text-xs text-(--t-text-dim)">{t("themeCreator.font.noneInstalled")}</p>
-          ) : (
-            <>
-              <div className="px-3 pt-2">
-                <input
-                  value={query}
-                  onChange={(e) => setQuery(e.target.value)}
-                  placeholder={t("themeCreator.font.searchPlaceholder")}
-                  className="w-full px-2 py-1 rounded-sm text-xs outline-hidden bg-(--t-bg-input) border border-(--t-border) text-(--t-text-primary)"
-                />
-              </div>
-              <div className="max-h-56 overflow-y-auto mt-1">
-                {listed.length === 0 ? (
-                  <p className="px-3 py-2 text-xs text-(--t-text-dim)">{t("themeCreator.font.noMatches")}</p>
-                ) : (
-                  listed.map((f) => (
-                    <Row
-                      key={f.family}
-                      label={f.family}
-                      stack={toFontStack(f.family, generic)}
-                      active={f.family.toLowerCase() === selected.toLowerCase()}
-                      onPick={() => onChange(toFontStack(f.family, generic))}
-                    />
-                  ))
-                )}
-              </div>
-              {monospaceOnly && (
-                <button
-                  type="button"
-                  onClick={() => setShowAll((s) => !s)}
-                  className="w-full px-3 py-2 text-left text-xs text-(--t-text-muted) cursor-pointer transition-colors border-t border-(--t-border)"
-                  onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.color = "var(--t-text-primary)"; }}
-                  onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.color = "var(--t-text-muted)"; }}
-                >
-                  {showAll ? t("themeCreator.font.showMonospaceOnly") : t("themeCreator.font.showAll")}
-                </button>
-              )}
-            </>
-          )}
-
-          {/* Custom divider */}
-          <div className="border-t border-(--t-border)" />
-          {!custom ? (
-            <button
-              type="button"
-              onClick={() => setCustom(true)}
-              className="w-full px-3 py-2 text-left text-xs text-(--t-text-muted) cursor-pointer transition-colors"
-              onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.color = "var(--t-text-primary)"; }}
-              onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.color = "var(--t-text-muted)"; }}
-            >
-              {t("themeCreator.font.customLabel")}
-            </button>
-          ) : (
-            <div className="px-3 py-2">
-              <input
-                autoFocus
-                defaultValue={isPreset ? "" : value}
-                placeholder={t("themeCreator.font.customPlaceholder")}
-                className="w-full px-2 py-1 rounded-sm text-xs outline-hidden font-mono bg-(--t-bg-input) border border-(--t-accent) text-(--t-text-primary)"
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") { onChange(e.currentTarget.value); close(); }
-                  if (e.key === "Escape") { setCustom(false); }
-                }}
+        {systemFonts === null ? (
+          note(t("themeCreator.font.loading"))
+        ) : systemFonts.length === 0 ? (
+          note(t("themeCreator.font.noneInstalled"))
+        ) : (
+          <>
+            {/* The surface is the only scroller — a nested one would clip a row
+                against its max height. The filter stays pinned to the top. */}
+            <div className="sticky top-0 z-10 pb-1 bg-(--t-bg-card)">
+              <PickerSearch
+                value={query}
+                onChange={setQuery}
+                placeholder={t("themeCreator.font.searchPlaceholder")}
+                autoFocus={false}
               />
-              <p className="text-[10px] text-(--t-text-dim) mt-1">{t("themeCreator.font.customHint")}</p>
             </div>
-          )}
-        </div>
-      )}
+            {listed.length === 0
+              ? note(t("themeCreator.font.noMatches"))
+              : listed.map((f) => (
+                <PickerOption
+                  key={f.family}
+                  label={f.family}
+                  labelFont={toFontStack(f.family, generic)}
+                  labelTone="primary"
+                  active={f.family.toLowerCase() === selected.toLowerCase()}
+                  onClick={() => pick(toFontStack(f.family, generic))}
+                />
+              ))}
+            {monospaceOnly && (
+              <PickerFooterAction
+                icon={showAll ? "lucide:filter" : "lucide:list"}
+                label={showAll ? t("themeCreator.font.showMonospaceOnly") : t("themeCreator.font.showAll")}
+                onClick={() => setShowAll((s) => !s)}
+              />
+            )}
+          </>
+        )}
+
+        <PickerDivider />
+
+        {!custom ? (
+          <PickerFooterAction
+            icon="lucide:pencil"
+            label={t("themeCreator.font.customLabel")}
+            onClick={() => setCustom(true)}
+          />
+        ) : (
+          <div className="px-1.5 py-1">
+            <input
+              autoFocus
+              defaultValue={isPreset ? "" : value}
+              placeholder={t("themeCreator.font.customPlaceholder")}
+              className={`${formInputClass} text-xs font-mono`}
+              style={{ ...formInputStyle, borderColor: "var(--t-accent)" }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") { onChange(e.currentTarget.value); close(); }
+                if (e.key === "Escape") { setCustom(false); }
+              }}
+            />
+            <p className="text-[10px] text-(--t-text-dim) mt-1">{t("themeCreator.font.customHint")}</p>
+          </div>
+        )}
+      </PickerSurface>
     </div>
   );
 }


### PR DESCRIPTION
The font picker added in #201 came with its own trigger, rows, dividers, footer
actions and search box. That left the one dropdown sitting next to the appearance
settings looking unlike every other dropdown in the app: a smaller trigger whose
chevron swapped glyphs instead of rotating, rows tinted with accent-12% instead of
carrying an accent label, and its own radius, paddings and shadow.

It is now assembled from `PickerTrigger`, `PickerSurface`, `PickerOption`,
`PickerDivider` and `PickerFooterAction` — the same parts as the encoding, key,
identity and folder pickers.

That is not only cosmetic. Going through `PickerSurface` gives the list the
surface's behaviour, which the in-flow `absolute` menu could not have:

- it is a portalled float that flips above the trigger when the theme panel is
  scrolled near the bottom, instead of opening down into the scroll region;
- it is a bottom sheet on Android, where the theme creator previously showed a
  desktop-sized float.

Two primitives are widened, both reusable:

- `PickerTrigger` and `PickerOption` take an optional `labelFont`, so a row can
  preview itself in the face it names;
- `PickerOption`'s `icon` becomes optional, for rows whose label is the whole
  content — the shape `DropdownMenuItem` already allowed.

The in-surface filter box was copied byte-for-byte between the distro icon picker
and the host command field. It is extracted as `PickerSearch` and used by all
three, so this removes a duplicate rather than adding a third.

One layout fix came out of looking at it: a nested fixed-height scroller inside
`PickerSurface` fights the surface's own 320px cap — two scrollbars, and a row
clipped mid-glyph. The surface is the only scroller now, with the filter pinned
`sticky top-0`.

Font previews, the monospace filter and its "show all fonts" escape hatch, the
free-text box and the "not installed" warning all behave as before.

## Verification

`tsc --noEmit` clean; 207 tests across `shared`, `connections` and `settings` pass.

Driven in the headless build and read back from screenshots:

- app font dropdown — presets, divider, pinned filter, installed families each
  rendered in their own face, accent check on the selection;
- terminal font dropdown — only `*Mono` families listed, `Show all fonts` and
  `Custom font…` footer actions;
- typing an unavailable family into the custom box — warning triangle in the
  trigger plus the "isn't installed" line;
- distro icon picker — search intact after the `PickerSearch` extraction.
