### PR TITLE
fix(vaults): gate the last silent private-to-team conversion (#68)

### DIFF
--- a/src/components/members/MembersPage.InvitePanel.test.tsx
+++ b/src/components/members/MembersPage.InvitePanel.test.tsx
@@ -5,7 +5,7 @@ import membersEn from "@/i18n/locales/en/members.json";
 
 const h = vi.hoisted(() => ({
   searchUsers: vi.fn(),
-  inviteUserById: vi.fn(),
+  inviteUserWithRoles: vi.fn(),
   inviteByEmailAddress: vi.fn(),
   assign: vi.fn(),
   reload: vi.fn(),
@@ -50,7 +50,7 @@ vi.mock("@/services/teamService", () => ({
 // only the network calls themselves are stubbed.
 vi.mock("@/services/vaultShare", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/services/vaultShare")>();
-  return { ...actual, inviteUserById: h.inviteUserById, inviteByEmailAddress: h.inviteByEmailAddress };
+  return { ...actual, inviteUserWithRoles: h.inviteUserWithRoles, inviteByEmailAddress: h.inviteByEmailAddress };
 });
 vi.mock("@/services/account", () => ({ getMyHandle: h.getMyHandle }));
 vi.mock("@/services/teamActionFeedback", () => ({
@@ -105,7 +105,7 @@ const inA = { user_id: "inA", handle: "included-alpha-3140", public_key: "pkA" }
 
 beforeEach(() => {
   h.searchUsers.mockReset();
-  h.inviteUserById.mockReset();
+  h.inviteUserWithRoles.mockReset();
   h.inviteByEmailAddress.mockReset();
   h.assign.mockReset();
   h.reload.mockReset().mockResolvedValue(undefined);
@@ -170,10 +170,10 @@ test("existingIds filter: excluded id absent from rendered results, included id 
   expect(screen.queryByText("excluded-bravo-9022")).toBeNull();
 });
 
-test("add success (not at limit): the chosen role travels with inviteUserById, not a doomed post-hoc assignment", async () => {
+test("add success (not at limit): the chosen roles travel with the invite, not a doomed post-hoc assignment", async () => {
   vi.useFakeTimers();
   h.searchUsers.mockResolvedValue([inA]);
-  h.inviteUserById.mockResolvedValue({ status: "pending" });
+  h.inviteUserWithRoles.mockResolvedValue({ status: "pending" });
   render(<InvitePanel {...baseProps} />);
 
   await typeAndDebounce("in");
@@ -182,21 +182,21 @@ test("add success (not at limit): the chosen role travels with inviteUserById, n
   fireEvent.click(screen.getByText("included-alpha-3140"));
 
   await waitFor(() => expect(baseProps.onMemberAdded).toHaveBeenCalled());
-  expect(h.inviteUserById).toHaveBeenCalledWith({
-    teamId: "t1", userId: "inA", handle: "included-alpha-3140", roleName: "member", roleId: "r-mem",
+  expect(h.inviteUserWithRoles).toHaveBeenCalledWith({
+    teamId: "t1", userId: "inA", handle: "included-alpha-3140", roleIds: ["r-mem"], roles: teamRoles,
   });
   expect(h.assign).not.toHaveBeenCalled();
   expect(h.reload).toHaveBeenCalled();
 });
 
-test("add resolves already_member: extra selected roles (beyond the first) are assigned", async () => {
+test("every ticked role is handed to the shared invite, in selection order", async () => {
   vi.useFakeTimers();
   const roles: TeamRole[] = [
     ...teamRoles,
     { id: "r-editor", team_id: "t1", name: "editor", is_builtin: true, permissions: 0, position: 2, created_at: "" },
   ];
   h.searchUsers.mockResolvedValue([inA]);
-  h.inviteUserById.mockResolvedValue({ status: "already_member" });
+  h.inviteUserWithRoles.mockResolvedValue({ status: "already_member" });
   h.assign.mockResolvedValue(undefined);
   render(<InvitePanel {...baseProps} teamRoles={roles} />);
 
@@ -206,11 +206,12 @@ test("add resolves already_member: extra selected roles (beyond the first) are a
   fireEvent.click(screen.getByText("included-alpha-3140"));
 
   await waitFor(() => expect(baseProps.onMemberAdded).toHaveBeenCalled());
-  expect(h.inviteUserById).toHaveBeenCalledWith(expect.objectContaining({ roleName: "member", roleId: "r-mem" }));
-  expect(h.assign).toHaveBeenCalledWith("t1", "inA", "r-editor");
+  expect(h.inviteUserWithRoles).toHaveBeenCalledWith(expect.objectContaining({ roleIds: ["r-mem", "r-editor"], roles }));
+  // Applying them is the shared helper's job, not the panel's.
+  expect(h.assign).not.toHaveBeenCalled();
 });
 
-test("add at seat limit: inviteUserById NOT called, BuySeatsModal shown with that user", async () => {
+test("add at seat limit: no invite call, BuySeatsModal shown with that user", async () => {
   h.usedSeats = 3;
   h.totalSeats = 3;
   vi.useFakeTimers();
@@ -221,7 +222,7 @@ test("add at seat limit: inviteUserById NOT called, BuySeatsModal shown with tha
   vi.useRealTimers();
   fireEvent.click(screen.getByText("included-alpha-3140"));
 
-  expect(h.inviteUserById).not.toHaveBeenCalled();
+  expect(h.inviteUserWithRoles).not.toHaveBeenCalled();
   const modal = await screen.findByTestId("buy-seats-modal");
   expect(modal.dataset.pendingUser).toBe("inA");
 });
@@ -229,7 +230,7 @@ test("add at seat limit: inviteUserById NOT called, BuySeatsModal shown with tha
 test("add rejects {code:402} (not at limit): BuySeatsModal shown, no error text", async () => {
   vi.useFakeTimers();
   h.searchUsers.mockResolvedValue([inA]);
-  h.inviteUserById.mockRejectedValue(Object.assign(new Error("x"), { code: 402 }));
+  h.inviteUserWithRoles.mockRejectedValue(Object.assign(new Error("x"), { code: 402 }));
   render(<InvitePanel {...baseProps} />);
 
   await typeAndDebounce("in");
@@ -244,7 +245,7 @@ test("add rejects {code:402} (not at limit): BuySeatsModal shown, no error text"
 test("add rejects Error with '402' in message (no code prop): BuySeatsModal shown", async () => {
   vi.useFakeTimers();
   h.searchUsers.mockResolvedValue([inA]);
-  h.inviteUserById.mockRejectedValue(new Error("boom 402 detail"));
+  h.inviteUserWithRoles.mockRejectedValue(new Error("boom 402 detail"));
   render(<InvitePanel {...baseProps} />);
 
   await typeAndDebounce("in");
@@ -260,7 +261,7 @@ test("add rejects generic error (no 402): named inviteFailed message shown, BuyS
   h.t.mockImplementation(interpolatingT);
   vi.useFakeTimers();
   h.searchUsers.mockResolvedValue([inA]);
-  h.inviteUserById.mockRejectedValue(new Error("nope"));
+  h.inviteUserWithRoles.mockRejectedValue(new Error("nope"));
   render(<InvitePanel {...baseProps} />);
 
   await typeAndDebounce("in");
@@ -275,7 +276,7 @@ test("add rejects a transport failure (no HTTP status): named message shown, no 
   h.t.mockImplementation(interpolatingT);
   vi.useFakeTimers();
   h.searchUsers.mockResolvedValue([inA]);
-  h.inviteUserById.mockRejectedValue(
+  h.inviteUserWithRoles.mockRejectedValue(
     new Error("error sending request for url (http://v68-server:8080/v1/teams/a5c2d19d/invite)"),
   );
   const { container } = render(<InvitePanel {...baseProps} />);
@@ -386,7 +387,7 @@ test("no role selected: the Add action is disabled, a hint is shown, clicking do
   const addButton = screen.getByText("included-alpha-3140").closest("button") as HTMLButtonElement;
   expect(addButton.disabled).toBe(true);
   fireEvent.click(addButton);
-  expect(h.inviteUserById).not.toHaveBeenCalled();
+  expect(h.inviteUserWithRoles).not.toHaveBeenCalled();
 });
 
 test("no role selected: the email-invite action is disabled, clicking does nothing", async () => {

--- a/src/components/members/MembersPage.tsx
+++ b/src/components/members/MembersPage.tsx
@@ -36,7 +36,7 @@ import { guestCapFor, inviteSessionOf, memberHasAccess, seatUsage, sessionDispla
 import { SeatsMeter } from "@/components/members/SeatsMeter";
 import { ROLE_META, RoleToggleChip } from "@/components/members/roleChips";
 import { useUserSearch, type UserSearchResult } from "@/hooks/useUserSearch";
-import { inviteUserById, inviteByEmailAddress, inviteFailureReason } from "@/services/vaultShare";
+import { inviteUserWithRoles, inviteByEmailAddress, inviteFailureReason } from "@/services/vaultShare";
 import { ConvertToTeamGate } from "@/components/vault-share/ConvertToTeamGate";
 import { assignableRoles, leastPrivilegedRole } from "@/components/vault-share/vaultShareModel";
 
@@ -668,7 +668,6 @@ interface InvitePanelProps {
 
 export function InvitePanel({ teamId, existingIds, teamRoles, onClose, onMemberAdded }: InvitePanelProps) {
   const { t } = useTranslation();
-  const assignMemberRole = useTeamStore((s) => s.assignMemberRole);
   const { usedSeats, totalSeats, load: reloadSubscription } = useSubscriptionStore();
   const { query, setQuery, results, searching, open, setOpen, inputRef, dropdownRef, reset } =
     useUserSearch(existingIds);
@@ -720,20 +719,13 @@ export function InvitePanel({ teamId, existingIds, teamRoles, onClose, onMemberA
     if (isAtSeatLimit) { setBuySeatsFor(user); setOpen(false); return; }
     setAdding(user.user_id); setError(""); setSuccess("");
     try {
-      const [firstRoleId, ...restRoleIds] = selectedRoleIds;
-      const firstRoleName = builtinRoles.find((r) => r.id === firstRoleId)?.name ?? fallbackRoleName;
-      const result = await inviteUserById({
+      const result = await inviteUserWithRoles({
         teamId,
         userId: user.user_id,
         handle: user.handle,
-        roleName: firstRoleName,
-        roleId: firstRoleId,
+        roleIds: selectedRoleIds,
+        roles: teamRoles,
       });
-      if (result.status === "already_member") {
-        for (const roleId of restRoleIds) {
-          await assignMemberRole(teamId, user.user_id, roleId).catch(() => {});
-        }
-      }
       reset();
       setSuccess(result.status === "pending"
         ? t("members.toast.invitationSentToUser", { name: user.handle })

--- a/src/components/settings/sections/VaultsSection.PrivateVaultMembersPanel.test.tsx
+++ b/src/components/settings/sections/VaultsSection.PrivateVaultMembersPanel.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, cleanup, fireEvent, waitFor, act } from "@testing-libra
 const h = vi.hoisted(() => ({
   searchUsers: vi.fn(async () => [] as { user_id: string; handle: string; public_key: string }[]),
   openBillingCheckout: vi.fn(async () => {}),
+  convertVaultToTeam: vi.fn(async () => "t-new"),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -29,6 +30,9 @@ vi.mock("@/services/teamActionFeedback", () => ({
 }));
 vi.mock("@/services/billingCheckout", () => ({ openBillingCheckout: h.openBillingCheckout }));
 vi.mock("@/services/teamVaultActivation", () => ({ markTeamVaultLoadedAfterLocalActivation: vi.fn() }));
+// The conversion itself is covered in vaultConvert.test.ts; what matters here is
+// that it only ever runs from behind the consent gate.
+vi.mock("@/services/vaultConvert", () => ({ convertVaultToTeam: h.convertVaultToTeam }));
 
 import { PrivateVaultMembersPanel } from "./VaultsSection";
 import { useSubscriptionStore } from "@/stores/subscriptionStore";
@@ -49,6 +53,7 @@ beforeEach(() => {
   localStorage.clear();
   h.searchUsers.mockReset().mockResolvedValue([]);
   h.openBillingCheckout.mockReset().mockResolvedValue(undefined);
+  h.convertVaultToTeam.mockReset().mockResolvedValue("t-new");
   openCloudAuth.mockReset();
   baseProps.onTeamCreated = vi.fn();
   useSubscriptionStore.setState({ isTeams: true, accountMode: "server" });
@@ -123,12 +128,8 @@ test("search debounce: no search under 2 chars, one call at 250ms rendering resu
   expect(screen.getByText("amber-lynx-4410")).toBeTruthy();
 });
 
-test("handleAdd error: createTeam rejects → error surfaced, setVaultTeamId not reached", async () => {
-  const createTeam = vi.fn(async () => { throw new Error("boom"); });
-  const setVaultTeamId = vi.fn();
-  useTeamStore.setState({ createTeam });
-  useVaultStore.setState({ setVaultTeamId });
-
+/** Renders the panel, searches, and picks the one result — the act that used to convert on the spot. */
+async function pickUser() {
   vi.useFakeTimers();
   h.searchUsers.mockResolvedValue([{ user_id: "u1", handle: "amber-lynx-4410", public_key: "pk" }]);
   render(<PrivateVaultMembersPanel {...baseProps} />);
@@ -136,11 +137,68 @@ test("handleAdd error: createTeam rejects → error surfaced, setVaultTeamId not
   fireEvent.change(input, { target: { value: "al" } });
   await act(async () => { await vi.advanceTimersByTimeAsync(250); });
   vi.useRealTimers();
-
   fireEvent.click(screen.getByText("amber-lynx-4410"));
+}
 
-  expect(await screen.findByText("boom")).toBeTruthy();
-  expect(createTeam).toHaveBeenCalledWith("My Vault");
-  expect(setVaultTeamId).not.toHaveBeenCalled();
+const memberRole = {
+  id: "r-mem", team_id: "t-new", name: "member",
+  is_builtin: true, permissions: 0, position: 1, created_at: "",
+};
+
+test("picking someone asks for consent first — nothing is converted yet", async () => {
+  await pickUser();
+
+  expect(await screen.findByText("members.convert.confirm")).toBeTruthy();
+  expect(h.convertVaultToTeam).not.toHaveBeenCalled();
   expect(baseProps.onTeamCreated).not.toHaveBeenCalled();
+});
+
+test("cancelling the consent gate leaves the vault private and adds nobody", async () => {
+  const addMemberById = vi.fn(async () => ({ status: "pending" as const }));
+  useTeamStore.setState({ addMemberById });
+
+  await pickUser();
+  fireEvent.click(await screen.findByText("members.convert.cancel"));
+
+  await waitFor(() => expect(screen.queryByText("members.convert.confirm")).toBeNull());
+  expect(h.convertVaultToTeam).not.toHaveBeenCalled();
+  expect(addMemberById).not.toHaveBeenCalled();
+  expect(baseProps.onTeamCreated).not.toHaveBeenCalled();
+});
+
+test("confirming converts, then invites the picked user as a member", async () => {
+  const addMemberById = vi.fn(async () => ({ status: "pending" as const }));
+  useTeamStore.setState({ addMemberById, rolesByTeam: { "t-new": [memberRole] } });
+
+  await pickUser();
+  fireEvent.click(await screen.findByText("members.convert.confirm"));
+
+  await waitFor(() => expect(baseProps.onTeamCreated).toHaveBeenCalledWith("t-new"));
+  expect(h.convertVaultToTeam).toHaveBeenCalledWith("v1", "My Vault");
+  expect(addMemberById).toHaveBeenCalledWith("t-new", "u1", "member");
+});
+
+test("a failed conversion keeps the gate up and invites nobody", async () => {
+  const addMemberById = vi.fn(async () => ({ status: "pending" as const }));
+  useTeamStore.setState({ addMemberById });
+  h.convertVaultToTeam.mockRejectedValue(new Error("boom"));
+
+  await pickUser();
+  fireEvent.click(await screen.findByText("members.convert.confirm"));
+
+  await waitFor(() => expect(h.convertVaultToTeam).toHaveBeenCalled());
+  expect(screen.getByText("members.convert.confirm")).toBeTruthy();
+  expect(addMemberById).not.toHaveBeenCalled();
+  expect(baseProps.onTeamCreated).not.toHaveBeenCalled();
+});
+
+test("a failed invite still hands the caller the team the conversion created", async () => {
+  const addMemberById = vi.fn(async () => { throw new Error("nope"); });
+  useTeamStore.setState({ addMemberById, rolesByTeam: { "t-new": [memberRole] } });
+
+  await pickUser();
+  fireEvent.click(await screen.findByText("members.convert.confirm"));
+
+  expect(await screen.findByText("nope")).toBeTruthy();
+  expect(baseProps.onTeamCreated).toHaveBeenCalledWith("t-new");
 });

--- a/src/components/settings/sections/VaultsSection.tsx
+++ b/src/components/settings/sections/VaultsSection.tsx
@@ -19,7 +19,9 @@ import { MiniAvatar, avatarColor } from "@/components/shared/AvatarStack";
 import { UserSearchField } from "@/components/shared/UserSearchField";
 import { ROLE_META, RoleToggleChip } from "@/components/members/roleChips";
 import { runTeamAction } from "@/services/teamActionFeedback";
-import { createTeamVaultFromVault } from "@/services/vaultConvert";
+import { inviteUserWithRoles } from "@/services/vaultShare";
+import { assignableRoles, leastPrivilegedRole } from "@/components/vault-share/vaultShareModel";
+import { ConvertToTeamGate } from "@/components/vault-share/ConvertToTeamGate";
 import { reloadLocalVaultObjectStores } from "@/services/vaultTeamMigration";
 
 import { openBillingCheckout } from "@/services/billingCheckout";
@@ -73,8 +75,6 @@ function InviteBar({ teamId, existingIds, roles, canInvite, onMemberAdded }: {
   onMemberAdded?: () => void;
 }) {
   const { t } = useTranslation();
-  const addMemberById = useTeamStore((s) => s.addMemberById);
-  const assignMemberRole = useTeamStore((s) => s.assignMemberRole);
   const { usedSeats, totalSeats, load: reloadSubscription } = useSubscriptionStore();
   const { query, setQuery, results, searching, open, setOpen, inputRef, dropdownRef, reset } =
     useUserSearch(existingIds);
@@ -87,10 +87,7 @@ function InviteBar({ teamId, existingIds, roles, canInvite, onMemberAdded }: {
 
   const isAtSeatLimit = seatAvailability(usedSeats, totalSeats).atLimit;
 
-  const inviteRoles = useMemo(
-    () => roles.filter((r) => !(r.is_builtin && r.name === "owner")).sort((a, b) => a.position - b.position),
-    [roles],
-  );
+  const inviteRoles = useMemo(() => assignableRoles(roles), [roles]);
   const defaultMemberRoleId = useMemo(() => inviteRoles.find((r) => r.is_builtin && r.name === "member")?.id, [inviteRoles]);
 
   useEffect(() => {
@@ -101,8 +98,12 @@ function InviteBar({ teamId, existingIds, roles, canInvite, onMemberAdded }: {
   const toggleRole = (roleId: string) =>
     setSelectedRoleIds((prev) => prev.includes(roleId) ? prev.filter((id) => id !== roleId) : [...prev, roleId]);
 
+  // With nothing ticked the stand-in is the least-privileged role, never "member":
+  // an empty selection is a lost choice, not a request for more access.
   const primaryRoleName = useMemo(
-    () => inviteRoles.find((r) => selectedRoleIds.includes(r.id))?.name ?? "member",
+    () => inviteRoles.find((r) => selectedRoleIds.includes(r.id))?.name
+      ?? leastPrivilegedRole(inviteRoles)?.name
+      ?? "connect-only",
     [selectedRoleIds, inviteRoles],
   );
 
@@ -113,14 +114,13 @@ function InviteBar({ teamId, existingIds, roles, canInvite, onMemberAdded }: {
     setAdding(user.user_id);
     setError(""); setSuccess("");
     try {
-      await runTeamAction({
-        pending: t("settings.vaults.members.adding", { name: user.handle }),
-        success: t("settings.vaults.members.added", { name: user.handle }),
-        run: () => addMemberById(teamId, user.user_id),
+      await inviteUserWithRoles({
+        teamId,
+        userId: user.user_id,
+        handle: user.handle,
+        roleIds: selectedRoleIds,
+        roles,
       });
-      for (const roleId of selectedRoleIds) {
-        await assignMemberRole(teamId, user.user_id, roleId).catch(() => {});
-      }
       reset();
       await reloadSubscription();
       onMemberAdded?.();
@@ -636,31 +636,38 @@ export function PrivateVaultMembersPanel({
   const { t } = useTranslation();
   const { isTeams, accountMode } = useSubscriptionStore();
   const openCloudAuth = useUIStore((s) => s.openCloudAuth);
-  const { loadRoles, addMemberById, assignMemberRole } = useTeamStore();
+  const { loadRoles } = useTeamStore();
 
   const { query, setQuery, results, searching, open, setOpen, inputRef, dropdownRef, reset } = useUserSearch();
   const [adding, setAdding] = useState<string | null>(null);
+  const [pendingUser, setPendingUser] = useState<UserSearchResult | null>(null);
   const [error, setError] = useState("");
 
-  const handleAdd = async (user: UserSearchResult) => {
-    setAdding(user.user_id);
-    setError("");
+  // Picking someone here used to convert the vault on the spot: a team appeared,
+  // key custody moved to the server and the vault stopped opening offline, none
+  // of it announced. The conversion now happens behind the same consent gate the
+  // other two share surfaces use, and only the invite runs after it.
+  const inviteAfterConvert = async (teamId: string, user: UserSearchResult) => {
+    setPendingUser(null);
     try {
-      const teamId = await createTeamVaultFromVault(vaultId, vaultName);
-      await addMemberById(teamId, user.user_id);
       await loadRoles(teamId);
-      const memberRole = useTeamStore.getState().rolesByTeam[teamId]?.find(
-        (r) => r.is_builtin && r.name === "member",
-      );
-      if (memberRole) {
-        await assignMemberRole(teamId, user.user_id, memberRole.id);
-      }
+      const roles = useTeamStore.getState().rolesByTeam[teamId] ?? [];
+      const memberRole = roles.find((r) => r.is_builtin && r.name === "member");
+      await inviteUserWithRoles({
+        teamId,
+        userId: user.user_id,
+        handle: user.handle,
+        roleIds: memberRole ? [memberRole.id] : [],
+        roles,
+      });
       reset();
-      onTeamCreated(teamId);
     } catch (e) {
       setError(e instanceof Error ? e.message : t("settings.vaults.members.failedToAdd"));
     } finally {
       setAdding(null);
+      // The vault is a team vault either way — the caller must switch panels even
+      // if the invite failed, or the next attempt converts an already-converted vault.
+      onTeamCreated(teamId);
     }
   };
 
@@ -697,6 +704,14 @@ export function PrivateVaultMembersPanel({
 
   return (
     <div>
+      {pendingUser && (
+        <ConvertToTeamGate
+          vaultId={vaultId}
+          vaultName={vaultName}
+          onCancel={() => { setPendingUser(null); setAdding(null); }}
+          onConverted={(teamId) => void inviteAfterConvert(teamId, pendingUser)}
+        />
+      )}
       <div className="rounded-xl overflow-hidden mb-4" style={{ border: "1px solid var(--t-border)" }}>
         <div className="flex items-center gap-3 px-4 py-2.5">
           <MiniAvatar name={myUserId} size={30} />
@@ -727,7 +742,7 @@ export function PrivateVaultMembersPanel({
         dropdownRef={dropdownRef}
         adding={adding}
         addLabel={t("settings.vaults.members.addAsMember")}
-        onAdd={(user) => void handleAdd(user)}
+        onAdd={(user) => { setError(""); setAdding(user.user_id); setOpen(false); setPendingUser(user); }}
         emptyLabel={t("settings.vaults.members.noUsersFound")}
       />
       {error && <p className="text-xs mt-1.5 px-1" style={{ color: "var(--t-status-error)" }}>{error}</p>}

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -622,7 +622,6 @@
         "searchUserPlaceholder": "Search by handle or email…",
         "noUsersFound": "No users found",
         "addAsMember": "Add as Member",
-        "adding": "Adding {{name}}…",
         "added": "{{name}} added",
         "inviting": "Inviting {{email}}…",
         "invitationSent": "Invitation sent to {{email}}",

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -622,7 +622,6 @@
         "searchUserPlaceholder": "Rechercher par pseudo ou e-mail…",
         "noUsersFound": "Aucun utilisateur trouvé",
         "addAsMember": "Ajouter comme membre",
-        "adding": "Ajout de {{name}}…",
         "added": "{{name}} ajouté",
         "inviting": "Invitation de {{email}}…",
         "invitationSent": "Invitation envoyée à {{email}}",

--- a/src/i18n/locales/ru/settings.json
+++ b/src/i18n/locales/ru/settings.json
@@ -630,7 +630,6 @@
         "searchUserPlaceholder": "Поиск по нику или email…",
         "noUsersFound": "Пользователи не найдены",
         "addAsMember": "Добавить как участника",
-        "adding": "Добавление {{name}}…",
         "added": "{{name}} добавлен",
         "inviting": "Приглашение {{email}}…",
         "invitationSent": "Приглашение отправлено на {{email}}",

--- a/src/i18n/locales/zh/settings.json
+++ b/src/i18n/locales/zh/settings.json
@@ -490,7 +490,6 @@
         "searchUserPlaceholder": "按用户名或邮箱搜索…",
         "noUsersFound": "未找到用户",
         "addAsMember": "添加为成员",
-        "adding": "正在添加 {{name}}…",
         "added": "已添加 {{name}}",
         "inviting": "正在邀请 {{email}}…",
         "invitationSent": "已发送邀请给 {{email}}",

--- a/src/services/vaultShare.test.ts
+++ b/src/services/vaultShare.test.ts
@@ -1,4 +1,5 @@
 import { test, expect, vi, beforeEach } from "vitest";
+import type { TeamRole } from "@/stores/teamStore";
 
 const h = vi.hoisted(() => ({
   addMemberById: vi.fn(),
@@ -17,7 +18,7 @@ vi.mock("@/services/teamActionFeedback", () => ({
 }));
 vi.mock("@/i18n", () => ({ default: { t: (k: string) => k } }));
 
-import { inviteUserById, inviteByEmailAddress, inviteFailureReason } from "./vaultShare";
+import { inviteUserById, inviteUserWithRoles, inviteByEmailAddress, inviteFailureReason } from "./vaultShare";
 
 beforeEach(() => {
   h.addMemberById.mockReset();
@@ -65,4 +66,53 @@ test("a transport failure's raw URL is never returned as the reason", () => {
 
 test("a real HTTP failure's short, already-translated message passes through unchanged", () => {
   expect(inviteFailureReason(new Error("User not found"))).toBe("User not found");
+});
+
+const ROLES: TeamRole[] = [
+  { id: "r-owner", team_id: "t1", name: "owner", is_builtin: true, permissions: 0, position: 0, created_at: "" },
+  { id: "r-mem", team_id: "t1", name: "member", is_builtin: true, permissions: 0, position: 1, created_at: "" },
+  { id: "r-editor", team_id: "t1", name: "editor", is_builtin: true, permissions: 0, position: 2, created_at: "" },
+  { id: "r-connect", team_id: "t1", name: "connect-only", is_builtin: true, permissions: 0, position: 3, created_at: "" },
+];
+
+const withRoles = (roleIds: string[]) =>
+  inviteUserWithRoles({ teamId: "t1", userId: "u1", handle: "bob-builder", roleIds, roles: ROLES });
+
+test("the first chosen role travels with the invitation", async () => {
+  h.addMemberById.mockResolvedValue({ status: "pending" });
+  await withRoles(["r-editor", "r-mem"]);
+  expect(h.addMemberById).toHaveBeenCalledWith("t1", "u1", "editor");
+});
+
+test("a pending invitee gets no role assignment, however many roles were ticked", async () => {
+  h.addMemberById.mockResolvedValue({ status: "pending" });
+  await withRoles(["r-editor", "r-mem"]);
+  expect(h.assignMemberRole).not.toHaveBeenCalled();
+});
+
+test("an already-member gets every ticked role, the first one included", async () => {
+  h.addMemberById.mockResolvedValue({ status: "already_member" });
+  h.assignMemberRole.mockResolvedValue(undefined);
+  await withRoles(["r-editor", "r-mem"]);
+  expect(h.assignMemberRole).toHaveBeenCalledWith("t1", "u1", "r-editor");
+  expect(h.assignMemberRole).toHaveBeenCalledWith("t1", "u1", "r-mem");
+});
+
+test("no role ticked falls back to the least-privileged role, never member", async () => {
+  h.addMemberById.mockResolvedValue({ status: "pending" });
+  await withRoles([]);
+  expect(h.addMemberById).toHaveBeenCalledWith("t1", "u1", "connect-only");
+});
+
+test("an unknown role id is not treated as a choice", async () => {
+  h.addMemberById.mockResolvedValue({ status: "pending" });
+  await withRoles(["r-gone"]);
+  expect(h.addMemberById).toHaveBeenCalledWith("t1", "u1", "connect-only");
+});
+
+test("with no assignable role at all, nothing is assigned after an already_member result", async () => {
+  h.addMemberById.mockResolvedValue({ status: "already_member" });
+  await inviteUserWithRoles({ teamId: "t1", userId: "u1", handle: "bob-builder", roleIds: [], roles: [] });
+  expect(h.addMemberById).toHaveBeenCalledWith("t1", "u1", "connect-only");
+  expect(h.assignMemberRole).not.toHaveBeenCalled();
 });

--- a/src/services/vaultShare.ts
+++ b/src/services/vaultShare.ts
@@ -1,7 +1,9 @@
 import i18n from "@/i18n";
 import { useTeamStore } from "@/stores/teamStore";
+import type { TeamRole } from "@/stores/teamStore";
 import { inviteByEmail } from "@/services/teamService";
 import { runTeamAction } from "@/services/teamActionFeedback";
+import { leastPrivilegedRole } from "@/components/vault-share/vaultShareModel";
 
 const URL_IN_MESSAGE = /https?:\/\//i;
 
@@ -32,7 +34,7 @@ export async function inviteUserById(args: {
   userId: string;
   handle: string;
   roleName: string;
-  roleId: string;
+  roleId?: string;
 }): Promise<{ status: "pending" | "already_member" }> {
   const { teamId, userId, handle, roleName, roleId } = args;
   const { addMemberById, assignMemberRole } = useTeamStore.getState();
@@ -47,8 +49,50 @@ export async function inviteUserById(args: {
     run: () => addMemberById(teamId, userId, roleName),
   });
 
-  if (result.status === "already_member") {
+  if (result.status === "already_member" && roleId) {
     await assignMemberRole(teamId, userId, roleId);
+  }
+  return result;
+}
+
+/**
+ * Invite a known user with a set of chosen roles — the one shape every invite
+ * surface uses.
+ *
+ * Only the first role can travel on the invitation, so the rest are assigned
+ * afterwards and only for someone who is already a member; for a pending
+ * invitee there is no `team_members` row to assign them to.
+ *
+ * With nothing chosen the fallback is the least-privileged assignable role,
+ * never "member": callers disable their invite actions without a selection, so
+ * reaching here at all means the choice was lost rather than made.
+ */
+export async function inviteUserWithRoles(args: {
+  teamId: string;
+  userId: string;
+  handle: string;
+  roleIds: string[];
+  roles: TeamRole[];
+}): Promise<{ status: "pending" | "already_member" }> {
+  const { teamId, userId, handle, roleIds, roles } = args;
+  const chosen = roleIds.map((id) => roles.find((r) => r.id === id)).filter((r): r is TeamRole => !!r);
+  const [first, ...rest] = chosen.length > 0 ? chosen : [leastPrivilegedRole(roles)].filter((r): r is TeamRole => !!r);
+
+  const result = await inviteUserById({
+    teamId,
+    userId,
+    handle,
+    roleName: first?.name ?? "connect-only",
+    roleId: first?.id,
+  });
+
+  if (result.status === "already_member") {
+    // Best-effort: the invite itself already landed, so one extra role that
+    // fails to apply must not report the whole invite as failed.
+    const { assignMemberRole } = useTeamStore.getState();
+    for (const role of rest) {
+      await assignMemberRole(teamId, userId, role.id).catch(() => {});
+    }
   }
   return result;
 }


### PR DESCRIPTION
Closes the residual that #71 handed to #68: the last private→team conversion that happened without asking.

### The un-gated path

`ConvertToTeamGate` was already wired into `MembersPage` and `VaultShareSheet`, but `PrivateVaultMembersPanel.handleAdd` in `VaultsSection.tsx` still called `createTeamVaultFromVault` directly. So Settings → Vaults was the one surface where picking a person silently created a team, moved the vault's key custody to the server and ended offline access — while the same act from the other two surfaces showed the full cost list first.

Picking someone there now opens the same gate, and the invite runs only after consent. `createTeamVaultFromVault` is left with no un-gated caller.

### The #179 role bug had two more copies

Both invite handlers in `VaultsSection.tsx` still carried the shape fixed for the Members page in #179: `addMemberById` creates a *pending invitation*, not a `team_members` row, so the follow-up `assignMemberRole` 404s — and both swallowed it with `.catch(() => {})`. Every invitee from Settings → Vaults silently landed on the default role.

All three callers now go through one shared `inviteUserWithRoles` in `services/vaultShare.ts`: the first chosen role travels on the invitation, the rest are applied only for someone already a member.

Two smaller things in the same file, both matching what the Members page already does:

- An empty role selection fell back to `member`; it now falls back to the least-privileged assignable role. An empty selection is a lost choice, not a request for more access.
- `inviteRoles` was a third hand-rolled copy of `assignableRoles()`.

`settings.vaults.members.adding` has no remaining caller and is dropped from all four locales.

### Verified against a running server

Driven in the app against an isolated server (self-host mode, three accounts), not only in tests:

- Picking a person in Settings → Vaults showed the consent modal with **0 requests to `/v1/teams`** and **0 rows in `teams`** — the old code would already have created the team.
- Cancel left both at zero and added nobody.
- Confirm converted, then logged `Pending invitation created for existing user … role=member`.
- From the Members page invite panel with only `connect-only` ticked, the invitation row carried `role=connect-only`.
- **Zero 4xx/5xx responses** across the whole run — no doomed role assignment on either path.

Final invitation rows: `bob → member`, `carol → connect-only`.

### Tests

`vaultShare.test.ts` covers the shared helper (first role on the invitation, extras only for `already_member`, unknown or empty selection falling back to least-privileged). The private-panel tests now assert the gate: nothing converts before consent, cancel converts nothing and invites nobody, confirm converts then invites, a failed conversion keeps the gate up, and a failed invite still hands the caller the team the conversion created — otherwise the next attempt would convert an already-converted vault into a second team.

tsc clean; `src/components/members`, `src/components/vault-share`, `src/components/settings`, `src/services`, `src/i18n` all pass (158 files, 1322 tests).

### Noted, not fixed

`TeamVaultPanel` — the component holding `InviteBar` — has **no render site in the app**; only its own test file imports it. That copy of the bug is therefore not user-reachable today. Deleting the dead component felt out of scope here.

Still open on #68: the share sheet / explicit Share verb, and vault invite links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gY5k7XbeR5zoTXdzsuWxF
