### PR TITLE
refactor(ui): draw the last two overflow menus from the shared menu parts

### DIFF
--- a/src/components/mobile/MobileTerminalTopBar.tsx
+++ b/src/components/mobile/MobileTerminalTopBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Icon } from "@iconify/react";
 import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/sessionStore";
@@ -7,6 +7,8 @@ import { useConnectionStore } from "@/stores/connectionStore";
 import type { TerminalSession } from "@/types";
 import { terminalPanelItems } from "./terminalPanelItems";
 import { NotificationBell } from "@/components/notifications/NotificationBell";
+import { PickerSurface } from "@/components/shared/PickerSurface";
+import { DropdownMenuItem } from "@/components/shared/DropdownMenuItem";
 
 const DOT: Record<TerminalSession["status"], string> = {
   connected: "#3fb950",
@@ -30,9 +32,17 @@ export default function MobileTerminalTopBar() {
   const openSheet = useMobileNavStore((s) => s.openSheet);
   const exitTo = useMobileNavStore((s) => s.lastNonTerminalTab);
   const [menuOpen, setMenuOpen] = useState(false);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
   // Derive Proxmox gate as a primitive (boolean) — Zustand-safe; no fresh array/object from the selector.
   const activeConnId = allSessions.find((s) => s.id === activeSessionId)?.connectionId;
   const isProxmox = useConnectionStore((s) => s.connections.find((c) => c.id === activeConnId)?.distro === "proxmox");
+
+  const panelItems = terminalPanelItems({
+    activeSessionId,
+    connectionIdOfActive: activeConnId,
+    nav: { push, openSheet },
+    isProxmox,
+  }, t);
 
   return (
     <div
@@ -79,8 +89,9 @@ export default function MobileTerminalTopBar() {
         <Icon icon="lucide:plus" width={20} />
       </button>
       <NotificationBell />
-      <div className="relative shrink-0">
+      <div className="shrink-0">
         <button
+          ref={menuButtonRef}
           data-mobile-terminal-menu
           onClick={() => setMenuOpen((v) => !v)}
           className="px-2 h-full text-(--t-text-primary)"
@@ -88,30 +99,25 @@ export default function MobileTerminalTopBar() {
         >
           <Icon icon="lucide:ellipsis-vertical" width={20} />
         </button>
-        {menuOpen && (
-          <div
-            className="absolute right-1 top-10 z-50 rounded-xl border py-1 min-w-40"
-            style={{ background: "var(--t-bg-modal)", borderColor: "var(--t-border-hover)", boxShadow: "var(--t-elev-2)" }}
-            onClick={() => setMenuOpen(false)}
-          >
-            {terminalPanelItems({
-              activeSessionId,
-              connectionIdOfActive: allSessions.find((s) => s.id === activeSessionId)?.connectionId,
-              nav: { push, openSheet },
-              isProxmox,
-            }, t).map((it) => (
-              <button
-                key={it.key}
-                data-mobile-panel={it.key}
-                onClick={() => { it.onTap(); setMenuOpen(false); }}
-                className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left text-sm text-(--t-text-primary)"
-              >
-                <Icon icon={it.icon} width={16} />
-                {it.label}
-              </button>
-            ))}
-          </div>
-        )}
+        <PickerSurface
+          open={menuOpen}
+          onClose={() => setMenuOpen(false)}
+          anchorRef={menuButtonRef}
+          title={t("mobile.terminalTopBar.panelsAriaLabel")}
+          width="content"
+          minWidth="10rem"
+          align="right"
+        >
+          {panelItems.map((it) => (
+            <DropdownMenuItem
+              key={it.key}
+              icon={it.icon}
+              iconSize={16}
+              label={it.label}
+              onClick={() => { it.onTap(); setMenuOpen(false); }}
+            />
+          ))}
+        </PickerSurface>
       </div>
     </div>
   );

--- a/src/components/shared/ContextMenu.tsx
+++ b/src/components/shared/ContextMenu.tsx
@@ -103,7 +103,11 @@ export function MenuItemList({
       {activeSub !== null && items[activeSub.idx]?.children &&
         createPortal(
           <div
-            className="surface-float fixed z-101 p-1.5 flex flex-col min-w-[12.667rem] overflow-y-auto"
+            // Marked so a surface that dismisses on outside-mousedown (PickerSurface)
+            // can tell a submenu of its own menu from a click elsewhere, and stacked
+            // above that surface because a flipped submenu overlaps its parent.
+            data-menu-portal=""
+            className="surface-float fixed z-10000 p-1.5 flex flex-col min-w-[12.667rem] overflow-y-auto"
             style={{ left: activeSub.x, top: activeSub.y, maxHeight: window.innerHeight - activeSub.y - 8 }}
             onMouseEnter={clearTimer}
             onMouseLeave={scheduleClose}

--- a/src/components/shared/PickerSurface.tsx
+++ b/src/components/shared/PickerSurface.tsx
@@ -75,6 +75,9 @@ export function PickerSurface({
     if (!open || isAndroid) return;
     const handler = (e: MouseEvent) => {
       const t = e.target as Node;
+      // A submenu portals to the body, so it is not a DOM descendant of the surface
+      // that opened it. Dismissing on it would unmount the row before its click fires.
+      if ((t as Element).closest?.("[data-menu-portal]")) return;
       if (!anchorRef.current?.contains(t) && !surfaceRef.current?.contains(t)) onClose();
     };
     document.addEventListener("mousedown", handler);

--- a/src/components/terminal/SnippetsPanel.tsx
+++ b/src/components/terminal/SnippetsPanel.tsx
@@ -17,6 +17,8 @@ import {
   type DynamicContext,
 } from "@/services/snippetParser";
 import { buildDynamicContext } from "@/services/snippetRunCore";
+import { PickerSurface } from "@/components/shared/PickerSurface";
+import { MenuItemList, type ContextMenuItem } from "@/components/shared/ContextMenu";
 import { runSnippetSequence, reportSequenceResult } from "@/services/snippetSequence";
 import { snippetScriptText, snippetSearchText } from "@/services/snippetSteps";
 import { SnippetVariableModal } from "@/components/terminal/SnippetVariableModal";
@@ -122,20 +124,25 @@ function SnippetRow({
 }: SnippetRowProps) {
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
-  const [movingToFolder, setMovingToFolder] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
 
-  useEffect(() => {
-    if (!menuOpen) return;
-    function handleClick(e: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuOpen(false);
-        setMovingToFolder(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [menuOpen]);
+  const menuItems: ContextMenuItem[] = [
+    { label: t("common.action.edit"), icon: "lucide:pencil", onClick: onEdit },
+    { label: t("terminal.snippets.duplicate"), icon: "lucide:copy", onClick: onDuplicate },
+    {
+      label: t("terminal.snippets.moveToFolder"),
+      icon: "lucide:folder",
+      children: [
+        { label: t("terminal.snippets.unfiled"), icon: "lucide:inbox", onClick: () => onMoveToFolder(null) },
+        ...folders.map((f) => ({
+          label: f.name,
+          icon: "lucide:folder",
+          onClick: () => onMoveToFolder(f.id),
+        })),
+      ],
+    },
+    { label: t("common.action.delete"), icon: "lucide:trash-2", danger: true, divider: true, onClick: onDelete },
+  ];
 
   return (
     <div
@@ -194,80 +201,27 @@ function SnippetRow({
             <Icon icon="lucide:play" width={13} />
           </button>
 
-          <div className="relative" ref={menuRef}>
-            <button onClick={() => { setMenuOpen((o) => !o); setMovingToFolder(false); }}
+          <div>
+            <button
+              ref={menuButtonRef}
+              onClick={() => setMenuOpen((o) => !o)}
               className="w-6 h-6 flex items-center justify-center rounded-sm transition-colors"
               style={{ color: "var(--t-text-muted)" }}
               onMouseEnter={(e) => (e.currentTarget.style.color = "var(--t-text-primary)")}
               onMouseLeave={(e) => (e.currentTarget.style.color = "var(--t-text-muted)")}>
               <Icon icon="lucide:ellipsis" width={13} />
             </button>
-            {menuOpen && !movingToFolder && (
-              <div className="absolute right-0 top-7 z-50 rounded-lg shadow-lg border py-1 min-w-[150px]"
-                style={{ background: "var(--t-bg-modal)", borderColor: "var(--t-border)" }}>
-                <button onClick={() => { onEdit(); setMenuOpen(false); }}
-                  className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-left"
-                  style={{ color: "var(--t-text-primary)" }}
-                  onMouseEnter={(e) => (e.currentTarget.style.background = "var(--t-bg-elevated)")}
-                  onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}>
-                  <Icon icon="lucide:pencil" width={12} /> {t("common.action.edit")}
-                </button>
-                <button onClick={() => { onDuplicate(); setMenuOpen(false); }}
-                  className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-left"
-                  style={{ color: "var(--t-text-primary)" }}
-                  onMouseEnter={(e) => (e.currentTarget.style.background = "var(--t-bg-elevated)")}
-                  onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}>
-                  <Icon icon="lucide:copy" width={12} /> {t("terminal.snippets.duplicate")}
-                </button>
-                <button onClick={() => setMovingToFolder(true)}
-                  className="w-full flex items-center justify-between gap-2 px-3 py-1.5 text-xs text-left"
-                  style={{ color: "var(--t-text-primary)" }}
-                  onMouseEnter={(e) => (e.currentTarget.style.background = "var(--t-bg-elevated)")}
-                  onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}>
-                  <span className="flex items-center gap-2"><Icon icon="lucide:folder" width={12} /> {t("terminal.snippets.moveToFolder")}</span>
-                  <Icon icon="lucide:chevron-right" width={10} />
-                </button>
-                <div className="my-1 border-t" style={{ borderColor: "var(--t-border)" }} />
-                <button onClick={() => { onDelete(); setMenuOpen(false); }}
-                  className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-left"
-                  style={{ color: "var(--t-status-error)" }}
-                  onMouseEnter={(e) => (e.currentTarget.style.background = "var(--t-bg-elevated)")}
-                  onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}>
-                  <Icon icon="lucide:trash-2" width={12} /> {t("common.action.delete")}
-                </button>
-              </div>
-            )}
-            {menuOpen && movingToFolder && (
-              <div className="absolute right-0 top-7 z-50 rounded-lg shadow-lg border py-1 min-w-[150px]"
-                style={{ background: "var(--t-bg-modal)", borderColor: "var(--t-border)" }}>
-                <button onClick={() => setMovingToFolder(false)}
-                  className="w-full flex items-center gap-2 px-3 py-1.5 text-xs"
-                  style={{ color: "var(--t-text-muted)" }}
-                  onMouseEnter={(e) => (e.currentTarget.style.background = "var(--t-bg-elevated)")}
-                  onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}>
-                  <Icon icon="lucide:arrow-left" width={11} /> {t("terminal.snippets.back")}
-                </button>
-                <div className="my-1 border-t" style={{ borderColor: "var(--t-border)" }} />
-                <button onClick={() => { onMoveToFolder(null); setMenuOpen(false); setMovingToFolder(false); }}
-                  className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-left"
-                  style={{ color: "var(--t-text-primary)" }}
-                  onMouseEnter={(e) => (e.currentTarget.style.background = "var(--t-bg-elevated)")}
-                  onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}>
-                  <Icon icon="lucide:inbox" width={12} /> {t("terminal.snippets.unfiled")}
-                </button>
-                {folders.map((f) => (
-                  <button key={f.id}
-                    onClick={() => { onMoveToFolder(f.id); setMenuOpen(false); setMovingToFolder(false); }}
-                    className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-left"
-                    style={{ color: "var(--t-text-primary)" }}
-                    onMouseEnter={(e) => (e.currentTarget.style.background = "var(--t-bg-elevated)")}
-                    onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}>
-                    <Icon icon="lucide:folder" width={12} style={{ color: f.color ?? "var(--t-text-muted)" }} />
-                    {f.name}
-                  </button>
-                ))}
-              </div>
-            )}
+            <PickerSurface
+              open={menuOpen}
+              onClose={() => setMenuOpen(false)}
+              anchorRef={menuButtonRef}
+              title={snippet.name}
+              width="content"
+              minWidth="12.667rem"
+              align="right"
+            >
+              <MenuItemList items={menuItems} onClose={() => setMenuOpen(false)} />
+            </PickerSurface>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Follow-up to #203 and #205, and the end of the sweep. These two were the menus
that did not merely position themselves by hand — they painted their own rows
too, on the wrong tokens: a `--t-bg-modal` surface with a `--t-border` divider
and `--t-bg-elevated` hover, where every other menu uses `surface-float` with
`--t-bg-card-hover`, and `py-1.5` rows with 12px icons against the shared 16px.

**`terminal/SnippetsPanel`** renders `MenuItemList` inside a `PickerSurface`. That
turns the two-step "move to folder / back" flow into a real submenu and deletes
the `movingToFolder` state along with the entire second menu — the file loses 118
lines and gains 43.

**`mobile/MobileTerminalTopBar`** renders `DropdownMenuItem` rows, and picks up an
outside-tap dismiss it never had: until now only tapping an item closed it.

## The one non-obvious bit

Hosting `MenuItemList` inside `PickerSurface` needed the submenu to be legible to
the surface that opened it. A submenu portals to the body, so it is not a DOM
descendant of that surface, and dismiss-on-outside-mousedown would unmount the row
before its click fired — the exact bug `ContextMenu`'s backdrop comment already
warns about. So the portal is marked `data-menu-portal`, `PickerSurface` skips
mousedowns inside one, and the portal moves to `z-10000` because a submenu that
flips left overlaps its parent. In the narrow right-hand panel that flip is the
normal case, not the edge case.

`ContextMenu` and `PanelActionsMenu` keep their own backdrop-based surfaces for
that same reason — swapping them for `PickerSurface` would reintroduce the bug.

## Verification

`tsc --noEmit` clean; 205 tests across `terminal`, `shared`, `mobile` and
`connections` pass.

Driven in the headless build against a real snippet and a real folder:

- the row menu opens as a `surface-float` card with 16px icons, a divider and a
  red Delete;
- hovering "Move to folder" opens the submenu, which **flips left over the parent**
  and draws above it;
- clicking `Ops` in that submenu moves the snippet and closes both menus — the
  dismissal hazard above, confirmed handled rather than assumed;
- Duplicate and Delete apply; an outside mousedown dismisses.

`MobileTerminalTopBar` is **not** live-verified: the mobile shell only mounts when
the backend reports `android`, so it is unreachable from the desktop build. It is
typechecked and covered by the suite; a run on the emulator would need
`iterating-on-voltius-android-emulator`.
