### PR TITLE
fix(mobile): keep the panels menu's CDP hook on the shared row

### DIFF
--- a/src/components/mobile/MobileTerminalTopBar.tsx
+++ b/src/components/mobile/MobileTerminalTopBar.tsx
@@ -111,6 +111,7 @@ export default function MobileTerminalTopBar() {
           {panelItems.map((it) => (
             <DropdownMenuItem
               key={it.key}
+              dataAttrs={{ "data-mobile-panel": it.key }}
               icon={it.icon}
               iconSize={16}
               label={it.label}

--- a/src/components/shared/DropdownMenuItem.tsx
+++ b/src/components/shared/DropdownMenuItem.tsx
@@ -16,9 +16,15 @@ interface Props {
    * button, never a child — a button inside a button is invalid DOM.
    */
   trailing?: ReactNode;
+  /**
+   * `data-*` hooks for the row. The mobile screens are driven over CDP by
+   * attribute selector, so a row that replaces a hand-written button has to
+   * carry the same hook the button did.
+   */
+  dataAttrs?: Record<string, string>;
 }
 
-export function DropdownMenuItem({ icon, label, onClick, checked, iconSize = 20, sublabel, title, trailing }: Props) {
+export function DropdownMenuItem({ icon, label, onClick, checked, iconSize = 20, sublabel, title, trailing, dataAttrs }: Props) {
   const { createRipple, rippleEls } = useRipple();
   const item = (
     <button
@@ -26,6 +32,7 @@ export function DropdownMenuItem({ icon, label, onClick, checked, iconSize = 20,
       onClick={onClick}
       onPointerDown={createRipple}
       title={title}
+      {...dataAttrs}
       className="w-full flex items-center gap-2.5 p-3 rounded-lg text-md font-medium-bold transition-colors whitespace-nowrap text-(--t-text-secondary) bg-transparent relative overflow-hidden"
       onMouseEnter={(e) => {
         (e.currentTarget as HTMLButtonElement).style.background = "var(--t-bg-card-hover)";


### PR DESCRIPTION
#206 replaced the terminal bar's hand-written menu buttons with `DropdownMenuItem`
and dropped `data-mobile-panel={key}` along with them.

Nothing in the repo reads that attribute — but nothing reads
`data-mobile-terminal-menu`, `data-mobile-session-chip` or `data-mobile-panel-quick`
either. The whole family arrived together in `1817d08a` as the selector surface for
driving the Android build over CDP, and this is the one member that went missing.

`DropdownMenuItem` now takes a `dataAttrs` map, so a shared row can carry the hook
its hand-written predecessor carried.

It matters more here than it would elsewhere: the mobile shell only mounts when the
backend reports `android`, so this menu cannot be reached from the desktop headless
build — those selectors are how it gets exercised at all, and there is no emulator
available to fall back on.

Found by re-reading the #206 diff for what it silently removed, rather than for what
it changed.

`tsc --noEmit` clean; 190 tests across `mobile`, `shared` and `terminal` pass.
