### PR TITLE
refactor(ui): open the remaining option menus from PickerSurface

### DIFF
--- a/src/components/keychain/IdentityForm.tsx
+++ b/src/components/keychain/IdentityForm.tsx
@@ -24,6 +24,8 @@ import {
   formInputClass, formInputStyle, formLabelClass, formLabelStyle,
 } from "@/components/shared/Panel";
 import { PanelActionsMenu } from "@/components/shared/PanelActionsMenu";
+import { PickerSurface } from "@/components/shared/PickerSurface";
+import { PickerDivider, PickerOption, PickerTrigger } from "@/components/shared/pickerParts";
 import { PinButton } from "@/components/shared/PinButton";
 import { useIdentityStore } from "@/stores/identityStore";
 import { useTeamStore } from "@/stores/teamStore";
@@ -37,34 +39,11 @@ import { buildKeychainMenuItems } from "@/utils/keychainMenuItems";
 import { selectVaultScopedItems } from "@/utils/vaultScopedItems";
 
 // ─────────────────────────────────────────────────────────────────
-// Dropdown sub-components (used by KeySelector)
-// ─────────────────────────────────────────────────────────────────
 
-function DropdownItem({ icon, label, active, onClick }: { icon: string; label: string; active: boolean; onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-xs transition-colors"
-      style={{ color: active ? "var(--t-accent)" : "var(--t-text-secondary)" }}
-      onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "var(--t-bg-card-hover)"; }}
-      onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "transparent"; }}
-    >
-      <Icon icon={icon} width={13} className="shrink-0" />
-      <span className="flex-1 text-left truncate">{label}</span>
-      {active && <Icon icon="lucide:check" width={13} className="text-(--t-accent)" />}
-    </button>
-  );
-}
-
-function DropdownDivider() {
-  return <div className="my-1 border-t border-t-(--t-bg-card-hover)" />;
-}
-
-// ─────────────────────────────────────────────────────────────────
-// KeySelector dropdown
-// ─────────────────────────────────────────────────────────────────
-
+// Deliberately not shared with connections/KeySelector: that one picks between an
+// inline key and the keychain and ends in a "manage in keychain" action, this one
+// has a third "no key" state and none of the key-type badges. Unifying them would
+// take more props than the two compositions cost lines.
 function KeySelector({
   value, onChange, vaultId,
 }: {
@@ -85,93 +64,52 @@ function KeySelector({
     resolveVaultId: resolveVaultIdForSave,
   }), [effectiveVaultId, personalKeys, teamKeys, teamVaultIds]);
   const [open, setOpen] = useState(false);
-  const [dropdownPos, setDropdownPos] = useState<{ top?: number; bottom?: number; left: number; width: number }>({ left: 0, width: 0 });
-  const wrapperRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const isInline = value === "__inline__";
   const selected = isInline ? null : (keys.find((k) => k.id === value) ?? null);
 
-  const handleToggle = () => {
-    if (!open && buttonRef.current) {
-      const r = buttonRef.current.getBoundingClientRect();
-      const estimatedHeight = 12 + 2 * 33 + (keys.length > 0 ? 9 + keys.length * 33 : 0);
-      const spaceBelow = window.innerHeight - r.bottom;
-      if (spaceBelow < estimatedHeight) {
-        setDropdownPos({ bottom: window.innerHeight - r.top + 4, left: r.left, width: r.width });
-      } else {
-        setDropdownPos({ top: r.bottom + 4, left: r.left, width: r.width });
-      }
-    }
-    setOpen((o) => !o);
-  };
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open]);
-
   return (
-    <div ref={wrapperRef}>
-      <button
-        ref={buttonRef}
-        type="button"
-        onClick={handleToggle}
-        className="w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors"
-        style={{ ...formInputStyle, color: (selected || isInline) ? "var(--t-text-primary)" : "var(--t-text-dim)" }}
-      >
-        <Icon icon={isInline ? "lucide:file-key" : selected ? "lucide:key-round" : "lucide:minus"} width={13} className="shrink-0" />
-        <span className="flex-1 text-left truncate text-xs">
-          {isInline ? t("keychain.identityForm.newKeyInline") : selected ? (selected.name ?? t("keychain.identityForm.unnamedKey")) : t("keychain.identityForm.noKey")}
-        </span>
-        <Icon
-          icon="lucide:chevron-down"
-          width={13}
-          className="text-(--t-text-dim) shrink-0"
-          style={{
-            transition: "transform 150ms",
-            transform: open ? "rotate(180deg)" : "rotate(0deg)",
-          }}
-        />
-      </button>
+    <div>
+      <PickerTrigger
+        buttonRef={buttonRef}
+        icon={isInline ? "lucide:file-key" : selected ? "lucide:key-round" : "lucide:minus"}
+        label={isInline
+          ? t("keychain.identityForm.newKeyInline")
+          : selected ? (selected.name ?? t("keychain.identityForm.unnamedKey")) : t("keychain.identityForm.noKey")}
+        filled={!!selected || isInline}
+        open={open}
+        onToggle={() => setOpen((o) => !o)}
+      />
 
-      {open && (
-        <div
-          className="surface-float p-1.5 fixed z-9999"
-          style={{
-            top: dropdownPos.top,
-            bottom: dropdownPos.bottom,
-            left: dropdownPos.left,
-            width: dropdownPos.width,
-          }}
-        >
-          <DropdownItem
-            icon="lucide:minus"
-            label={t("keychain.identityForm.noKey")}
-            active={value === null}
-            onClick={() => { onChange(null); setOpen(false); }}
+      <PickerSurface
+        open={open}
+        onClose={() => setOpen(false)}
+        anchorRef={buttonRef}
+        title={t("connections.common.sshKey")}
+      >
+        <PickerOption
+          icon="lucide:minus"
+          label={t("keychain.identityForm.noKey")}
+          active={value === null}
+          onClick={() => { onChange(null); setOpen(false); }}
+        />
+        <PickerOption
+          icon="lucide:file-key"
+          label={t("keychain.identityForm.newKeyInline")}
+          active={value === "__inline__"}
+          onClick={() => { onChange("__inline__"); setOpen(false); }}
+        />
+        {keys.length > 0 && <PickerDivider />}
+        {keys.map((k) => (
+          <PickerOption
+            key={k.id}
+            icon="lucide:key-round"
+            label={k.name ?? k.id}
+            active={value === k.id}
+            onClick={() => { onChange(k.id); setOpen(false); }}
           />
-          <DropdownItem
-            icon="lucide:file-key"
-            label={t("keychain.identityForm.newKeyInline")}
-            active={value === "__inline__"}
-            onClick={() => { onChange("__inline__"); setOpen(false); }}
-          />
-          {keys.length > 0 && <DropdownDivider />}
-          {keys.map((k) => (
-            <DropdownItem
-              key={k.id}
-              icon="lucide:key-round"
-              label={k.name ?? k.id}
-              active={value === k.id}
-              onClick={() => { onChange(k.id); setOpen(false); }}
-            />
-          ))}
-        </div>
-      )}
+        ))}
+      </PickerSurface>
     </div>
   );
 }

--- a/src/components/keychain/KeychainToolbar.tsx
+++ b/src/components/keychain/KeychainToolbar.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Icon } from "@iconify/react";
 import { ToolbarViewControls, type LayoutMode, type SortMode } from "@/components/shared/ToolbarViewControls";
 import { useToolbarResize } from "@/hooks/useToolbarResize";
 import { DropdownMenuItem } from "@/components/shared/DropdownMenuItem";
 import { useRipple } from "@/hooks/useRipple";
+import { PickerSurface } from "@/components/shared/PickerSurface";
 
 interface KeychainToolbarProps {
   search: string;
@@ -91,31 +92,14 @@ export function KeychainToolbar({
 function NewKeyChevron({ onGenerate, onNewIdentity, onNewFolder, accent }: { onImport?: () => void; onGenerate?: () => void; onNewIdentity?: () => void; onNewFolder: () => void; accent?: boolean }) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
-  const [pos, setPos] = useState<{ top: number; right: number }>({ top: 0, right: 0 });
-  const wrapperRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const { createRipple, rippleEls } = useRipple();
 
-  const handleClick = () => {
-    if (!open && wrapperRef.current) {
-      const r = wrapperRef.current.getBoundingClientRect();
-      setPos({ top: r.bottom + 4, right: window.innerWidth - r.right });
-    }
-    setOpen((o) => !o);
-  };
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open]);
-
   return (
-    <div ref={wrapperRef}>
+    <div>
       <button
-        onClick={handleClick}
+        ref={buttonRef}
+        onClick={() => setOpen((o) => !o)}
         onPointerDown={createRipple}
         className="flex items-center justify-center w-8 h-8 transition-colors relative overflow-hidden rounded-tr-[0.533rem] rounded-br-[0.533rem]"
         style={{ background: accent ? "var(--t-accent)" : "var(--t-bg-input)" }}
@@ -130,20 +114,18 @@ function NewKeyChevron({ onGenerate, onNewIdentity, onNewFolder, accent }: { onI
         </span>
       </button>
 
-      {open && (
-        <div
-          className="surface-float p-1.5 fixed z-9999"
-          style={{
-            top: pos.top,
-            right: pos.right,
-            width: "max-content",
-          }}
-        >
-          {onGenerate && <DropdownMenuItem icon="lucide:key-round" label={t("keychain.toolbar.generateKeyPair")} onClick={() => { setOpen(false); onGenerate(); }} />}
-          {onNewIdentity && <DropdownMenuItem icon="lucide:user-plus" label={t("keychain.toolbar.newIdentity")} onClick={() => { setOpen(false); onNewIdentity(); }} />}
-          <DropdownMenuItem icon="lucide:folder-plus" label={t("keychain.toolbar.newFolder")} onClick={() => { setOpen(false); onNewFolder(); }} />
-        </div>
-      )}
+      <PickerSurface
+        open={open}
+        onClose={() => setOpen(false)}
+        anchorRef={buttonRef}
+        title={t("keychain.toolbar.newKeyOptionsAriaLabel")}
+        width="content"
+        align="right"
+      >
+        {onGenerate && <DropdownMenuItem icon="lucide:key-round" label={t("keychain.toolbar.generateKeyPair")} onClick={() => { setOpen(false); onGenerate(); }} />}
+        {onNewIdentity && <DropdownMenuItem icon="lucide:user-plus" label={t("keychain.toolbar.newIdentity")} onClick={() => { setOpen(false); onNewIdentity(); }} />}
+        <DropdownMenuItem icon="lucide:folder-plus" label={t("keychain.toolbar.newFolder")} onClick={() => { setOpen(false); onNewFolder(); }} />
+      </PickerSurface>
     </div>
   );
 }

--- a/src/components/shared/PickerSurface.tsx
+++ b/src/components/shared/PickerSurface.tsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom";
 import BottomSheet from "@/components/mobile/sheets/BottomSheet";
 import { useIsAndroid } from "@/utils/platform";
 
-interface Pos { top?: number; bottom?: number; left: number; width: number; maxHeight: number }
+interface Pos { top?: number; bottom?: number; left?: number; right?: number; width?: number; maxHeight: number }
 
 /** A ref to any element used only for reading (positioning). `readonly current` makes it
  *  covariant, so a `RefObject<HTMLButtonElement | null>` etc. assigns without a cast. */
@@ -13,14 +13,21 @@ type AnchorRef = { readonly current: HTMLElement | null };
  *  `anchorRef` (with below/above flip). Mobile: a BottomSheet. Open state + the trigger
  *  stay owned by the caller; this owns only the open surface + its dismiss. */
 export function PickerSurface({
-  open, onClose, anchorRef, title, children, width, align = "left", gap = 4,
+  open, onClose, anchorRef, title, children, width, minWidth, maxHeight = 320, align = "left", gap = 4,
 }: {
   open: boolean;
   onClose: () => void;
   anchorRef: AnchorRef;
   title?: string;
   children: ReactNode;
-  width?: number;
+  /** A pixel width, or `"content"` to let the surface size to its rows. Defaults to
+   *  the anchor's width, which is what a field-shaped trigger wants. */
+  width?: number | "content";
+  /** Floor for a `"content"`-width surface, so a narrow trigger still opens a
+   *  readable menu. */
+  minWidth?: number;
+  /** Cap on the surface's own height, before the space around the anchor is applied. */
+  maxHeight?: number;
   /** Which anchor edge the surface lines up with. Right-align keeps a surface wider
    *  than its anchor on screen when the anchor sits near the right edge. */
   align?: "left" | "right";
@@ -30,7 +37,7 @@ export function PickerSurface({
 }) {
   const isAndroid = useIsAndroid();
   const surfaceRef = useRef<HTMLDivElement>(null);
-  const [pos, setPos] = useState<Pos>({ left: 0, width: 0, maxHeight: 320 });
+  const [pos, setPos] = useState<Pos>({ left: 0, width: 0, maxHeight });
 
   // Desktop: measure the anchor on open, and keep the float pinned to it while open as the
   // form panel scrolls or the window resizes (the fixed-position float doesn't move on its own).
@@ -40,14 +47,18 @@ export function PickerSurface({
       const el = anchorRef.current;
       if (!el) return;
       const r = el.getBoundingClientRect();
-      const w = width ?? r.width;
-      const left = align === "right" ? Math.max(8, r.right - w) : r.left;
+      // A content-width surface has no width to subtract from the anchor's right
+      // edge, so it is pinned by `right` instead of a computed `left`.
+      const w = width === "content" ? undefined : (width ?? r.width);
+      const edge = w === undefined
+        ? (align === "right" ? { right: Math.max(8, window.innerWidth - r.right) } : { left: r.left })
+        : { left: align === "right" ? Math.max(8, r.right - w) : r.left };
       const spaceBelow = window.innerHeight - r.bottom - 8;
       const spaceAbove = r.top - 8;
       const goUp = spaceBelow < 150 && spaceAbove > spaceBelow;
       setPos(goUp
-        ? { bottom: window.innerHeight - r.top + gap, left, width: w, maxHeight: Math.min(spaceAbove, 320) }
-        : { top: r.bottom + gap, left, width: w, maxHeight: Math.min(spaceBelow, 320) });
+        ? { bottom: window.innerHeight - r.top + gap, ...edge, width: w, maxHeight: Math.min(spaceAbove, maxHeight) }
+        : { top: r.bottom + gap, ...edge, width: w, maxHeight: Math.min(spaceBelow, maxHeight) });
     };
     measure();
     window.addEventListener("scroll", measure, true); // capture: catch scrolls in any ancestor
@@ -56,7 +67,7 @@ export function PickerSurface({
       window.removeEventListener("scroll", measure, true);
       window.removeEventListener("resize", measure);
     };
-  }, [open, isAndroid, anchorRef, width, align, gap]);
+  }, [open, isAndroid, anchorRef, width, maxHeight, align, gap]);
 
   // Desktop: outside-mousedown dismiss (ignores the anchor so the trigger toggles cleanly).
   useEffect(() => {
@@ -79,7 +90,10 @@ export function PickerSurface({
     <div
       ref={surfaceRef}
       className="surface-float fixed p-1.5 z-9999 flex flex-col overflow-y-auto"
-      style={{ top: pos.top, bottom: pos.bottom, left: pos.left, width: pos.width, maxHeight: pos.maxHeight }}
+      style={{
+        top: pos.top, bottom: pos.bottom, left: pos.left, right: pos.right,
+        width: pos.width, minWidth, maxHeight: pos.maxHeight,
+      }}
     >
       {children}
     </div>,

--- a/src/components/shared/PickerSurface.tsx
+++ b/src/components/shared/PickerSurface.tsx
@@ -24,8 +24,9 @@ export function PickerSurface({
    *  the anchor's width, which is what a field-shaped trigger wants. */
   width?: number | "content";
   /** Floor for a `"content"`-width surface, so a narrow trigger still opens a
-   *  readable menu. */
-  minWidth?: number;
+   *  readable menu. A CSS length: prefer `rem`, which tracks the UI scale the way
+   *  a Tailwind `min-w-*` on the surface used to. */
+  minWidth?: number | string;
   /** Cap on the surface's own height, before the space around the anchor is applied. */
   maxHeight?: number;
   /** Which anchor edge the surface lines up with. Right-align keeps a surface wider

--- a/src/components/shared/PortInput.tsx
+++ b/src/components/shared/PortInput.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { DropdownMenuItem } from "./DropdownMenuItem";
 import { formInputClass, formInputStyle } from "./Panel";
+import { PickerSurface } from "./PickerSurface";
 
 interface Props {
   value: string;
@@ -16,31 +16,14 @@ interface Props {
 export function PortInput({ value, ports, onChange, placeholder, className = "", autoFocus }: Props) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
-  const [menuRect, setMenuRect] = useState({ top: 0, left: 0, width: 0 });
   const inputRef = useRef<HTMLInputElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
 
   const filtered = ports.filter(
     (p) => !value || p.name.toLowerCase().includes(value.toLowerCase()) || p.path.toLowerCase().includes(value.toLowerCase()),
   );
 
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (!inputRef.current?.contains(target) && !menuRef.current?.contains(target)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open]);
-
   const showDropdown = () => {
-    if (!inputRef.current || ports.length === 0) return;
-    const r = inputRef.current.getBoundingClientRect();
-    setMenuRect({ top: r.bottom + 4, left: r.left, width: r.width });
-    setOpen(true);
+    if (ports.length > 0) setOpen(true);
   };
 
   useEffect(() => {
@@ -62,24 +45,23 @@ export function PortInput({ value, ports, onChange, placeholder, className = "",
         className={`w-full ${formInputClass}`}
         style={{ ...formInputStyle }}
       />
-      {open && filtered.length > 0 && createPortal(
-        <div
-          ref={menuRef}
-          className="surface-float fixed p-1.5 z-9999 flex flex-col max-h-[240px] overflow-y-auto"
-          style={{ top: menuRect.top, left: menuRect.left, width: menuRect.width }}
-        >
-          {filtered.map((p) => (
-            <DropdownMenuItem
-              key={p.path}
-              label={p.name}
-              checked={value === p.path}
-              iconSize={15}
-              onClick={() => { onChange(p.path); setOpen(false); }}
-            />
-          ))}
-        </div>,
-        document.body,
-      )}
+      <PickerSurface
+        open={open && filtered.length > 0}
+        onClose={() => setOpen(false)}
+        anchorRef={inputRef}
+        title={t("shared.portInput.placeholder")}
+        maxHeight={240}
+      >
+        {filtered.map((p) => (
+          <DropdownMenuItem
+            key={p.path}
+            label={p.name}
+            checked={value === p.path}
+            iconSize={15}
+            onClick={() => { onChange(p.path); setOpen(false); }}
+          />
+        ))}
+      </PickerSurface>
     </div>
   );
 }

--- a/src/components/shared/VaultPicker.tsx
+++ b/src/components/shared/VaultPicker.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import { Icon } from "@iconify/react";
 import { useTranslation } from "react-i18next";
 import { useVaultStore } from "@/stores/vaultStore";
 import { useTeamStore } from "@/stores/teamStore";
 import { getMyUserId } from "@/services/teamService";
 import { effectivePermissions, PERM_BITS } from "@/hooks/usePermission";
+import { PickerSurface } from "./PickerSurface";
 
 export function VaultPicker({
   vaultId,
@@ -19,9 +19,7 @@ export function VaultPicker({
   const { teams, membersByTeam, loadMembers, loadTeams, rolesByTeam, loadRoles } = useTeamStore();
   const [myUserId, setMyUserId] = useState("");
   const [open, setOpen] = useState(false);
-  const [pos, setPos] = useState({ top: 0, left: 0 });
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     getMyUserId().then((id) => { if (id) setMyUserId(id); }).catch(() => {});
@@ -68,14 +66,6 @@ export function VaultPicker({
   const currentVault = allVaults.find((v) => v.id === currentId);
   const label = currentVault?.name ?? t("common.entity.personal");
 
-  const handleOpen = () => {
-    if (triggerRef.current) {
-      const rect = triggerRef.current.getBoundingClientRect();
-      setPos({ top: rect.bottom + 4, left: rect.left });
-    }
-    setOpen((o) => !o);
-  };
-
   const select = (id: string) => {
     if (!canWrite(id)) return;
     onChange(id);
@@ -88,7 +78,7 @@ export function VaultPicker({
       <button
         ref={triggerRef}
         type="button"
-        onClick={handleOpen}
+        onClick={() => setOpen((o) => !o)}
         className="flex items-center gap-1 text-xs select-none transition-opacity hover:opacity-80"
         style={{ color: "var(--t-text-dim)" }}
       >
@@ -96,18 +86,15 @@ export function VaultPicker({
         <Icon icon="lucide:chevron-down" width={11} style={{ color: "var(--t-text-dim)" }} />
       </button>
 
-      {open && createPortal(
-        <>
-          <div className="fixed inset-0 z-9998" onClick={() => setOpen(false)} />
-          <div
-            ref={dropdownRef}
-            className="surface-float fixed z-9999 p-1.5 min-w-52"
-            style={{
-              top: pos.top,
-              left: pos.left,
-            }}
-          >
-            {allVaults.map((v) => {
+      <PickerSurface
+        open={open}
+        onClose={() => setOpen(false)}
+        anchorRef={triggerRef}
+        title={t("common.entity.vault")}
+        width="content"
+        minWidth={208}
+      >
+        {allVaults.map((v) => {
               const selected = v.id === currentId;
               const writable = canWrite(v.id);
               const role = v.team ? myPrimaryRoleIn(v.id) : "";
@@ -145,11 +132,8 @@ export function VaultPicker({
                   )}
                 </button>
               );
-            })}
-          </div>
-        </>,
-        document.body
-      )}
+        })}
+      </PickerSurface>
     </>
   );
 }

--- a/src/components/shared/VaultPicker.tsx
+++ b/src/components/shared/VaultPicker.tsx
@@ -92,7 +92,7 @@ export function VaultPicker({
         anchorRef={triggerRef}
         title={t("common.entity.vault")}
         width="content"
-        minWidth={208}
+        minWidth="13rem"
       >
         {allVaults.map((v) => {
               const selected = v.id === currentId;


### PR DESCRIPTION
Follow-up to #203. Four more dropdowns positioned themselves: each measured its
anchor with its own `getBoundingClientRect` block and painted a
`surface-float fixed z-9999` div. Each therefore also missed what `PickerSurface`
already does — re-measuring while the form panel scrolls, flipping above the
trigger when there is no room below, and becoming a bottom sheet on Android.

**`keychain/IdentityForm`'s `KeySelector`** was the furthest gone. Its local
`DropdownItem` was a copy of `PickerOption` down to the class list and the accent
check, `DropdownDivider` a copy of `PickerDivider`, and its trigger a copy of
`PickerTrigger` including the 150ms chevron rotation. It also carried a
hand-rolled flip that guessed the menu height from a row count. All of that is
deleted in favour of the shared parts.

**`KeychainToolbar`**, **`VaultPicker`** and **`PortInput`** already used the
canonical rows, so they only lose their positioning code.

`PickerSurface` grows what those callers needed:

- `width: "content"` — a menu that sizes to its rows rather than to a narrow
  trigger. Pinned by `right` when right-aligned, since there is no width to
  subtract from the anchor's edge.
- `minWidth` — the floor for that mode, so `VaultPicker` keeps its `min-w-52` off
  a text-sized trigger.
- `maxHeight` — `PortInput`'s list keeps its shorter 240px cap.

## Left alone deliberately

`SyncDropdown` and `ShareMenu` are anchored *panels* — header row, close button,
fixed `w-64`/`280px`, `animate-fadeIn` with `transformOrigin` math — not option
lists; routing them through `PickerSurface` would be a redesign.
`SidebarAccountButton` compensates for the UI scale with its own
`transform: scale(uiScale)`, which `PickerSurface` has no handling for.

`connections/KeySelector` is intentionally still separate from the keychain one:
that one picks between an inline key and the keychain and ends in a "manage in
keychain" action, this one has a third "no key" state and no key-type badges.
Unifying them would take more props than the two compositions cost lines, and
there is now a comment saying so.

## Verification

`tsc --noEmit` clean; 132 tests across `shared`, `connections` and `keychain`
pass (266 including `settings`).

Driven in the headless build and read back from screenshots:

- `KeychainToolbar` — right-aligned, content-width, rows unchanged;
- `IdentityForm`'s key selector — sits at the bottom of the form panel and now
  **flips above** the trigger, with the accent check on "No key";
- `VaultPicker` — content width at its 208px floor, left-aligned to the small
  text trigger;
- `PortInput` — against two emulated ptys, the list opens under the input,
  picking one fills `/dev/ttyUSB99` and dismisses the surface.
