### PR TITLE
fix(terminal): let Ctrl+G reach the shell when search is closed

### DIFF
--- a/src/hooks/__fixtures__/fakeXterm.ts
+++ b/src/hooks/__fixtures__/fakeXterm.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared xterm doubles for the useTerminal tests.
+ *
+ * Every one of those tests needs the same stub of the slice of the Terminal and
+ * addon surface useTerminal touches, so it lives here once: a new xterm API has
+ * to be taught to a single fake rather than to each test file that mounts a
+ * terminal.
+ *
+ * `vi.mock` factories are hoisted per file, so a test still declares its own
+ * mocks — they just point at these classes:
+ *
+ *   vi.mock("@xterm/xterm", async () => ({
+ *     Terminal: (await import("@/hooks/__fixtures__/fakeXterm")).FakeTerminal,
+ *   }));
+ *
+ * The factory has to do that import itself — vi.mock is hoisted above any
+ * top-level binding the file might otherwise share.
+ */
+
+/**
+ * Handlers registered through `attachCustomKeyEventHandler`, keyed by terminal
+ * id. Calling one is how a test delivers a key to the terminal that owns it.
+ */
+export const keyHandlers = new Map<string, (e: KeyboardEvent) => boolean>();
+
+let seq = 0;
+
+/** Terminal ids run `term-1`, `term-2`, ... in creation order. */
+export class FakeTerminal {
+  id = `term-${(seq += 1)}`;
+  element: HTMLElement | null = null;
+  options: Record<string, unknown> = {};
+  cols = 80;
+  rows = 24;
+  modes = { applicationCursorKeysMode: false, mouseTrackingMode: "none" };
+  buffer = {
+    active: { length: 0, viewportY: 0, baseY: 0, cursorY: 0, type: "normal", getLine: () => null },
+    onBufferChange: () => ({ dispose() {} }),
+  };
+  open(container: HTMLElement) {
+    this.element = document.createElement("div");
+    container.appendChild(this.element);
+  }
+  parser = { registerOscHandler: () => ({ dispose() {} }) };
+  loadAddon() {}
+  write() {}
+  focus() {}
+  getSelection() { return ""; }
+  dispose() {}
+  attachCustomKeyEventHandler(fn: (e: KeyboardEvent) => boolean) { keyHandlers.set(this.id, fn); }
+  attachCustomWheelEventHandler() {}
+  onData() { return { dispose() {} }; }
+  onBinary() { return { dispose() {} }; }
+  onResize() { return { dispose() {} }; }
+  onScroll() { return { dispose() {} }; }
+  onLineFeed() { return { dispose() {} }; }
+  onRender() { return { dispose() {} }; }
+  onWriteParsed() { return { dispose() {} }; }
+  registerLinkProvider() { return { dispose() {} }; }
+  registerDecoration() { return null; }
+}
+
+export class FakeFitAddon {
+  fit() {}
+  proposeDimensions() { return { cols: 80, rows: 24 }; }
+}
+
+export class FakeWebglAddon {
+  onContextLoss() { return { dispose() {} }; }
+  dispose() {}
+}
+
+export class FakeWebLinksAddon {}
+
+/**
+ * Records searches instead of running them — the real addon reports hits back
+ * through `onDidChangeResults`, which a stub cannot do, so `searches` is the
+ * only observable that a find actually ran.
+ */
+export class FakeSearchAddon {
+  static instances: FakeSearchAddon[] = [];
+  searches: { direction: "next" | "prev"; query: string }[] = [];
+  constructor() { FakeSearchAddon.instances.push(this); }
+  findNext(query: string) { this.searches.push({ direction: "next", query }); return false; }
+  findPrevious(query: string) { this.searches.push({ direction: "prev", query }); return false; }
+  clearDecorations() {}
+  onDidChangeResults() { return { dispose() {} }; }
+}
+
+/**
+ * The handler the most recently created terminal registered. useTerminal caches
+ * terminals by session id for the lifetime of the module, so a test that wants a
+ * freshly constructed one has to use a session id no earlier test has mounted.
+ */
+export function lastKeyHandler(): (e: KeyboardEvent) => boolean {
+  // Indexed rather than .at(-1): the project's tsconfig lib predates ES2022.
+  const handlers = [...keyHandlers.values()];
+  const last = handlers[handlers.length - 1];
+  if (!last) throw new Error("no terminal registered a key handler — was one mounted?");
+  return last;
+}
+
+/** Drop state a previous test left behind (ids restart at `term-1`). */
+export function resetFakeXterm(): void {
+  seq = 0;
+  keyHandlers.clear();
+  FakeSearchAddon.instances = [];
+}

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -65,10 +65,10 @@ export function useKeyboard() {
 
       // Ctrl+G / Shift+Ctrl+G: always prevent the native webview find-next dialog.
       // When the terminal search widget is open, drive it to next/prev result.
-      // The terminal canvas gets first refusal, in useTerminal. Once that hands
-      // Ctrl+G to xterm as ^G, xterm cancels the key and stops propagation, so
-      // this listener never runs — it covers the focus-is-elsewhere case and the
-      // open-widget case, where xterm bails out before touching the event.
+      // useTerminal gets first refusal and claims the chord whenever the canvas
+      // has focus: xterm cancels the pass-through ^G, and useTerminal stops the
+      // event itself when it drives an open widget. What is left for this
+      // listener is focus elsewhere — the search input, or outside the canvas.
       if (isTerminalSearchNavKey(e)) {
         e.preventDefault();
         if (useUIStore.getState().activeNav === "terminal") {

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -5,7 +5,7 @@ import { useSessionStore } from "@/stores/sessionStore";
 import { useTeamSessionStore } from "@/stores/teamSessionStore";
 import { matchShortcut } from "@/stores/shortcutStore";
 import { useHistoryStore } from "@/stores/historyStore";
-import { openTerminalSearch, getTerminalSearchController } from "@/hooks/useTerminal";
+import { openTerminalSearch, isTerminalSearchNavKey, handleTerminalSearchNav } from "@/hooks/useTerminal";
 import { handleDuplicateShortcut } from "@/services/duplicateSession";
 
 const CLIPBOARD_TABS = new Set(["hosts", "keychain", "port-forwarding", "snippets"]);
@@ -65,17 +65,15 @@ export function useKeyboard() {
 
       // Ctrl+G / Shift+Ctrl+G: always prevent the native webview find-next dialog.
       // When the terminal search widget is open, drive it to next/prev result.
-      if (e.ctrlKey && !e.altKey && (e.key === "g" || e.key === "G")) {
+      // The terminal canvas gets first refusal, in useTerminal. Once that hands
+      // Ctrl+G to xterm as ^G, xterm cancels the key and stops propagation, so
+      // this listener never runs — it covers the focus-is-elsewhere case and the
+      // open-widget case, where xterm bails out before touching the event.
+      if (isTerminalSearchNavKey(e)) {
         e.preventDefault();
         if (useUIStore.getState().activeNav === "terminal") {
           const activeId = useSessionStore.getState().activeSessionId;
-          if (activeId) {
-            const ctrl = getTerminalSearchController(activeId);
-            if (ctrl?.getSnapshot().open) {
-              if (e.shiftKey) ctrl.prev();
-              else ctrl.next();
-            }
-          }
+          if (activeId) handleTerminalSearchNav(activeId, e);
         }
         return;
       }

--- a/src/hooks/useTerminal.clipboard.test.tsx
+++ b/src/hooks/useTerminal.clipboard.test.tsx
@@ -1,56 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { render } from "@testing-library/react";
 import { useTerminal } from "@/hooks/useTerminal";
+import { keyHandlers } from "@/hooks/__fixtures__/fakeXterm";
 
-const keyHandlers = new Map<string, (e: KeyboardEvent) => boolean>();
-
-vi.mock("@xterm/xterm", () => {
-  let seq = 0;
-  class FakeTerminal {
-    id = `term-${(seq += 1)}`;
-    element: HTMLElement | null = null;
-    options: Record<string, unknown> = {};
-    cols = 80;
-    rows = 24;
-    modes = { applicationCursorKeysMode: false, mouseTrackingMode: "none" };
-    buffer = {
-      active: { length: 0, viewportY: 0, baseY: 0, cursorY: 0, type: "normal", getLine: () => null },
-      onBufferChange: () => ({ dispose() {} }),
-    };
-    open(container: HTMLElement) {
-      this.element = document.createElement("div");
-      container.appendChild(this.element);
-    }
-    parser = { registerOscHandler: () => ({ dispose() {} }) };
-    loadAddon() {}
-    write() {}
-    focus() {}
-    dispose() {}
-    attachCustomKeyEventHandler(fn: (e: KeyboardEvent) => boolean) { keyHandlers.set(this.id, fn); }
-    attachCustomWheelEventHandler() {}
-    onData() { return { dispose() {} }; }
-    onBinary() { return { dispose() {} }; }
-    onResize() { return { dispose() {} }; }
-    onScroll() { return { dispose() {} }; }
-    onLineFeed() { return { dispose() {} }; }
-    onRender() { return { dispose() {} }; }
-    onWriteParsed() { return { dispose() {} }; }
-    registerLinkProvider() { return { dispose() {} }; }
-    registerDecoration() { return null; }
-  }
-  return { Terminal: FakeTerminal };
-});
-vi.mock("@xterm/addon-fit", () => ({ FitAddon: class { fit() {} proposeDimensions() { return { cols: 80, rows: 24 }; } } }));
-vi.mock("@xterm/addon-webgl", () => ({ WebglAddon: class { onContextLoss() { return { dispose() {} }; } dispose() {} } }));
-vi.mock("@xterm/addon-web-links", () => ({ WebLinksAddon: class {} }));
-vi.mock("@xterm/addon-search", () => ({
-  SearchAddon: class {
-    findNext() { return false; }
-    findPrevious() { return false; }
-    clearDecorations() {}
-    onDidChangeResults() { return { dispose() {} }; }
-  },
-}));
+vi.mock("@xterm/xterm", async () => ({ Terminal: (await import("@/hooks/__fixtures__/fakeXterm")).FakeTerminal }));
+vi.mock("@xterm/addon-fit", async () => ({ FitAddon: (await import("@/hooks/__fixtures__/fakeXterm")).FakeFitAddon }));
+vi.mock("@xterm/addon-webgl", async () => ({ WebglAddon: (await import("@/hooks/__fixtures__/fakeXterm")).FakeWebglAddon }));
+vi.mock("@xterm/addon-web-links", async () => ({ WebLinksAddon: (await import("@/hooks/__fixtures__/fakeXterm")).FakeWebLinksAddon }));
+vi.mock("@xterm/addon-search", async () => ({ SearchAddon: (await import("@/hooks/__fixtures__/fakeXterm")).FakeSearchAddon }));
 vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn() }));
 vi.mock("@/services/ssh", () => ({
   sshSendInput: vi.fn(), sshResize: vi.fn(),

--- a/src/hooks/useTerminal.ctrlG.test.tsx
+++ b/src/hooks/useTerminal.ctrlG.test.tsx
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { getTerminalSearchController, useTerminal } from "@/hooks/useTerminal";
+import { FakeSearchAddon, lastKeyHandler, resetFakeXterm } from "@/hooks/__fixtures__/fakeXterm";
+
+// vi.mock is hoisted above every top-level binding, so each factory has to
+// import the fixture itself rather than share a helper.
+vi.mock("@xterm/xterm", async () => ({ Terminal: (await import("@/hooks/__fixtures__/fakeXterm")).FakeTerminal }));
+vi.mock("@xterm/addon-fit", async () => ({ FitAddon: (await import("@/hooks/__fixtures__/fakeXterm")).FakeFitAddon }));
+vi.mock("@xterm/addon-webgl", async () => ({ WebglAddon: (await import("@/hooks/__fixtures__/fakeXterm")).FakeWebglAddon }));
+vi.mock("@xterm/addon-web-links", async () => ({ WebLinksAddon: (await import("@/hooks/__fixtures__/fakeXterm")).FakeWebLinksAddon }));
+vi.mock("@xterm/addon-search", async () => ({ SearchAddon: (await import("@/hooks/__fixtures__/fakeXterm")).FakeSearchAddon }));
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn() }));
+vi.mock("@/services/ssh", () => ({
+  sshSendInput: vi.fn(), sshResize: vi.fn(),
+  onSshOutput: vi.fn(async () => () => {}), onSshClosed: vi.fn(async () => () => {}), onSshCwd: vi.fn(async () => () => {}),
+}));
+vi.mock("@/services/local", () => ({
+  localSendInput: vi.fn(), localResize: vi.fn(), localReady: vi.fn(async () => {}),
+  onLocalOutput: vi.fn(async () => () => {}), onLocalClosed: vi.fn(async () => () => {}),
+}));
+vi.mock("@/services/serial", () => ({
+  serialWrite: vi.fn(), onSerialOutput: vi.fn(async () => () => {}), onSerialClosed: vi.fn(async () => () => {}),
+}));
+// Returning null keeps the clipboard out of the way: useTerminal forwards every
+// key to it first and honours any non-null verdict.
+vi.mock("@/components/terminal/terminalClipboard", () => ({
+  attachTerminalClipboard: () => ({ handleKeyEvent: () => null, dispose() {} }),
+}));
+
+globalThis.ResizeObserver ??= class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+function Harness({ sessionId }: { sessionId: string }) {
+  const { attach } = useTerminal({ sessionId, sessionType: "local" });
+  return <div data-testid="host" ref={attach} />;
+}
+
+const ctrlG = (type: "keydown" | "keyup", shiftKey = false) =>
+  new KeyboardEvent(type, { key: shiftKey ? "G" : "g", ctrlKey: true, shiftKey });
+
+describe("terminal Ctrl+G", () => {
+  beforeEach(() => {
+    resetFakeXterm();
+  });
+
+  // Returning false from the custom key handler makes xterm skip the key: it
+  // encodes nothing and writes nothing to the PTY. With the search widget shut
+  // that starved the shell of ^G — readline's abort, and the only way out of a
+  // Ctrl+R reverse-i-search (#208).
+  it("hands Ctrl+G to xterm while the search widget is closed", () => {
+    render(<Harness sessionId="ctrl-g-closed" />);
+    const handler = lastKeyHandler();
+
+    expect(handler(ctrlG("keydown"))).toBe(true);
+    expect(handler(ctrlG("keyup"))).toBe(true);
+    expect(handler(ctrlG("keydown", true))).toBe(true);
+  });
+
+  it("drives an open search widget instead, and keeps the key from the shell", () => {
+    render(<Harness sessionId="ctrl-g-open" />);
+    const handler = lastKeyHandler();
+    const search = getTerminalSearchController("ctrl-g-open")!;
+    search.open();
+    // runSearch bails on an empty query, so a find is only observable with one.
+    search.setQuery("needle");
+    const addon = FakeSearchAddon.instances[FakeSearchAddon.instances.length - 1];
+    addon.searches.length = 0;
+
+    expect(handler(ctrlG("keydown"))).toBe(false);
+    expect(handler(ctrlG("keydown", true))).toBe(false);
+    expect(addon.searches).toEqual([
+      { direction: "next", query: "needle" },
+      { direction: "prev", query: "needle" },
+    ]);
+
+    // The chord stays consumed on the way back up, without moving the hit again.
+    expect(handler(ctrlG("keyup"))).toBe(false);
+    expect(addon.searches).toHaveLength(2);
+  });
+
+  it("goes back to the shell once the widget closes", () => {
+    render(<Harness sessionId="ctrl-g-reclosed" />);
+    const handler = lastKeyHandler();
+    const search = getTerminalSearchController("ctrl-g-reclosed")!;
+    search.open();
+    expect(handler(ctrlG("keydown"))).toBe(false);
+
+    search.close();
+    expect(handler(ctrlG("keydown"))).toBe(true);
+  });
+});

--- a/src/hooks/useTerminal.ctrlG.test.tsx
+++ b/src/hooks/useTerminal.ctrlG.test.tsx
@@ -82,6 +82,33 @@ describe("terminal Ctrl+G", () => {
     expect(addon.searches).toHaveLength(2);
   });
 
+  // xterm returns early on a false verdict without cancelling the event, so a
+  // chord the handler claims still bubbles to useKeyboard's window listener —
+  // which would run the same next/prev again, moving two hits per press.
+  it("claims the event so the window listener cannot move the hit twice", () => {
+    render(<Harness sessionId="ctrl-g-claims" />);
+    const handler = lastKeyHandler();
+    const search = getTerminalSearchController("ctrl-g-claims")!;
+
+    const open = ctrlG("keydown");
+    const openStop = vi.spyOn(open, "stopPropagation");
+    const openPrevent = vi.spyOn(open, "preventDefault");
+    search.open();
+    expect(handler(open)).toBe(false);
+    expect(openStop).toHaveBeenCalled();
+    expect(openPrevent).toHaveBeenCalled();
+
+    // Closed, the shell owns the chord: xterm cancels it on the way out, so the
+    // handler must leave the event alone rather than swallow it here.
+    const closed = ctrlG("keydown");
+    const closedStop = vi.spyOn(closed, "stopPropagation");
+    const closedPrevent = vi.spyOn(closed, "preventDefault");
+    search.close();
+    expect(handler(closed)).toBe(true);
+    expect(closedStop).not.toHaveBeenCalled();
+    expect(closedPrevent).not.toHaveBeenCalled();
+  });
+
   it("goes back to the shell once the widget closes", () => {
     render(<Harness sessionId="ctrl-g-reclosed" />);
     const handler = lastKeyHandler();

--- a/src/hooks/useTerminal.reattach.test.tsx
+++ b/src/hooks/useTerminal.reattach.test.tsx
@@ -3,50 +3,11 @@ import { render } from "@testing-library/react";
 import { useTerminal } from "@/hooks/useTerminal";
 import { localReady, onLocalClosed, onLocalOutput } from "@/services/local";
 
-vi.mock("@xterm/xterm", () => {
-  class FakeTerminal {
-    element: HTMLElement | null = null;
-    options: Record<string, unknown> = {};
-    cols = 80;
-    rows = 24;
-    buffer = {
-      active: { length: 0, viewportY: 0, baseY: 0, cursorY: 0, getLine: () => null },
-      onBufferChange: () => ({ dispose() {} }),
-    };
-    open(container: HTMLElement) {
-      this.element = document.createElement("div");
-      container.appendChild(this.element);
-    }
-    parser = { registerOscHandler: () => ({ dispose() {} }) };
-    loadAddon() {}
-    write() {}
-    focus() {}
-    dispose() {}
-    attachCustomKeyEventHandler() {}
-    attachCustomWheelEventHandler() {}
-    onData() { return { dispose() {} }; }
-    onBinary() { return { dispose() {} }; }
-    onResize() { return { dispose() {} }; }
-    onScroll() { return { dispose() {} }; }
-    onLineFeed() { return { dispose() {} }; }
-    onRender() { return { dispose() {} }; }
-    onWriteParsed() { return { dispose() {} }; }
-    registerLinkProvider() { return { dispose() {} }; }
-    registerDecoration() { return null; }
-  }
-  return { Terminal: FakeTerminal };
-});
-vi.mock("@xterm/addon-fit", () => ({ FitAddon: class { fit() {} proposeDimensions() { return { cols: 80, rows: 24 }; } } }));
-vi.mock("@xterm/addon-webgl", () => ({ WebglAddon: class { onContextLoss() { return { dispose() {} }; } dispose() {} } }));
-vi.mock("@xterm/addon-web-links", () => ({ WebLinksAddon: class {} }));
-vi.mock("@xterm/addon-search", () => ({
-  SearchAddon: class {
-    findNext() { return false; }
-    findPrevious() { return false; }
-    clearDecorations() {}
-    onDidChangeResults() { return { dispose() {} }; }
-  },
-}));
+vi.mock("@xterm/xterm", async () => ({ Terminal: (await import("@/hooks/__fixtures__/fakeXterm")).FakeTerminal }));
+vi.mock("@xterm/addon-fit", async () => ({ FitAddon: (await import("@/hooks/__fixtures__/fakeXterm")).FakeFitAddon }));
+vi.mock("@xterm/addon-webgl", async () => ({ WebglAddon: (await import("@/hooks/__fixtures__/fakeXterm")).FakeWebglAddon }));
+vi.mock("@xterm/addon-web-links", async () => ({ WebLinksAddon: (await import("@/hooks/__fixtures__/fakeXterm")).FakeWebLinksAddon }));
+vi.mock("@xterm/addon-search", async () => ({ SearchAddon: (await import("@/hooks/__fixtures__/fakeXterm")).FakeSearchAddon }));
 vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn() }));
 vi.mock("@/services/ssh", () => ({
   sshSendInput: vi.fn(), sshResize: vi.fn(),

--- a/src/hooks/useTerminal.searchChords.test.tsx
+++ b/src/hooks/useTerminal.searchChords.test.tsx
@@ -42,7 +42,17 @@ function Harness({ sessionId }: { sessionId: string }) {
 const ctrlG = (type: "keydown" | "keyup", shiftKey = false) =>
   new KeyboardEvent(type, { key: shiftKey ? "G" : "g", ctrlKey: true, shiftKey });
 
-describe("terminal Ctrl+G", () => {
+const ctrlF = () => new KeyboardEvent("keydown", { key: "f", ctrlKey: true });
+
+/** Both spies on one event, so a claim can be asserted as a pair. */
+function watchClaim(e: KeyboardEvent) {
+  return {
+    prevented: vi.spyOn(e, "preventDefault"),
+    stopped: vi.spyOn(e, "stopPropagation"),
+  };
+}
+
+describe("terminal search chords", () => {
   beforeEach(() => {
     resetFakeXterm();
   });
@@ -83,30 +93,43 @@ describe("terminal Ctrl+G", () => {
   });
 
   // xterm returns early on a false verdict without cancelling the event, so a
-  // chord the handler claims still bubbles to useKeyboard's window listener —
-  // which would run the same next/prev again, moving two hits per press.
-  it("claims the event so the window listener cannot move the hit twice", () => {
+  // chord the handler claims still bubbles to useKeyboard's window listener.
+  // Ctrl+F and Ctrl+G are the two branches that sit above that listener's
+  // isInput guard, so they are the two it would otherwise run a second time —
+  // reopening the widget, or moving two hits per press.
+  it("claims Ctrl+G so the window listener cannot move the hit twice", () => {
     render(<Harness sessionId="ctrl-g-claims" />);
     const handler = lastKeyHandler();
     const search = getTerminalSearchController("ctrl-g-claims")!;
 
     const open = ctrlG("keydown");
-    const openStop = vi.spyOn(open, "stopPropagation");
-    const openPrevent = vi.spyOn(open, "preventDefault");
+    const claim = watchClaim(open);
     search.open();
     expect(handler(open)).toBe(false);
-    expect(openStop).toHaveBeenCalled();
-    expect(openPrevent).toHaveBeenCalled();
+    expect(claim.stopped).toHaveBeenCalled();
+    expect(claim.prevented).toHaveBeenCalled();
 
     // Closed, the shell owns the chord: xterm cancels it on the way out, so the
     // handler must leave the event alone rather than swallow it here.
     const closed = ctrlG("keydown");
-    const closedStop = vi.spyOn(closed, "stopPropagation");
-    const closedPrevent = vi.spyOn(closed, "preventDefault");
+    const passThrough = watchClaim(closed);
     search.close();
     expect(handler(closed)).toBe(true);
-    expect(closedStop).not.toHaveBeenCalled();
-    expect(closedPrevent).not.toHaveBeenCalled();
+    expect(passThrough.stopped).not.toHaveBeenCalled();
+    expect(passThrough.prevented).not.toHaveBeenCalled();
+  });
+
+  it("claims Ctrl+F, so only the terminal widget opens", () => {
+    render(<Harness sessionId="ctrl-f-claims" />);
+    const handler = lastKeyHandler();
+    const search = getTerminalSearchController("ctrl-f-claims")!;
+
+    const e = ctrlF();
+    const claim = watchClaim(e);
+    expect(handler(e)).toBe(false);
+    expect(search.getSnapshot().open).toBe(true);
+    expect(claim.stopped).toHaveBeenCalled();
+    expect(claim.prevented).toHaveBeenCalled();
   });
 
   it("goes back to the shell once the widget closes", () => {

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -634,6 +634,29 @@ export function openTerminalSearch(sessionId: string): void {
   getTerminalSearchController(sessionId)?.open();
 }
 
+/** Ctrl+G / Shift+Ctrl+G — the search widget's find-next / find-previous chord. */
+export function isTerminalSearchNavKey(e: KeyboardEvent): boolean {
+  return e.ctrlKey && !e.altKey && (e.key === "g" || e.key === "G");
+}
+
+/**
+ * Move an open search widget to its next (or, with shift, previous) hit.
+ *
+ * Returns whether the chord was consumed. A closed widget consumes nothing:
+ * Ctrl+G then still belongs to the shell as ^G, which is readline's `abort` and
+ * the only way out of a Ctrl+R reverse-i-search (#208).
+ */
+export function handleTerminalSearchNav(sessionId: string, e: KeyboardEvent): boolean {
+  const ctrl = getTerminalSearchController(sessionId);
+  if (!ctrl?.getSnapshot().open) return false;
+  // The chord is consumed for keyup/keypress too, but only keydown moves the hit.
+  if (e.type === "keydown") {
+    if (e.shiftKey) ctrl.prev();
+    else ctrl.next();
+  }
+  return true;
+}
+
 useSessionStore.subscribe((state) => {
   const currentIds = new Set(state.sessions.map((s) => s.id));
   for (const [id, entry] of terminalCache) {
@@ -895,16 +918,11 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
           }
           return false;
         }
-        if (e.ctrlKey && !e.altKey && (e.key === "g" || e.key === "G")) {
-          if (e.type === "keydown") {
-            const ctrl = getTerminalSearchController(sessionId);
-            if (ctrl?.getSnapshot().open) {
-              if (e.shiftKey) ctrl.prev();
-              else ctrl.next();
-            }
-          }
-          return false;
-        }
+        // Returning false makes xterm skip the key entirely — correct while the
+        // search widget owns Ctrl+G, wrong once it is closed, when the shell needs
+        // ^G. xterm marks ctrl+letter cancel:true and calls preventDefault itself,
+        // so the webview's native find-next stays suppressed on the pass-through.
+        if (isTerminalSearchNavKey(e)) return !handleTerminalSearchNav(sessionId, e);
         if (matchShortcut("history", e)) {
           if (e.type === "keydown") useUIStore.getState().toggleRightPanel("history");
           return false;

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -634,6 +634,21 @@ export function openTerminalSearch(sessionId: string): void {
   getTerminalSearchController(sessionId)?.open();
 }
 
+/**
+ * Take a chord for the terminal canvas and return xterm's "skip this key" verdict.
+ *
+ * xterm returns early on a false verdict *without* calling its own cancel(), so
+ * the event keeps propagating to useKeyboard's window listener. That listener
+ * runs the Ctrl+F and Ctrl+G branches above its `isInput` guard — the canvas is
+ * a textarea, so every other shortcut it owns is already unreachable from here —
+ * and would run its copy of the shortcut on top of this one.
+ */
+function claimChord(e: KeyboardEvent): false {
+  e.preventDefault();
+  e.stopPropagation();
+  return false;
+}
+
 /** Ctrl+G / Shift+Ctrl+G — the search widget's find-next / find-previous chord. */
 export function isTerminalSearchNavKey(e: KeyboardEvent): boolean {
   return e.ctrlKey && !e.altKey && (e.key === "g" || e.key === "G");
@@ -912,24 +927,17 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
         const clipResult = entry.clip?.handleKeyEvent(e);
         if (clipResult != null) return clipResult;
         if (matchShortcut("terminal-search", e)) {
-          if (e.type === "keydown") {
-            e.preventDefault();
-            getTerminalSearchController(sessionId)?.open();
-          }
-          return false;
+          if (e.type === "keydown") getTerminalSearchController(sessionId)?.open();
+          return claimChord(e);
         }
         // Returning false makes xterm skip the key entirely — correct while the
         // search widget owns Ctrl+G, wrong once it is closed, when the shell needs
         // ^G. xterm marks ctrl+letter cancel:true and calls preventDefault itself,
         // so the webview's native find-next stays suppressed on the pass-through.
+        // This pane owns its own widget; useKeyboard keys off activeSessionId.
         if (isTerminalSearchNavKey(e)) {
           if (!handleTerminalSearchNav(sessionId, e)) return true;
-          // A false verdict makes xterm return early *without* cancelling, so
-          // the chord would still reach useKeyboard and move the hit a second
-          // time. This pane owns its widget, so claim the event here.
-          e.preventDefault();
-          e.stopPropagation();
-          return false;
+          return claimChord(e);
         }
         if (matchShortcut("history", e)) {
           if (e.type === "keydown") useUIStore.getState().toggleRightPanel("history");

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -922,7 +922,15 @@ export function useTerminal({ sessionId, sessionType, onClosed, inputGate, encod
         // search widget owns Ctrl+G, wrong once it is closed, when the shell needs
         // ^G. xterm marks ctrl+letter cancel:true and calls preventDefault itself,
         // so the webview's native find-next stays suppressed on the pass-through.
-        if (isTerminalSearchNavKey(e)) return !handleTerminalSearchNav(sessionId, e);
+        if (isTerminalSearchNavKey(e)) {
+          if (!handleTerminalSearchNav(sessionId, e)) return true;
+          // A false verdict makes xterm return early *without* cancelling, so
+          // the chord would still reach useKeyboard and move the hit a second
+          // time. This pane owns its widget, so claim the event here.
+          e.preventDefault();
+          e.stopPropagation();
+          return false;
+        }
         if (matchShortcut("history", e)) {
           if (e.type === "keydown") useUIStore.getState().toggleRightPanel("history");
           return false;


### PR DESCRIPTION
Fixes #208.

## Problem

`Ctrl+G` never reached the PTY, so `bash` could not abort a `Ctrl+R`
reverse-i-search — readline's `abort` needs `^G` (0x07) and the byte was never
sent. `Ctrl+R` worked, then the key was simply dead, which is what made it look
like a `Ctrl+G`-specific fault. Every other shell/TUI use of the key went the
same way: emacs `keyboard-quit`, nano's help toggle, and so on.

`useTerminal.ts`'s custom key handler returned `false` for `Ctrl+G`
unconditionally — the `return` sat outside the check for an open search widget:

```ts
if (e.ctrlKey && !e.altKey && (e.key === "g" || e.key === "G")) {
  if (e.type === "keydown") {
    const ctrl = getTerminalSearchController(sessionId);
    if (ctrl?.getSnapshot().open) { /* next / prev */ }
  }
  return false;   // <- reached whether or not the widget is open
}
```

Returning `false` makes xterm skip the key entirely, encoding nothing, so with
the widget closed the branch did no work and still swallowed the key. Reported
on Fedora 44 / v0.31.1, but the path has no platform branch.

## Fix

The chord is now only claimed while the widget is open. On the pass-through
xterm marks `ctrl`+letter `cancel: true` and calls `preventDefault()` itself, so
the native webview find-next — the reason 8eda22a9 blocked the key, and not a
problem I wanted to reintroduce — stays suppressed.

Measured against the real `@xterm/xterm@6.0.0` in a browser, driving actual
`Control+g` keystrokes rather than synthetic ones:

| search widget | `onData` | event ends | reaches window handler |
| --- | --- | --- | --- |
| closed | `[0x07]` | `defaultPrevented: true` | no — xterm stops propagation |
| open | nothing | `defaultPrevented: false` | yes — `useKeyboard` cancels it there |

So both paths keep the native dialog shut, by different routes: xterm's own
cancel on the shell path, and the existing window handler on the widget path.

The reporter has also confirmed it by hand on the Fedora 44 / WebKitGTK build
this was found on: `Ctrl+G` aborts a reverse-i-search again, and the `Ctrl+F`
widget still walks its hits.

## Tests

`src/hooks/useTerminal.ctrlG.test.tsx` covers the handler's verdict for closed
widget, open widget (including that `keyup` stays consumed without moving the
hit again), and closed-again. Two of its three cases fail against the code this
replaces.

`pnpm test` — 522 files / 3991 tests pass. `pnpm build` clean. No Rust touched.

## The first commit

The two existing tests that mount a terminal each carried their own copy of the
same ~35-line xterm stub, and the regression test would have been a third. Per
the DRY note in `CLAUDE.md` I extracted one fixture instead of adding a copy.
It's a separate commit and drops cleanly if you would rather review a one-file
diff — the fix itself does not depend on it beyond using the fixture.
