### PR TITLE
feat(mobile): surface team-vault first-access state on mobile (#70)

### DIFF
--- a/src/components/layout/MainPanel.tsx
+++ b/src/components/layout/MainPanel.tsx
@@ -1,13 +1,10 @@
-import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useSessionStore } from "@/stores/sessionStore";
 import { sessionClosed } from "@/stores/reconnectBackoff";
 import { useUIStore } from "@/stores/uiStore";
 import { useVaultStore } from "@/stores/vaultStore";
-import { useTeamStore } from "@/stores/teamStore";
-import { useTeamVaultStateStore } from "@/stores/teamVaultStateStore";
-import { fetchTeamData } from "@/services/teamVaultSync";
-import { ownerHandle, selectedTeamId } from "@/services/teamVaultFirstAccess";
+import { useBlockedTeamVault } from "@/hooks/useBlockedTeamVault";
+import TeamVaultStatePanel from "@/components/team/TeamVaultStatePanel";
 import MultiplayerTerminalView from "@/components/terminal/MultiplayerTerminalView";
 import { MultiplayerBar } from "@/components/terminal/MultiplayerBar";
 import { HostAwareTerminalView, SessionConnectionOverlay } from "@/components/terminal/SessionView";
@@ -55,122 +52,7 @@ function NoVaultSelected() {
   );
 }
 
-function TeamVaultState({
-  status,
-  teamId,
-}: {
-  status: string;
-  teamId: string;
-}) {
-  const { t } = useTranslation();
-  const team = useTeamStore((s) => s.teams.find((t) => t.id === teamId));
-  const rolesByTeam = useTeamStore((s) => s.rolesByTeam);
-  const members = useTeamStore((s) => s.membersByTeam[teamId]);
-  const loadMembers = useTeamStore((s) => s.loadMembers);
-  const myRoleIds = team?.role_ids ?? [];
-  const teamRoles = rolesByTeam[teamId] ?? [];
-  const isOwner = myRoleIds.some((rid) => {
-    const r = teamRoles.find((role) => role.id === rid);
-    return r?.is_builtin && r.name === "owner";
-  });
-
-  // The waiting copy names the owner the user is waiting on, so the roster has
-  // to be there — this panel replaces the pages that would otherwise load it.
-  useEffect(() => {
-    if (status === "awaiting_key" && !members) loadMembers(teamId).catch(() => {});
-  }, [status, members, teamId, loadMembers]);
-
-  // Generic until the handle resolves: a name flashing in from blank reads worse
-  // than the sentence that never had one.
-  const owner = ownerHandle(team, members);
-
-  const configs: Record<string, { icon: string; title: string; body: string }> = {
-    offline: {
-      icon: "lucide:cloud-off",
-      title: t("layout.mainPanel.teamVault.offlineTitle"),
-      body: t("layout.mainPanel.teamVault.offlineBody"),
-    },
-    forbidden: {
-      icon: "lucide:shield-off",
-      title: t("layout.mainPanel.teamVault.forbiddenTitle"),
-      body: t("layout.mainPanel.teamVault.forbiddenBody"),
-    },
-    // Member has joined the team but no vault owner has distributed a key yet
-    // (issue #41). Distinct from a hard error — a key-holder self-heals this on
-    // their next sync, so present it as a benign waiting state, not a failure.
-    awaiting_key: {
-      icon: "lucide:clock",
-      title: t("layout.mainPanel.teamVault.waitingForAccessTitle"),
-      body: owner
-        ? t("layout.mainPanel.teamVault.waitingForAccessBodyNamed", { owner: `@${owner}` })
-        : t("layout.mainPanel.teamVault.waitingForAccessBody"),
-    },
-    payment_required: {
-      icon: "lucide:credit-card",
-      title: t("layout.mainPanel.teamVault.paymentRequiredTitle"),
-      body: isOwner
-        ? t("layout.mainPanel.teamVault.paymentRequiredBodyOwner")
-        : t("layout.mainPanel.teamVault.paymentRequiredBodyMember"),
-    },
-    error: {
-      icon: "lucide:triangle-alert",
-      title: t("layout.mainPanel.teamVault.errorTitle"),
-      body: t("layout.mainPanel.teamVault.errorBody"),
-    },
-  };
-
-  const cfg = configs[status] ?? configs.error;
-
-  const openBilling = () => {
-    useUIStore.getState().openSettings("account");
-  };
-
-  return (
-    <div className="flex-1 flex flex-col items-center justify-center gap-4 bg-(--t-bg-base)">
-      <div
-        className="flex items-center justify-center rounded-3xl w-[5.333rem] h-[5.333rem] text-(--t-text-dim)"
-        style={{
-          background: "linear-gradient(135deg, var(--t-bg-elevated) 0%, var(--t-bg-card) 100%)",
-          border: "1px solid var(--t-border)",
-        }}
-      >
-        <Icon icon={cfg.icon} width={36} />
-      </div>
-      <div className="flex flex-col items-center gap-1.5 text-center max-w-xs">
-        <span className="text-base font-semibold text-(--t-text-primary)">{cfg.title}</span>
-        <span className="text-sm text-(--t-text-dim)">{cfg.body}</span>
-        {status === "payment_required" && isOwner && (
-          <button
-            onClick={openBilling}
-            className="mt-2 text-sm px-3 py-1.5 rounded-lg"
-            style={{ background: "var(--t-accent)", color: "#fff" }}
-          >
-            {t("layout.mainPanel.manageSubscription")}
-          </button>
-        )}
-        {(!status || status === "error" || status === "awaiting_key") && (
-          <button
-            onClick={() => fetchTeamData(teamId).catch(() => {})}
-            className="mt-2 text-sm px-3 py-1.5 rounded-lg"
-            style={{ background: "var(--t-bg-elevated)", color: "var(--t-text-primary)", border: "1px solid var(--t-border)" }}
-          >
-            {t("layout.mainPanel.tryAgain")}
-          </button>
-        )}
-      </div>
-    </div>
-  );
-}
-
 const PLACEHOLDER_PAGES: Record<string, { icon: string; title: string; description: string }> = {};
-
-function useSelectedTeamId(): string | null {
-  const selectedVaultIds = useVaultStore((s) => s.selectedVaultIds);
-  const vaults = useVaultStore((s) => s.vaults);
-  const teams = useTeamStore((s) => s.teams);
-
-  return selectedTeamId(selectedVaultIds, vaults, teams);
-}
 
 export default function MainPanel() {
   const { sessions, activeSessionId } = useSessionStore();
@@ -193,18 +75,8 @@ export default function MainPanel() {
   useHostPingPolling();
 
   // Check if selected vault is a team vault in a non-loaded state
-  const selectedTeamId = useSelectedTeamId();
-  const teamVaultStatus = useTeamVaultStateStore(
-    (s) => selectedTeamId ? s.statusByTeamId[selectedTeamId] : null,
-  );
-  const showTeamVaultState =
-    selectedTeamId !== null &&
-    (teamVaultStatus === "offline" ||
-      teamVaultStatus === "forbidden" ||
-      teamVaultStatus === "payment_required" ||
-      teamVaultStatus === "awaiting_key" ||
-      teamVaultStatus === "error") &&
-    !homeView;
+  const blockedTeamVault = useBlockedTeamVault();
+  const showTeamVaultState = blockedTeamVault !== null && !homeView;
   const showSplitWorkspace = activeNav === "terminal" && splitTabActive && !sftpPanelOpen;
 
   // Determine vault/home overlay to show on top of terminals
@@ -240,7 +112,7 @@ export default function MainPanel() {
         </div>
       ) : showTeamVaultState ? (
         <div className="absolute inset-0 flex flex-col overflow-hidden">
-          <TeamVaultState status={teamVaultStatus!} teamId={selectedTeamId!} />
+          <TeamVaultStatePanel status={blockedTeamVault!.status} teamId={blockedTeamVault!.teamId} />
         </div>
       ) : sessions.length === 0 && !showSplitWorkspace ? (
         <div className="absolute inset-0 flex flex-col overflow-hidden">

--- a/src/components/mobile/MobileShell.teamVault.test.tsx
+++ b/src/components/mobile/MobileShell.teamVault.test.tsx
@@ -1,0 +1,85 @@
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (k: string, o?: Record<string, string>) => (o?.owner ? `${k} ${o.owner}` : k),
+  }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
+}));
+vi.mock("@iconify/react", () => ({ Icon: () => null }));
+vi.mock("@/services/teamVaultSync", () => ({ fetchTeamData: vi.fn(async () => {}) }));
+
+// The shell's own chrome and every tab screen are irrelevant here: this asserts
+// which of them the blocked-vault panel replaces, not what they render.
+vi.mock("./MobileSessionLayer", () => ({ default: () => null }));
+vi.mock("./screens/MobileHostsScreen", () => ({ default: () => <div>hosts-screen</div> }));
+vi.mock("./screens/MobileSnippetsScreen", () => ({ default: () => <div>snippets-screen</div> }));
+vi.mock("./screens/MobileTerminalScreen", () => ({ default: () => <div>terminal-screen</div> }));
+vi.mock("./panels/MobileSftpScreen", () => ({ default: () => <div>sftp-screen</div> }));
+
+import MobileShell from "./MobileShell";
+import { useTeamStore } from "@/stores/teamStore";
+import { useVaultStore } from "@/stores/vaultStore";
+import { useTeamVaultStateStore } from "@/stores/teamVaultStateStore";
+import { useMobileNavStore } from "@/stores/mobileNavStore";
+import { useSessionStore } from "@/stores/sessionStore";
+import type { Team } from "@/services/teamService";
+
+const TEAM: Team = {
+  id: "t1", name: "Ops", owner_id: "u9", owner_tier: "team", created_at: "", role_ids: [],
+};
+
+beforeEach(() => {
+  useTeamStore.setState({
+    teams: [TEAM],
+    membersByTeam: { t1: [] },
+    rolesByTeam: { t1: [] },
+  });
+  useVaultStore.setState({ vaults: [], selectedVaultIds: ["t1"] });
+  useTeamVaultStateStore.setState({ statusByTeamId: {} });
+  useMobileNavStore.setState({ tab: "hosts", stack: [], sheet: null });
+  useSessionStore.setState({ sessions: [] });
+});
+afterEach(cleanup);
+
+test("a keyless team vault explains itself instead of showing an empty hosts list", () => {
+  useTeamVaultStateStore.setState({ statusByTeamId: { t1: "awaiting_key" } });
+
+  render(<MobileShell />);
+
+  expect(screen.getByText("layout.mainPanel.teamVault.waitingForAccessTitle")).toBeTruthy();
+  expect(screen.queryByText("hosts-screen")).toBeNull();
+});
+
+test("the blocked vault is escapable — the vault switcher stays reachable", () => {
+  useTeamVaultStateStore.setState({ statusByTeamId: { t1: "awaiting_key" } });
+
+  const { container } = render(<MobileShell />);
+
+  // MobileHeader is the only route to the vault switcher on mobile, and it
+  // lives inside the tab screens the panel replaces. Without it a member who
+  // opens a keyless vault cannot get back to any other one.
+  expect(container.querySelector("[data-mobile-vault-switch]")).not.toBeNull();
+});
+
+test("the blocked panel never hides the tab bar", () => {
+  useSessionStore.setState({ sessions: [{ id: "s1" }] as never });
+  useMobileNavStore.setState({ tab: "terminal" });
+  useTeamVaultStateStore.setState({ statusByTeamId: { t1: "awaiting_key" } });
+
+  const { container } = render(<MobileShell />);
+
+  // Immersive mode hides the tab bar for a live terminal; with the panel on top
+  // of it that would leave no navigation at all.
+  expect(container.querySelector("[data-mobile-tab]")).not.toBeNull();
+});
+
+test("a loaded team vault shows its pages", () => {
+  useTeamVaultStateStore.setState({ statusByTeamId: { t1: "loaded" } });
+
+  render(<MobileShell />);
+
+  expect(screen.getByText("hosts-screen")).toBeTruthy();
+  expect(screen.queryByText("layout.mainPanel.teamVault.waitingForAccessTitle")).toBeNull();
+});

--- a/src/components/mobile/MobileShell.tsx
+++ b/src/components/mobile/MobileShell.tsx
@@ -19,6 +19,8 @@ import MobileLogsScreen from "./screens/MobileLogsScreen";
 import MobileSftpScreen from "./panels/MobileSftpScreen";
 import MobileAccountPage from "./screens/MobileAccountPage";
 import MobilePanelHeader from "./panels/MobilePanelHeader";
+import MobileHeader from "./MobileHeader";
+import TeamVaultStatePanel from "@/components/team/TeamVaultStatePanel";
 import MobileSnippetTargetSheet from "./sheets/MobileSnippetTargetSheet";
 import MobileSnippetActionsSheet from "./sheets/MobileSnippetActionsSheet";
 import MobileSnippetsSheet from "./sheets/MobileSnippetsSheet";
@@ -43,6 +45,7 @@ import { resolvePanelScreen } from "./mobilePanelDispatch";
 import { useAndroidBack } from "@/hooks/useAndroidBack";
 import { useVisualViewport } from "@/hooks/useVisualViewport";
 import { useHostPingPolling } from "@/hooks/useHostPingPolling";
+import { useBlockedTeamVault } from "@/hooks/useBlockedTeamVault";
 import { refitSession } from "@/hooks/useTerminal";
 
 export default function MobileShell() {
@@ -71,8 +74,14 @@ export default function MobileShell() {
   };
   const resolvedPanel = resolvePanelScreen(top);
 
+  // A team vault that cannot show its contents replaces the vault's screens with
+  // the explanatory panel, the way MainPanel does on desktop (issue #70).
+  const blockedTeamVault = useBlockedTeamVault();
+
   // Terminal tab with sessions = immersive: hide the tab bar, give xterm every pixel.
-  const immersive = tab === "terminal" && hasSessions && !top;
+  // Never while the blocked panel is up — it covers the screens, so dropping the tab
+  // bar as well would leave the member no way off the vault at all.
+  const immersive = tab === "terminal" && hasSessions && !top && !blockedTeamVault;
   const terminalVisible = tab === "terminal" && !top;
   // SFTP tab is always-mounted (below) so its connections/cwd survive tab switches; this only gates visibility.
   const sftpVisible = !terminalVisible && tab === "sftp" && !top;
@@ -107,7 +116,10 @@ export default function MobileShell() {
           {/* Always-mounted sessions; visibility toggled so xterm survives tab switches */}
           <MobileSessionLayer visible={terminalVisible && hasSessions} />
           {/* Non-terminal tab content layers above the session layer when terminal isn't foreground */}
-          {!terminalVisible && tab !== "sftp" && (
+          {/* Not while the vault is blocked: these screens list vault objects, and the
+              panel covers them anyway. The session and SFTP layers below stay mounted —
+              unmounting them would drop a live terminal or an SFTP connection. */}
+          {!terminalVisible && tab !== "sftp" && !blockedTeamVault && (
             <div className="absolute inset-0 flex flex-col bg-(--t-bg-base)" style={{ overflow: "clip" }}>
               {tab === "hosts" && !top && <MobileHostsScreen />}
               {tab === "snippets" && !top && <MobileSnippetsScreen />}
@@ -141,6 +153,16 @@ export default function MobileShell() {
         {resolvedPanel && renderMobileScreen(resolvedPanel.screenKind, resolvedPanel.props)}
         {top?.kind === "panel-sftp" && <MobileSftpScreen presetConnectionId={top.connectionId} />}
         {top?.kind === "account" && <MobileAccountPage />}
+        {/* Above every screen and pushed page — all of them read vault objects this
+            member cannot see yet. MobileHeader rides along because it owns the vault
+            switcher: desktop leaves its sidebar uncovered, and this is the mobile
+            equivalent of that escape route. */}
+        {blockedTeamVault && (
+          <div className="absolute inset-0 z-40 flex flex-col bg-(--t-bg-base)">
+            <MobileHeader />
+            <TeamVaultStatePanel status={blockedTeamVault.status} teamId={blockedTeamVault.teamId} />
+          </div>
+        )}
       </div>
       {/* Hide the tab bar while a full-screen page is pushed — it would otherwise sit
           visible-but-covered under the overlay, and tapping a tab silently clears the stack. */}

--- a/src/components/team/TeamVaultStatePanel.test.tsx
+++ b/src/components/team/TeamVaultStatePanel.test.tsx
@@ -1,0 +1,52 @@
+import { test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (k: string, o?: Record<string, string>) => (o?.owner ? `${k} ${o.owner}` : k),
+  }),
+  initReactI18next: { type: "3rdParty", init: () => {} },
+}));
+vi.mock("@iconify/react", () => ({ Icon: () => null }));
+vi.mock("@/services/teamVaultSync", () => ({ fetchTeamData: vi.fn(async () => {}) }));
+
+import TeamVaultStatePanel from "./TeamVaultStatePanel";
+import { useTeamStore } from "@/stores/teamStore";
+import type { Team, TeamMember } from "@/services/teamService";
+
+const TEAM: Team = {
+  id: "t1", name: "Ops", owner_id: "u9", owner_tier: "team", created_at: "", role_ids: [],
+};
+function member(user_id: string, handle?: string): TeamMember {
+  return {
+    team_id: "t1", user_id, handle, public_key: "pk",
+    invited_by_display_name: null, joined_at: "", role_ids: [],
+  };
+}
+
+beforeEach(() => {
+  useTeamStore.setState({ teams: [TEAM], membersByTeam: {}, rolesByTeam: { t1: [] } });
+});
+afterEach(cleanup);
+
+test("the waiting copy names the owner the member is waiting on", () => {
+  useTeamStore.setState({ membersByTeam: { t1: [member("u9", "bob")] } });
+
+  render(<TeamVaultStatePanel status="awaiting_key" teamId="t1" />);
+
+  expect(screen.getByText("layout.mainPanel.teamVault.waitingForAccessBodyNamed @bob")).toBeTruthy();
+});
+
+test("the waiting copy stays generic while the owner's handle is unknown", () => {
+  useTeamStore.setState({ membersByTeam: { t1: [member("u9")] } });
+
+  render(<TeamVaultStatePanel status="awaiting_key" teamId="t1" />);
+
+  expect(screen.getByText("layout.mainPanel.teamVault.waitingForAccessBody")).toBeTruthy();
+});
+
+test("an unrecognised status falls back to the generic error", () => {
+  render(<TeamVaultStatePanel status="banana" teamId="t1" />);
+
+  expect(screen.getByText("layout.mainPanel.teamVault.errorTitle")).toBeTruthy();
+});

--- a/src/components/team/TeamVaultStatePanel.tsx
+++ b/src/components/team/TeamVaultStatePanel.tsx
@@ -1,0 +1,120 @@
+/**
+ * The panel a shell shows in place of a team vault's pages when the vault
+ * cannot show its contents (issue #70). Shared by MainPanel and MobileShell so
+ * the copy, the statuses and the recovery actions exist once.
+ */
+
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { Icon } from "@iconify/react";
+import { useTeamStore } from "@/stores/teamStore";
+import { useUIStore } from "@/stores/uiStore";
+import { fetchTeamData } from "@/services/teamVaultSync";
+import { ownerHandle } from "@/services/teamVaultFirstAccess";
+
+export default function TeamVaultStatePanel({
+  status,
+  teamId,
+}: {
+  status: string;
+  teamId: string;
+}) {
+  const { t } = useTranslation();
+  const team = useTeamStore((s) => s.teams.find((t) => t.id === teamId));
+  const rolesByTeam = useTeamStore((s) => s.rolesByTeam);
+  const members = useTeamStore((s) => s.membersByTeam[teamId]);
+  const loadMembers = useTeamStore((s) => s.loadMembers);
+  const myRoleIds = team?.role_ids ?? [];
+  const teamRoles = rolesByTeam[teamId] ?? [];
+  const isOwner = myRoleIds.some((rid) => {
+    const r = teamRoles.find((role) => role.id === rid);
+    return r?.is_builtin && r.name === "owner";
+  });
+
+  // The waiting copy names the owner the user is waiting on, so the roster has
+  // to be there — this panel replaces the pages that would otherwise load it.
+  useEffect(() => {
+    if (status === "awaiting_key" && !members) loadMembers(teamId).catch(() => {});
+  }, [status, members, teamId, loadMembers]);
+
+  // Generic until the handle resolves: a name flashing in from blank reads worse
+  // than the sentence that never had one.
+  const owner = ownerHandle(team, members);
+
+  const configs: Record<string, { icon: string; title: string; body: string }> = {
+    offline: {
+      icon: "lucide:cloud-off",
+      title: t("layout.mainPanel.teamVault.offlineTitle"),
+      body: t("layout.mainPanel.teamVault.offlineBody"),
+    },
+    forbidden: {
+      icon: "lucide:shield-off",
+      title: t("layout.mainPanel.teamVault.forbiddenTitle"),
+      body: t("layout.mainPanel.teamVault.forbiddenBody"),
+    },
+    // Member has joined the team but no vault owner has distributed a key yet
+    // (issue #41). Distinct from a hard error — a key-holder self-heals this on
+    // their next sync, so present it as a benign waiting state, not a failure.
+    awaiting_key: {
+      icon: "lucide:clock",
+      title: t("layout.mainPanel.teamVault.waitingForAccessTitle"),
+      body: owner
+        ? t("layout.mainPanel.teamVault.waitingForAccessBodyNamed", { owner: `@${owner}` })
+        : t("layout.mainPanel.teamVault.waitingForAccessBody"),
+    },
+    payment_required: {
+      icon: "lucide:credit-card",
+      title: t("layout.mainPanel.teamVault.paymentRequiredTitle"),
+      body: isOwner
+        ? t("layout.mainPanel.teamVault.paymentRequiredBodyOwner")
+        : t("layout.mainPanel.teamVault.paymentRequiredBodyMember"),
+    },
+    error: {
+      icon: "lucide:triangle-alert",
+      title: t("layout.mainPanel.teamVault.errorTitle"),
+      body: t("layout.mainPanel.teamVault.errorBody"),
+    },
+  };
+
+  const cfg = configs[status] ?? configs.error;
+
+  const openBilling = () => {
+    useUIStore.getState().openSettings("account");
+  };
+
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center gap-4 bg-(--t-bg-base)">
+      <div
+        className="flex items-center justify-center rounded-3xl w-[5.333rem] h-[5.333rem] text-(--t-text-dim)"
+        style={{
+          background: "linear-gradient(135deg, var(--t-bg-elevated) 0%, var(--t-bg-card) 100%)",
+          border: "1px solid var(--t-border)",
+        }}
+      >
+        <Icon icon={cfg.icon} width={36} />
+      </div>
+      <div className="flex flex-col items-center gap-1.5 text-center max-w-xs">
+        <span className="text-base font-semibold text-(--t-text-primary)">{cfg.title}</span>
+        <span className="text-sm text-(--t-text-dim)">{cfg.body}</span>
+        {status === "payment_required" && isOwner && (
+          <button
+            onClick={openBilling}
+            className="mt-2 text-sm px-3 py-1.5 rounded-lg"
+            style={{ background: "var(--t-accent)", color: "#fff" }}
+          >
+            {t("layout.mainPanel.manageSubscription")}
+          </button>
+        )}
+        {(!status || status === "error" || status === "awaiting_key") && (
+          <button
+            onClick={() => fetchTeamData(teamId).catch(() => {})}
+            className="mt-2 text-sm px-3 py-1.5 rounded-lg"
+            style={{ background: "var(--t-bg-elevated)", color: "var(--t-text-primary)", border: "1px solid var(--t-border)" }}
+          >
+            {t("layout.mainPanel.tryAgain")}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useBlockedTeamVault.ts
+++ b/src/hooks/useBlockedTeamVault.ts
@@ -1,0 +1,20 @@
+import { useVaultStore } from "@/stores/vaultStore";
+import { useTeamStore } from "@/stores/teamStore";
+import { isBlockedTeamVaultStatus, useTeamVaultStateStore, type TeamVaultStatus } from "@/stores/teamVaultStateStore";
+import { selectedTeamId } from "@/services/teamVaultFirstAccess";
+
+/**
+ * The team vault on screen that cannot show its contents, or null. Both shells
+ * read this to decide whether to render `TeamVaultStatePanel` in place of the
+ * vault's pages, so the selection rule and the blocked statuses live once.
+ */
+export function useBlockedTeamVault(): { teamId: string; status: TeamVaultStatus } | null {
+  const selectedVaultIds = useVaultStore((s) => s.selectedVaultIds);
+  const vaults = useVaultStore((s) => s.vaults);
+  const teams = useTeamStore((s) => s.teams);
+  const teamId = selectedTeamId(selectedVaultIds, vaults, teams);
+  const status = useTeamVaultStateStore((s) => (teamId ? s.statusByTeamId[teamId] : undefined));
+
+  if (!teamId || !isBlockedTeamVaultStatus(status)) return null;
+  return { teamId, status: status! };
+}

--- a/src/services/teamDataManager.firstAccess.test.ts
+++ b/src/services/teamDataManager.firstAccess.test.ts
@@ -12,6 +12,9 @@ const h = vi.hoisted(() => ({
   loadRoles: vi.fn(async () => {}),
   setActiveNav: vi.fn(),
   setHomeView: vi.fn(),
+  setTab: vi.fn(),
+  push: vi.fn(),
+  isMobileShell: vi.fn(() => false),
   statusByTeamId: {} as Record<string, string>,
   setStatus: vi.fn(),
   teams: [] as unknown[],
@@ -44,6 +47,10 @@ vi.mock("@/stores/uiStore", () => ({
 vi.mock("@/stores/vaultStore", () => ({
   useVaultStore: { getState: () => ({ selectedVaultIds: h.selectedVaultIds, vaults: h.vaults }) },
 }));
+vi.mock("@/stores/mobileNavStore", () => ({
+  useMobileNavStore: { getState: () => ({ setTab: h.setTab, push: h.push }) },
+}));
+vi.mock("@/utils/platform", () => ({ isMobileShell: h.isMobileShell }));
 
 import { refreshAwaitingKeyTeams, joinAndLoadTeamVault } from "./teamDataManager";
 
@@ -52,6 +59,7 @@ beforeEach(() => {
   // clearAllMocks keeps implementations — a status-flipping stub from an earlier
   // test would otherwise make the next one's vault load on its own.
   h.fetchTeamData.mockImplementation(async () => {});
+  h.isMobileShell.mockImplementation(() => false);
   h.statusByTeamId = {};
   h.teams = [];
   h.rolesByTeam = {};
@@ -62,6 +70,18 @@ beforeEach(() => {
 function connectOnlyTeam(teamId: string) {
   h.teams = [{ id: teamId, role_ids: ["r1"] }];
   h.rolesByTeam = { [teamId]: [{ id: "r1", name: "connect-only", permissions: CONNECT_ONLY }] };
+}
+
+function secretsReaderTeam(teamId: string) {
+  h.teams = [{ id: teamId, role_ids: ["r1"] }];
+  h.rolesByTeam = { [teamId]: [{ id: "r1", name: "reader", permissions: PERM_BITS.VIEW_SECRETS }] };
+}
+
+/** A team whose vault unlocks on the next fetch, selected and on screen. */
+function unlockingOnScreen(teamId: string) {
+  h.selectedVaultIds = [teamId];
+  h.statusByTeamId = { [teamId]: "awaiting_key" };
+  h.fetchTeamData.mockImplementation(async () => { h.statusByTeamId[teamId] = "loaded"; });
 }
 
 test("only teams still waiting on a key are re-read", async () => {
@@ -107,6 +127,48 @@ test("a vault still waiting on its key does not steer the nav", async () => {
   await refreshAwaitingKeyTeams();
 
   expect(h.setActiveNav).not.toHaveBeenCalled();
+});
+
+test("on mobile a connect-only member lands on the hosts tab", async () => {
+  h.isMobileShell.mockImplementation(() => true);
+  connectOnlyTeam("t1");
+  unlockingOnScreen("t1");
+
+  await refreshAwaitingKeyTeams();
+
+  expect(h.setTab).toHaveBeenCalledWith("hosts");
+  expect(h.push).not.toHaveBeenCalled();
+});
+
+test("on mobile a secrets reader is pushed to the keychain page under More", async () => {
+  h.isMobileShell.mockImplementation(() => true);
+  secretsReaderTeam("t1");
+  unlockingOnScreen("t1");
+
+  await refreshAwaitingKeyTeams();
+
+  expect(h.setTab).toHaveBeenCalledWith("more");
+  expect(h.push).toHaveBeenCalledWith({ kind: "more-page", page: "keychain" });
+});
+
+test("on mobile the desktop nav is left alone", async () => {
+  h.isMobileShell.mockImplementation(() => true);
+  connectOnlyTeam("t1");
+  unlockingOnScreen("t1");
+
+  await refreshAwaitingKeyTeams();
+
+  expect(h.setActiveNav).not.toHaveBeenCalled();
+});
+
+test("on desktop the mobile nav is left alone", async () => {
+  connectOnlyTeam("t1");
+  unlockingOnScreen("t1");
+
+  await refreshAwaitingKeyTeams();
+
+  expect(h.setActiveNav).toHaveBeenCalledWith("hosts");
+  expect(h.setTab).not.toHaveBeenCalled();
 });
 
 test("joining a vault that loads lands on the role's surface", async () => {

--- a/src/services/teamDataManager.ts
+++ b/src/services/teamDataManager.ts
@@ -9,7 +9,9 @@ import { useTeamStore } from "@/stores/teamStore";
 import { useTeamVaultStateStore } from "@/stores/teamVaultStateStore";
 import { useUIStore } from "@/stores/uiStore";
 import { useVaultStore } from "@/stores/vaultStore";
-import { firstViewNav, selectedTeamId } from "@/services/teamVaultFirstAccess";
+import { useMobileNavStore } from "@/stores/mobileNavStore";
+import { firstViewNav, mobileFirstViewTarget, selectedTeamId } from "@/services/teamVaultFirstAccess";
+import { isMobileShell } from "@/utils/platform";
 import { effectivePermissions } from "@/services/permissions";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useIdentityStore } from "@/stores/identityStore";
@@ -86,13 +88,24 @@ export async function joinAndLoadTeamVault(teamId: string): Promise<void> {
  *
  * A no-op until the roles are known: guessing a landing surface from an
  * unresolved role is worse than leaving the user where they were.
+ *
+ * The two shells navigate through different stores, so each gets the write it
+ * understands and neither touches the other's: `activeNav`/`homeView` mean
+ * nothing to MobileShell, and a mobile tab means nothing to MainPanel.
  */
 function applyFirstViewNav(teamId: string): void {
   const { teams, rolesByTeam } = useTeamStore.getState();
   const team = teams.find((t) => t.id === teamId);
   const roles = rolesByTeam[teamId];
   if (!team || !roles || roles.length === 0) return;
-  useUIStore.getState().setActiveNav(firstViewNav(effectivePermissions({ role_ids: team.role_ids }, roles)));
+  const nav = firstViewNav(effectivePermissions({ role_ids: team.role_ids }, roles));
+  if (isMobileShell()) {
+    const { tab, screen } = mobileFirstViewTarget(nav);
+    useMobileNavStore.getState().setTab(tab);
+    if (screen) useMobileNavStore.getState().push(screen);
+    return;
+  }
+  useUIStore.getState().setActiveNav(nav);
   useUIStore.getState().setHomeView(false);
 }
 

--- a/src/services/teamVaultFirstAccess.test.ts
+++ b/src/services/teamVaultFirstAccess.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "vitest";
-import { ownerHandle, firstViewNav, selectedTeamId } from "./teamVaultFirstAccess.ts";
+import { ownerHandle, firstViewNav, mobileFirstViewTarget, selectedTeamId } from "./teamVaultFirstAccess.ts";
 import { PERM_BITS } from "./permissions.ts";
 import type { Team, TeamMember } from "@/services/teamService";
 import type { Vault } from "@/stores/vaultStore";
@@ -37,6 +37,25 @@ test("connect-only lands on connections, never the keychain", () => {
 test("a role without CONNECT lands where it can read", () => {
   expect(firstViewNav(PERM_BITS.VIEW_SECRETS)).toBe("keychain");
   expect(firstViewNav(PERM_BITS.MANAGE_MEMBERS)).toBe("members");
+});
+
+test("the mobile landing for a connect-only member is the hosts tab, no pushed page", () => {
+  expect(mobileFirstViewTarget("hosts")).toEqual({ tab: "hosts", screen: null });
+});
+
+test("mobile landings that live under More push the page they mean", () => {
+  expect(mobileFirstViewTarget("keychain")).toEqual({
+    tab: "more",
+    screen: { kind: "more-page", page: "keychain" },
+  });
+  expect(mobileFirstViewTarget("members")).toEqual({
+    tab: "more",
+    screen: { kind: "more-page", page: "members" },
+  });
+});
+
+test("a nav item with no mobile destination falls back to the hosts tab", () => {
+  expect(mobileFirstViewTarget("terminal")).toEqual({ tab: "hosts", screen: null });
 });
 
 test("a team is selected directly or through a vault linked to it", () => {

--- a/src/services/teamVaultFirstAccess.ts
+++ b/src/services/teamVaultFirstAccess.ts
@@ -9,6 +9,7 @@
 import type { Team, TeamMember } from "@/services/teamService";
 import type { Vault } from "@/stores/vaultStore";
 import type { NavItem } from "@/stores/uiStore";
+import type { MobileScreen, MobileTab } from "@/stores/mobileNavCore";
 import { PERM_BITS } from "@/services/permissions";
 
 /**
@@ -35,6 +36,22 @@ export function firstViewNav(permissions: number): NavItem {
   if (permissions & PERM_BITS.VIEW_SECRETS) return "keychain";
   if (permissions & PERM_BITS.MANAGE_MEMBERS) return "members";
   return "hosts";
+}
+
+/**
+ * The mobile destination for a `firstViewNav` result. The mobile shell has no
+ * single nav axis: `hosts` is a tab, while the keychain and members live as
+ * pushed pages under More. Kept as a mapping off the desktop nav item so the
+ * permission rule stays in `firstViewNav` alone.
+ */
+export function mobileFirstViewTarget(nav: NavItem): {
+  tab: MobileTab;
+  screen: MobileScreen | null;
+} {
+  if (nav === "keychain" || nav === "members") {
+    return { tab: "more", screen: { kind: "more-page", page: nav } };
+  }
+  return { tab: "hosts", screen: null };
 }
 
 /**

--- a/src/stores/teamVaultStateStore.test.ts
+++ b/src/stores/teamVaultStateStore.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "vitest";
+import { isBlockedTeamVaultStatus } from "./teamVaultStateStore.ts";
+
+test("a team vault that cannot show its contents is blocked", () => {
+  expect(isBlockedTeamVaultStatus("awaiting_key")).toBe(true);
+  expect(isBlockedTeamVaultStatus("offline")).toBe(true);
+  expect(isBlockedTeamVaultStatus("forbidden")).toBe(true);
+  expect(isBlockedTeamVaultStatus("payment_required")).toBe(true);
+  expect(isBlockedTeamVaultStatus("error")).toBe(true);
+});
+
+test("a vault that is loading or loaded is not blocked", () => {
+  expect(isBlockedTeamVaultStatus("idle")).toBe(false);
+  expect(isBlockedTeamVaultStatus("loading")).toBe(false);
+  expect(isBlockedTeamVaultStatus("loaded")).toBe(false);
+});
+
+test("a team with no status yet is not blocked", () => {
+  expect(isBlockedTeamVaultStatus(undefined)).toBe(false);
+});

--- a/src/stores/teamVaultStateStore.ts
+++ b/src/stores/teamVaultStateStore.ts
@@ -10,6 +10,23 @@ export type TeamVaultStatus =
   | "awaiting_key"
   | "error";
 
+/**
+ * Statuses where the vault's pages have nothing truthful to render, so a shell
+ * shows the explanatory panel instead. `loading` is excluded on purpose — it
+ * resolves on its own and flashing a panel through it reads as an error.
+ */
+const BLOCKED_STATUSES = new Set<TeamVaultStatus>([
+  "offline",
+  "forbidden",
+  "payment_required",
+  "awaiting_key",
+  "error",
+]);
+
+export function isBlockedTeamVaultStatus(status: TeamVaultStatus | undefined | null): boolean {
+  return !!status && BLOCKED_STATUSES.has(status);
+}
+
 interface TeamVaultStateStore {
   statusByTeamId: Record<string, TeamVaultStatus>;
   errorByTeamId: Record<string, string | null>;


### PR DESCRIPTION
Closes the last unbuilt item on #70: **mobile surfacing**.

The mobile shell rendered no team-vault state at all. A member who opened a keyless team vault got an empty hosts list with no explanation, and the role-aware landing from #186 never fired on mobile — `applyFirstViewNav` writes `uiStore.activeNav`, which `MobileShell` does not read.

## What changed

**Shared, not copied.** `TeamVaultState` moves out of `MainPanel.tsx` into `src/components/team/TeamVaultStatePanel.tsx` unchanged, and the blocked-status rule becomes `isBlockedTeamVaultStatus` on the store that owns `TeamVaultStatus`. Both shells read one predicate through `useBlockedTeamVault`, so the five statuses and the selection rule exist once.

**Mobile mount.** `MobileShell` renders the panel above every screen and pushed page when the selected team vault is blocked — the same statuses desktop covers (`offline`, `forbidden`, `payment_required`, `awaiting_key`, `error`).

**Role-aware landing.** `applyFirstViewNav` gains a mobile branch that navigates through `mobileNavStore`. `firstViewNav` is untouched, so the permission-bit rule stays in one place; `mobileFirstViewTarget` only maps its result onto the mobile shell's two-axis navigation — `hosts` is a tab, while the keychain and members are pushed pages under More.

## Two things the desktop version does not need

The mobile shell has no sidebar, and both of these are dead ends rather than polish:

- **The vault switcher lives only in `MobileHeader`, inside the tab screens the panel replaces.** Covering everything would leave a member who opened a keyless vault with no way back to any other vault. The panel keeps a `MobileHeader` above it — desktop's sidebar is never covered either, so this is the same rule, not an exception to it: the panel replaces vault *contents*, not vault *chrome*.
- **Immersive mode hides the tab bar.** With the panel over a live terminal that would remove the last navigation on screen, so immersive is suppressed while blocked.

Both are pinned by tests that failed for the right reason before the fix.

The session and SFTP layers stay mounted under the panel — unmounting them would drop a live terminal or an SFTP connection. The plain tab screens are unmounted, since they only list vault objects and the panel covers them.

No new strings: mobile reuses the existing `layout.mainPanel.teamVault.*` keys.

## Verification

`npx tsc --noEmit` clean. 232 test files / 1738 tests pass across every directory the diff touches (`services`, `stores`, `hooks`, `components/{team,mobile,layout}`), plus the two cross-directory importers (`runtime.mobileScreen`, `VaultShareSheet`). New tests: the mobile nav mapping, the shell-aware landing on both shells, the blocked-status rule, the shared panel's copy, and the four `MobileShell` mount cases including the two dead ends above.

**Not device-verified.** No `adb`, emulator, or `/dev/kvm` on the dev box, so the layout in a real WebView and the two-account keyless window were not exercised on hardware. That gate is still owed before #70's mobile checkbox is ticked.
