### PR TITLE
fix(sftp): use tar acceleration for pasted directories

### DIFF
--- a/src/components/filetransfer/SFTPPage.tsx
+++ b/src/components/filetransfer/SFTPPage.tsx
@@ -16,7 +16,7 @@ import { transferItem } from "@/services/sftpTransferCore";
 import { runIntraPaneMove } from "./moveService";
 import { hitTestDropTarget, setExternalDragHover, clearExternalDragHover } from "./internalDrag";
 import { triggerUpload } from "./osDropPipeline";
-import { tarUsable } from "./tarSupport";
+import { tarUsable, tarUsableForPair } from "./tarSupport";
 import { useTransferQueueStore } from "@/stores/transferQueueStore";
 import { useFileClipboardStore, type FileEndpoint } from "@/stores/fileClipboardStore";
 import { buildPasteDeps, executePaste } from "./pasteService";
@@ -235,9 +235,10 @@ export default function SFTPPage() {
     const dstIsLocal = dstHost?.kind === "local";
     const srcSftpId = src.tag === "connected" ? src.sftpId : null;
     const dstSftpId = dst.tag === "connected" ? dst.sftpId : null;
-    // local↔local uses fsCopy, never tar.
-    const useTar = !(srcIsLocal && dstIsLocal)
-      && await tarUsable([srcSftpId, dstSftpId], srcIsLocal || dstIsLocal);
+    const useTar = await tarUsableForPair(
+      { isLocal: !!srcIsLocal, sftpId: srcSftpId },
+      { isLocal: !!dstIsLocal, sftpId: dstSftpId },
+    );
     if (useTar && files.length > 1) {
       await execBatchTar(files, fromSide, targetFolder);
     } else {

--- a/src/components/filetransfer/pasteService.test.ts
+++ b/src/components/filetransfer/pasteService.test.ts
@@ -1,7 +1,19 @@
-import { describe, it, expect, vi } from "vitest";
-import { executePaste, type PasteDeps } from "./pasteService";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { executePaste, buildPasteDeps, type PasteDeps } from "./pasteService";
 import type { FileEntry } from "@/components/filetransfer/SFTPTypes";
 import type { FileClipboard, FileEndpoint } from "@/stores/fileClipboardStore";
+import { transferItem } from "@/services/sftpTransferCore";
+import { tarUsableForPair } from "./tarSupport";
+
+vi.mock("@/services/sftpTransferCore", () => ({ transferItem: vi.fn(async () => {}) }));
+vi.mock("./tarSupport", () => ({ tarUsableForPair: vi.fn(async () => false) }));
+vi.mock("@/services/sftp", () => ({
+  fsExists: vi.fn(async () => false), sftpExists: vi.fn(async () => false),
+  fsRename: vi.fn(async () => {}), sftpRename: vi.fn(async () => {}),
+  fsDelete: vi.fn(async () => {}), sftpDelete: vi.fn(async () => {}),
+}));
+
+beforeEach(() => { vi.clearAllMocks(); });
 
 const file = (path: string): FileEntry => ({ path, name: path.split("/").pop()!, isDir: false } as FileEntry);
 const local = (cwd: string): FileEndpoint => ({ isLocal: true, sftpId: null, cwd });
@@ -78,5 +90,47 @@ describe("executePaste", () => {
     await executePaste(clip!, local("/a"), deps);
     expect(deps.moveSameHost).not.toHaveBeenCalled();
     expect(deps.copyTarget).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildPasteDeps", () => {
+  const dir = (path: string): FileEntry => ({ path, name: path.split("/").pop()!, isDir: true } as FileEntry);
+
+  const wiring = () => ({
+    runTransfer: vi.fn(async (_l: string, _d: string, fn: (t: string) => Promise<void>, onDone?: () => void) => {
+      await fn("t1");
+      onDone?.();
+    }),
+    setPending: vi.fn(),
+    refresh: vi.fn(),
+    clearClipboard: vi.fn(),
+  });
+
+  const copyOne = async (source: FileEndpoint, dest: FileEndpoint, item: FileEntry) => {
+    const w = wiring();
+    const clip: FileClipboard = { items: [item], source, mode: "cut" };
+    const deps = buildPasteDeps(clip, dest, w as never);
+    await deps.copyTarget({ srcPath: item.path, dstPath: `${dest.cwd}/${item.name}`, isDir: item.isDir, name: item.name });
+    return w;
+  };
+
+  it("tars a directory paste when the endpoint pair supports it", async () => {
+    vi.mocked(tarUsableForPair).mockResolvedValue(true);
+    const w = await copyOne(remote("s1", "/a"), local("/b"), dir("/a/saves"));
+    expect(transferItem).toHaveBeenCalledWith(expect.objectContaining({ useTar: true }));
+    expect(w.runTransfer).toHaveBeenCalledWith("saves", "→", expect.any(Function), expect.any(Function), true);
+  });
+
+  it("falls back to plain SFTP when the pair cannot tar", async () => {
+    vi.mocked(tarUsableForPair).mockResolvedValue(false);
+    const w = await copyOne(remote("s1", "/a"), local("/b"), dir("/a/saves"));
+    expect(transferItem).toHaveBeenCalledWith(expect.objectContaining({ useTar: false }));
+    expect(w.runTransfer).toHaveBeenCalledWith("saves", "→", expect.any(Function), expect.any(Function), false);
+  });
+
+  it("never flags a single file as accelerated", async () => {
+    vi.mocked(tarUsableForPair).mockResolvedValue(true);
+    const w = await copyOne(remote("s1", "/a"), local("/b"), file("/a/x.txt"));
+    expect(w.runTransfer).toHaveBeenCalledWith("x.txt", "→", expect.any(Function), expect.any(Function), false);
   });
 });

--- a/src/components/filetransfer/pasteService.ts
+++ b/src/components/filetransfer/pasteService.ts
@@ -3,6 +3,7 @@ import type { FileClipboard, FileEndpoint } from "@/stores/fileClipboardStore";
 import type { PendingTransferAction } from "@/stores/transferQueueStore";
 import { type TransferTarget, transferItem } from "@/services/sftpTransferCore";
 import { classifyPaste } from "./pasteClassify";
+import { tarUsableForPair } from "./tarSupport";
 import { copyNameCandidate } from "./copyNameCandidate";
 import { sameHost } from "@/stores/fileClipboardStore";
 import { runIntraPaneMove } from "./moveService";
@@ -103,6 +104,7 @@ export function buildPasteDeps(
     existsInDest: (name) => existsAt(dest, joinDir(dest.cwd, name)),
     copyTarget: async (target) => {
       let ok = false;
+      const useTar = await tarUsableForPair(src, dest);
       await wiring.runTransfer(
         target.name, "→",
         (tid) => transferItem({
@@ -110,9 +112,10 @@ export function buildPasteDeps(
           srcSftpId: src.sftpId ?? undefined,
           dstSftpId: dest.sftpId ?? undefined,
           srcPath: target.srcPath, dstPath: target.dstPath,
-          isDir: target.isDir, useTar: false, transferId: tid,
+          isDir: target.isDir, useTar, transferId: tid,
         }),
         () => { ok = true; },
+        target.isDir && useTar,
       );
       if (!ok) throw new Error(`paste: copy failed for ${target.name}`);
     },

--- a/src/components/filetransfer/tarSupport.ts
+++ b/src/components/filetransfer/tarSupport.ts
@@ -27,3 +27,12 @@ export async function tarUsable(
   }
   return (await Promise.all(checks)).every(Boolean);
 }
+
+export interface TarEndpoint { isLocal: boolean; sftpId?: string | null }
+
+// Tar usability for one src → dst pair. local↔local never tars: `fsCopy` already
+// does the whole copy in one native call.
+export function tarUsableForPair(src: TarEndpoint, dst: TarEndpoint): Promise<boolean> {
+  if (src.isLocal && dst.isLocal) return Promise.resolve(false);
+  return tarUsable([src.sftpId, dst.sftpId], src.isLocal || dst.isLocal);
+}


### PR DESCRIPTION
## Problem

Pasting a directory in the SFTP page never used tar acceleration. `buildPasteDeps` passed `useTar: false` as a literal (`pasteService.ts:113`), so copy/paste and cut/paste fell back to per-file SFTP even when both endpoints had `tar` and the `sftp-tar` toggle was on. It also never passed the `accelerated` flag to `runTransfer`, so the badge could not appear.

Drag-and-drop between the panes did use tar (`SFTPPage.executeFiles`). The same directory therefore transferred fast or slow depending on which gesture the user picked, with nothing in the UI explaining the difference. On a directory of many small files the gap is an order of magnitude over a high-latency link.

Found while investigating a user report of a missing acceleration badge. That report turned out to be a different, expected case — the remote was an FTP connection, which has no SSH exec channel, so tar is structurally unavailable there (`src-tauri/src/sftp/mod.rs:139`). This bug was found alongside it.

## Change

- `tarSupport.ts`: new `tarUsableForPair(src, dst)` holding the rule "local↔local never tars, otherwise the toggle plus `tar` present on every endpoint involved".
- `pasteService.ts`: `copyTarget` resolves `useTar` through that helper and passes `target.isDir && useTar` as the `accelerated` flag.
- `SFTPPage.tsx`: `executeFiles` held the only copy of that rule inline; it now calls the shared helper.

The probe cache in `tarSupport.ts` already dedupes per host, so the added call costs one `command -v tar` per session per host.

## Destination naming

`sftp_download_dir_tar` / `sftp_upload_dir_tar` / `sftp_transfer_dir_tar` extract into the destination path with `--strip-components=1`, so the paste path's collision renaming (`saves - Copy`) is preserved — the extracted directory takes the name in `dstPath`, not the archive's.

## Scope

Multi-item pastes still tar per item rather than batching into one archive like drag-and-drop's `execBatchTar`. Paste renames each item individually on collision, while batch tar drops the original names into the destination directory; unifying them needs the collision path reworked first.

## Behaviour changes users will see

- Progress tracks the archive rather than individual files, so the bar sits still during remote compression and extraction. Already true of drag-and-drop; new for the paste path.
- A `.tar.gz` is staged in the remote `/tmp` and the local temp dir. A full `/tmp` now fails a paste that previously succeeded slowly.
- All-or-nothing: a mid-transfer failure leaves nothing extracted instead of a partial set. Cut/paste still only deletes the source after a successful copy.
- `tar` preserves permissions, symlinks and timestamps that the per-file path did not.

Unchanged for single files, local↔local, FTP endpoints, hosts without `tar`, and with the `sftp-tar` toggle off.

## Tests

Three cases added to `pasteService.test.ts` covering `buildPasteDeps` — directory with a tar-capable pair, a pair that cannot tar, and a single file never flagged accelerated. Red before the change, green after.

`vitest run`: 521 files, 3988 tests passed. `tsc --noEmit`: clean.