### PR TITLE
style(vaults): prune narrative comments from the join-links work

### DIFF
--- a/src/components/layout/VaultHeader.tsx
+++ b/src/components/layout/VaultHeader.tsx
@@ -102,10 +102,6 @@ export function MembersStack({
         </button>
       )}
 
-      {/* The Share verb (issue #68). This affordance already opened the share
-          sheet; it just never said so — a bare "+" with an "Invite member"
-          tooltip. Naming it is the whole of the explicit verb: no second entry
-          point, and no second surface to keep in step with this one. */}
       <button
         type="button"
         onClick={toggleOpen}
@@ -134,9 +130,7 @@ export function MembersStack({
         onClose={() => setOpen(false)}
         anchorRef={ref}
         width={320}
-        // The default 320 was sized for a short members list. This surface now
-        // carries three tabs, and at 320 the Links tab's Create button sat
-        // below the fold behind a scroll.
+        // 320 leaves the Links tab's Create button below the fold.
         maxHeight={480}
         align="right"
         gap={4}
@@ -299,10 +293,8 @@ export default function VaultHeader() {
 
       {/* Right zone: online members */}
       <div className="flex items-center justify-end min-w-0">
-        {/* Shown for a private vault too. The sheet's own `!teamId` branch is
-            the conversion consent gate, so hiding the verb until a team already
-            exists put it everywhere except the one place it matters most. A
-            private vault simply has no avatar stack to show beside it. */}
+        {/* Shown for a private vault too: the sheet's `!teamId` branch is the
+            conversion consent gate. */}
         {activeVaultId && (accountMode === "server" || team) && (
           <MembersStack
             members={members ?? []}

--- a/src/components/terminal/DeepLinkConfirmModal.test.tsx
+++ b/src/components/terminal/DeepLinkConfirmModal.test.tsx
@@ -375,8 +375,6 @@ test("a plugin-install link naming a disabled source installs nothing", async ()
   expect(fetchManifestMock).not.toHaveBeenCalled();
 });
 
-// ─── vault-join (issue #68) ───────────────────────────────────────────────────
-
 const acceptVaultJoin = async () => {
   await waitFor(() => expect(acceptButton("members.joinLinks.confirm.action").disabled).toBe(false));
   await userEvent.click(acceptButton("members.joinLinks.confirm.action"));
@@ -394,7 +392,6 @@ test("the sheet names the team, the role and the inviter before accept does anyt
   render(<DeepLinkConfirmModal />);
   await waitFor(() => expect(screen.getByText("members.joinLinks.confirm.title")).toBeTruthy());
   expect(screen.getByText("members.joinLinks.confirm.bodyNamed")).toBeTruthy();
-  // The one thing a joiner must not assume: the link is not the key.
   expect(screen.getByText("members.joinLinks.confirm.keyFollowsLater")).toBeTruthy();
 });
 

--- a/src/components/terminal/deepLinkConfirmSpecs.tsx
+++ b/src/components/terminal/deepLinkConfirmSpecs.tsx
@@ -90,10 +90,7 @@ export interface ConfirmLoad {
   "vault-join": JoinGrantPreview;
 }
 
-/**
- * A refused grant is matched on the error's code, never on its message: the
- * message is translated, and a translated string is not a protocol.
- */
+/** Matched on code, never on the translated message. */
 function joinGrantErrorMessage(e: unknown, fallbackKey: string): TranslatableMessage {
   if (!(e instanceof JoinGrantError)) return { key: fallbackKey };
   switch (e.code) {
@@ -269,9 +266,7 @@ export const CONFIRM_SPECS: { [K in ConfirmRoute]: ConfirmSpec<K, ConfirmLoad[K]
     acceptLabelKey: "members.joinLinks.confirm.action",
     errorKey: "members.joinLinks.confirm.failed",
     errorMessage: joinGrantErrorMessage,
-    // Preview consumes no use, so a sheet the user closes costs the link
-    // nothing. The server re-checks revocation, expiry and exhaustion again
-    // inside the redemption transaction; this result is copy, not a decision.
+    // Consumes no use; the server re-validates inside the redeem transaction.
     load: ({ grantId, secret }) => previewJoinGrant(grantId, secret),
     details: (_intent, loaded, t) => ({
       title: loaded
@@ -286,15 +281,11 @@ export const CONFIRM_SPECS: { [K in ConfirmRoute]: ConfirmSpec<K, ConfirmLoad[K]
             })
           : t("members.joinLinks.confirm.body", { team: loaded.team_name, role: loaded.role })
         : t("members.joinLinks.confirm.loading"),
-      // The one thing the sheet must not let the user assume. A link confers
-      // membership; the vault key is wrapped per member with X25519 and only
-      // arrives once an online key-holder wraps it.
+      // A link confers membership only; the key follows separately.
       note: loaded ? t("members.joinLinks.confirm.keyFollowsLater") : undefined,
     }),
     accept: async (intent, _loaded) => {
-      // Sent so the roster row a key-holder reads is wrappable immediately.
-      // The server fills a NULL only and never overwrites — overwriting would
-      // orphan every vault key already wrapped to the old key.
+      // Sent so a key-holder can wrap for this member at once.
       const publicKey = await getMyX25519Keypair()
         .then(({ publicKey }) => publicKey)
         .catch(() => null);

--- a/src/components/vault-share/ChoiceChip.tsx
+++ b/src/components/vault-share/ChoiceChip.tsx
@@ -1,9 +1,3 @@
-/**
- * The one selectable chip of the share surface — roles, use counts, lifetimes.
- * Extracted because the same markup, the same accent-mix background and the same
- * `aria-pressed` had been written three times across this folder and would
- * otherwise drift a fourth time.
- */
 export function ChoiceChip({
   label,
   selected,
@@ -13,7 +7,6 @@ export function ChoiceChip({
   label: string;
   selected: boolean;
   onClick: () => void;
-  /** Role names are stored lowercase but read as proper nouns in the UI. */
   capitalize?: boolean;
 }) {
   return (

--- a/src/components/vault-share/JoinLinksTab.test.tsx
+++ b/src/components/vault-share/JoinLinksTab.test.tsx
@@ -19,8 +19,6 @@ vi.mock("@/services/teamJoinGrants", async (importOriginal) => ({
   createJoinGrant: h.create,
   revokeJoinGrant: h.revoke,
 }));
-// Passes the action straight through: the toast wrapper is not what these
-// tests are about, and mocking it keeps the notification store out of them.
 vi.mock("@/services/teamActionFeedback", () => ({
   runTeamAction: ({ run }: { run: () => Promise<unknown> }) => run(),
 }));
@@ -31,7 +29,6 @@ import { JoinLinksTab } from "./JoinLinksTab";
 const ROLES = [
   { id: "r1", team_id: "t1", name: "member", permissions: 0, is_builtin: true, position: 2, created_at: "" },
   { id: "r2", team_id: "t1", name: "connect-only", permissions: 0, is_builtin: true, position: 3, created_at: "" },
-  // Never offered by a link: the server answers 400 for it.
   { id: "r0", team_id: "t1", name: "owner", permissions: 0, is_builtin: true, position: 0, created_at: "" },
 ];
 
@@ -39,7 +36,6 @@ const inADay = () => new Date(Date.now() + 24 * 3600_000).toISOString();
 
 afterEach(() => { cleanup(); h.grants = []; vi.clearAllMocks(); });
 
-/** The mint form is folded away behind "New link"; open it. */
 const openForm = async () => {
   await waitFor(() => expect(screen.getByText("members.joinLinks.newLink")).toBeTruthy());
   fireEvent.click(screen.getByText("members.joinLinks.newLink"));
@@ -76,14 +72,12 @@ test("the freshly minted grant is the only one that offers its link", async () =
   const { rerender } = render(<JoinLinksTab teamId="t1" roles={ROLES} canMint />);
   await openForm();
 
-  // The reload after minting is what surfaces the row the link belongs to.
   h.grants = [{ id: "g1", role: "member", max_uses: 1, uses: 0, expires_at: inADay(), created_by: "u1" }];
   fireEvent.click(screen.getByText("members.joinLinks.create"));
   rerender(<JoinLinksTab teamId="t1" roles={ROLES} canMint />);
 
   const field = await waitFor(() => screen.getByDisplayValue(new RegExp(secret)));
   expect((field as HTMLInputElement).value).toContain("#vault-join?g=g1&k=");
-  // The secret rides in the fragment, so it never reaches a web server log.
   expect((field as HTMLInputElement).value.split("#")[0]).not.toContain(secret);
 });
 

--- a/src/components/vault-share/JoinLinksTab.tsx
+++ b/src/components/vault-share/JoinLinksTab.tsx
@@ -25,20 +25,6 @@ interface Props {
   canMint: boolean;
 }
 
-/**
- * Open join links for a team vault (issue #68).
- *
- * Two honesty rules drive the whole layout:
- *
- * 1. A link confers **membership, not vault access**. The vault key is wrapped
- *    per member with X25519, so it cannot travel in a link — the joiner waits
- *    in `awaiting_key` until an online key-holder wraps it. The tab says so
- *    rather than letting a manager assume the link is a key.
- * 2. The secret is returned by the mint call and **never again** — only its
- *    sha256 is stored. So a listed grant has no copyable URL, and this tab must
- *    not render a Copy button that would produce a broken link. Only the grant
- *    minted in this session, still held in memory, offers one.
- */
 export function JoinLinksTab({ teamId, roles, canMint }: Props) {
   const { t } = useTranslation();
   const [grants, setGrants] = useState<JoinGrant[] | null>(null);
@@ -46,8 +32,7 @@ export function JoinLinksTab({ teamId, roles, canMint }: Props) {
   const [minting, setMinting] = useState(false);
   const [creating, setCreating] = useState(false);
 
-  // The URL for a grant minted in this session, keyed by grant id. Never
-  // persisted: writing a live join secret to disk would outlive the tab.
+  // In memory only: a live join secret must not outlive the tab.
   const [freshLinks, setFreshLinks] = useState<Record<string, string>>({});
   const [copiedId, setCopiedId] = useState<string | null>(null);
 
@@ -57,8 +42,7 @@ export function JoinLinksTab({ teamId, roles, canMint }: Props) {
   const [ttlSecs, setTtlSecs] = useState<number>(TTL_PRESETS[2].secs);
 
   useEffect(() => {
-    // Least privileged of what this team actually offers, never a hardcoded
-    // "member": a link is unattended credential material.
+    // Least privileged available, never a hardcoded "member".
     if (!role && options.length > 0) setRole(options[options.length - 1].name as GrantableRole);
   }, [options, role]);
 
@@ -93,12 +77,10 @@ export function JoinLinksTab({ teamId, roles, canMint }: Props) {
         ...prev,
         [grant.id]: buildDeepLink({ route: "vault-join", grantId: grant.id, secret: grant.secret }),
       }));
-      // Folded away again so the new link, which is only readable now, is what
-      // the tab shows rather than the form that made it.
       setCreating(false);
       reload();
     } catch {
-      // runTeamAction already toasted the reason; the tab stays as it was.
+      // Already toasted.
     } finally {
       setMinting(false);
     }
@@ -158,7 +140,6 @@ export function JoinLinksTab({ teamId, roles, canMint }: Props) {
                 </span>
                 <span
                   className="text-[11px] text-(--t-text-secondary) flex-1 min-w-0"
-                  // The friendly count is rounded; this is the exact moment.
                   title={new Date(grant.expires_at).toLocaleString()}
                 >
                   {t("members.joinLinks.usesLeft", {
@@ -199,8 +180,7 @@ export function JoinLinksTab({ teamId, roles, canMint }: Props) {
                   </button>
                 </div>
               ) : (
-                // Not a failure — the server keeps only the secret's hash, so
-                // there is nothing to copy. Saying so beats a dead button.
+                // Only the hash is stored, so there is nothing to copy.
                 <span className="text-[10px] text-(--t-text-dim)">{t("members.joinLinks.secretNotRecoverable")}</span>
               )}
             </div>

--- a/src/components/vault-share/PeopleList.tsx
+++ b/src/components/vault-share/PeopleList.tsx
@@ -10,7 +10,7 @@ export type Person = {
   online: boolean;
   state: "member" | "pending" | "awaiting_key";
   invitationId?: string;
-  /** The member's X25519 public key, so "Grant now" can wrap the vault key. */
+  /** X25519 public key, so "Grant now" can wrap the vault key. */
   publicKey?: string;
 };
 
@@ -28,22 +28,15 @@ export function PeopleList({ people, canManage, onRemove, onRevoke, onGrantKey, 
   return (
     <div className="flex flex-col gap-1.5">
       {people.map((p) => (
-        // Two lines rather than one. At the popover's 320px, an untruncated
-        // handle plus a role chip plus "Grant now" plus remove squeezed the
-        // handle into a three-line column and the waiting note into a six-line
-        // one. The identity line now owns the full width; the waiting note and
-        // its action sit under it, and only for someone actually waiting.
         <div
           key={p.invitationId ?? p.userId}
           className="flex flex-col gap-1 px-3 py-2 rounded-lg bg-(--t-bg-card)"
         >
-          {/* Wraps rather than squeezes. An email address is long enough that
-              flexing it against the chips shredded it into a five-line column
-              at the popover's width; here the chips drop to the next line and
-              the identity keeps a readable floor. */}
+          {/* Wraps rather than squeezes: at the popover's width, flexing a long
+              handle against the chips shredded it into a five-line column. */}
           <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
             <PresenceAvatar handle={p.handle} size={26} online={p.online} />
-            {/* No truncation: the handle is what an owner reads before granting access. */}
+            {/* No truncation: read before granting access. */}
             <span className="text-xs text-(--t-text-primary) break-all flex-1 basis-32 min-w-0">
               {p.handle}
             </span>

--- a/src/components/vault-share/VaultShareSheet.test.tsx
+++ b/src/components/vault-share/VaultShareSheet.test.tsx
@@ -10,14 +10,12 @@ const h = vi.hoisted(() => ({
   revokeInvitation: vi.fn().mockResolvedValue(undefined),
   grantVaultKeyToMember: vi.fn().mockResolvedValue(undefined),
   writeClipboard: vi.fn().mockResolvedValue(undefined),
-  /** User ids the server reports as already holding a wrapped vault key. */
   keyHolders: [] as string[],
 }));
 
 vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
 vi.mock("@iconify/react", () => ({ Icon: () => null }));
-// Exposes each row action as a button, so a handler wired to `() => {}` — which
-// is how all four of these shipped — fails the test rather than passing it.
+// A button per handler, so a no-op handler fails rather than passes.
 vi.mock("./PeopleList", () => ({
   PeopleList: ({
     people,
@@ -139,7 +137,6 @@ test("Remove and Grant now run the real calls, not a no-op", () => {
     teamId: "t1",
     userId: "u1",
     handle: "bob",
-    // Carried through from the roster, so granting needs no second fetch.
     publicKey: "pk-bob",
   });
 });
@@ -157,7 +154,6 @@ test("Revoke runs against the invitation id, and does nothing without one", () =
     name: "carol@example.com",
   });
 
-  // A member row has no invitation to revoke.
   fireEvent.click(screen.getByText("revoke:u1"));
   expect(h.revokeInvitation).toHaveBeenCalledTimes(1);
 });
@@ -168,8 +164,6 @@ test("only members missing from the key-holder list read as waiting", async () =
     { user_id: "u1", handle: "bob", role_ids: [], public_key: "pk1" },
     { user_id: "u2", handle: "carol", role_ids: [], public_key: "pk2" },
   ];
-  // The old code read the *viewer's* own vault status and applied it to
-  // everyone, so a reader who was waiting saw the whole roster as waiting.
   h.keyHolders = ["u1"];
   render(<VaultShareSheet vaultId="v1" variant="full" />);
   await waitFor(() => expect(screen.getByText("waiting:u2")).toBeTruthy());

--- a/src/components/vault-share/VaultShareSheet.tsx
+++ b/src/components/vault-share/VaultShareSheet.tsx
@@ -29,10 +29,8 @@ export function VaultShareSheet({ vaultId, variant, onRequestFull }: Props) {
   const { t } = useTranslation();
   const vault = useVaultStore((s) => s.vaults.find((v) => v.id === vaultId));
   const teams = useTeamStore((s) => s.teams);
-  // `vaultId` is a local vault id for an owner, but a *team* id for anyone
-  // reached through the sidebar's standalone-team entry — every invited member,
-  // and an owner whose local vault has not yet re-read its teamId after a
-  // conversion. Resolving only the first left the sheet blank for the second.
+  // `vaultId` is a local vault id for an owner but a *team* id when reached
+  // through the sidebar's standalone-team entry.
   const standaloneTeam = vault ? null : (teams.find((t) => t.id === vaultId) ?? null);
   const teamId = vault?.teamId ?? standaloneTeam?.id ?? null;
 
@@ -46,7 +44,6 @@ export function VaultShareSheet({ vaultId, variant, onRequestFull }: Props) {
   // Owned by the sheet, never by a tab: the bug this component replaces was an
   // error written to a panel the same handler had just unmounted.
   const [error, setError] = useState("");
-  /** The invitation whose addressed link was just copied, for the confirmation line. */
   const [copiedInvite, setCopiedInvite] = useState<string | null>(null);
 
   // undefined while resolving, null once resolved with no signed-in user.
@@ -60,12 +57,8 @@ export function VaultShareSheet({ vaultId, variant, onRequestFull }: Props) {
     return () => { cancelled = true; };
   }, []);
 
-  /**
-   * User ids that already hold a wrapped copy of the vault key, or null while
-   * unknown. This is the only honest source for "who is still waiting": the
-   * team's own vault status is *this viewer's* status, and using it marked
-   * every member as awaiting whenever the reader happened to be.
-   */
+  // Null while unknown. `statusByTeamId` is the *viewer's* own status, so it
+  // cannot say who is waiting.
   const [keyHolders, setKeyHolders] = useState<Set<string> | null>(null);
 
   useEffect(() => {
@@ -78,9 +71,7 @@ export function VaultShareSheet({ vaultId, variant, onRequestFull }: Props) {
         if (results.some((r) => r.status === "rejected")) setError(t("members.share.loadFailed"));
       },
     );
-    // Best-effort and non-blocking: a member without MANAGE permission is
-    // refused this list, and their view simply shows nobody as waiting rather
-    // than showing everybody as waiting.
+    // Best-effort: a member without MANAGE permission is refused this list.
     let cancelled = false;
     void getVaultKeyHolders(teamId)
       .then((ids) => { if (!cancelled) setKeyHolders(new Set(ids)); })
@@ -100,11 +91,7 @@ export function VaultShareSheet({ vaultId, variant, onRequestFull }: Props) {
       handle: m.handle ?? "?",
       roleNames: m.role_ids.map(roleName).filter(Boolean),
       online: !!m.is_online,
-      // Per member, from the server's key-holder list. Unknown means "say
-      // nothing" rather than "everyone is waiting".
       state: keyHolders && !keyHolders.has(m.user_id) ? "awaiting_key" : "member",
-      // Carried so "Grant now" can wrap the vault key for this member without
-      // a second roster fetch.
       publicKey: m.public_key,
     }));
     const pending: Person[] = (pendingInvitationsByTeam[teamId] ?? []).map((inv) => ({
@@ -130,10 +117,9 @@ export function VaultShareSheet({ vaultId, variant, onRequestFull }: Props) {
       .filter((n): n is string => !!n);
   }, [teamId, myUserId, membersByTeam, rolesByTeam]);
 
-  // Neither a vault this device holds nor a team it belongs to.
   if (!vault && !standaloneTeam) return null;
 
-  // Only a *local* vault can be converted; a standalone team is one already.
+  // Only a local vault can be converted; a standalone team already is one.
   if (!teamId) {
     return (
       <ConvertToTeamGate
@@ -148,15 +134,10 @@ export function VaultShareSheet({ vaultId, variant, onRequestFull }: Props) {
   const canManage = canManageShare(myRoleNames);
   const canMint = canMintLink(myRoleNames);
 
-  // Every one of these shipped as `() => {}` while PeopleList rendered a button
-  // for it, so the popover's Remove, Revoke, Grant now and copy-link controls
-  // all did nothing. They run the same calls the Members page runs, then
-  // refetch so the list reflects what just happened.
   const reloadMembers = () => {
     void useTeamStore.getState().loadMembers(teamId);
     void useTeamStore.getState().loadPendingInvitations(teamId);
-    // Refetched too, so a member who just received their key stops reading as
-    // waiting without the user having to reopen the sheet.
+    // So a member who just received their key stops reading as waiting.
     void getVaultKeyHolders(teamId).then((ids) => setKeyHolders(new Set(ids))).catch(() => {});
   };
 
@@ -181,9 +162,6 @@ export function VaultShareSheet({ vaultId, variant, onRequestFull }: Props) {
       .then(reloadMembers)
       .catch(() => {});
 
-  // The addressed vault invite link: it opens the invitee's own inbox entry,
-  // where Accept and Decline already are. It carries no capability — the
-  // invitation is already bound to that one user — so it needs no new route.
   const handleCopyInviteLink = (p: Person) => {
     if (!p.invitationId) return;
     void writeClipboard(addressedInviteLink(p.invitationId)).then(() => setCopiedInvite(p.invitationId!));

--- a/src/components/vault-share/joinLinkModel.test.ts
+++ b/src/components/vault-share/joinLinkModel.test.ts
@@ -19,7 +19,6 @@ test("every preset is already inside the server's clamps", () => {
 });
 
 test("the unit floors but the count rounds, so a fresh 7-day link reads as 7 days", () => {
-  // The case that drove this: minted a moment ago, so a hair under 7 days.
   expect(expiresIn(at(7 * 24 * 3600_000 - 4_000), NOW)).toEqual({ unit: "days", count: 7 });
   expect(expiresIn(at(3600_000 - 4_000), NOW)).toEqual({ unit: "minutes", count: 60 });
   expect(expiresIn(at(5 * 60_000), NOW)).toEqual({ unit: "minutes", count: 5 });

--- a/src/components/vault-share/joinLinkModel.ts
+++ b/src/components/vault-share/joinLinkModel.ts
@@ -1,6 +1,5 @@
 import { MAX_TTL_SECS, MAX_USES_CEILING, MIN_TTL_SECS } from "@/services/teamJoinGrants";
 
-/** TTL presets, all inside the server's own `[60, 2592000]` clamp. */
 export const TTL_PRESETS = [
   { key: "hour1", secs: 3600 },
   { key: "day1", secs: 24 * 3600 },
@@ -8,13 +7,8 @@ export const TTL_PRESETS = [
   { key: "day30", secs: MAX_TTL_SECS },
 ] as const;
 
-/** Use presets, all inside the server's own `[1, 500]` clamp. */
 export const USES_PRESETS = [1, 5, 25, MAX_USES_CEILING] as const;
 
-/**
- * Mirrors the server's clamps rather than trusting the form. A request the
- * server would silently reshape is a link whose printed terms are a lie.
- */
 export function clampTtlSecs(secs: number): number {
   return Math.min(Math.max(Math.round(secs), MIN_TTL_SECS), MAX_TTL_SECS);
 }
@@ -27,16 +21,8 @@ export type ExpiryLabel =
   | { unit: "expired" }
   | { unit: "minutes" | "hours" | "days"; count: number };
 
-/**
- * How long a live grant has left, as a unit and a count for the caller to
- * translate. Anything under a minute reads as expired rather than "0 minutes".
- *
- * The unit is picked by flooring but the count is rounded to nearest, so a link
- * minted seconds ago with a 7-day life reads "7 days left" rather than "6" —
- * flooring there looked like a bug and taught the user to distrust the number.
- * The count is a hint either way: the row carries the exact expiry as a
- * tooltip, and the server, not this, decides when the grant stops working.
- */
+// The unit floors but the count rounds: flooring both showed "6 days left" on a
+// link minted seconds earlier with a 7-day life.
 export function expiresIn(expiresAt: string, now: number = Date.now()): ExpiryLabel {
   const remainingMs = new Date(expiresAt).getTime() - now;
   if (!Number.isFinite(remainingMs) || remainingMs < 60_000) return { unit: "expired" };
@@ -47,7 +33,6 @@ export function expiresIn(expiresAt: string, now: number = Date.now()): ExpiryLa
   return { unit: "days", count: Math.round(hours / 24) };
 }
 
-/** Uses left on a grant, never negative even if the server ever over-issued. */
 export function usesRemaining(grant: { uses: number; max_uses: number }): number {
   return Math.max(0, grant.max_uses - grant.uses);
 }

--- a/src/services/authFetch.ts
+++ b/src/services/authFetch.ts
@@ -3,23 +3,11 @@ import { appFetch } from "@/services/http";
 import { getJwt, isJwtExpiredOrExpiring, tryRefreshJwt } from "@/services/authTokens";
 
 interface AuthFetchOptions {
-  /** Send `Content-Type: application/json`. */
   json?: boolean;
-  /** Turn a 429 into a translated "rate limited, retry in N" error. */
+  /** Turn a 429 into a translated "retry in N" error. */
   rateLimit?: boolean;
 }
 
-/**
- * The one authenticated fetch against the sync server: refresh a token that is
- * expired or about to be, send, and retry once if the server still says 401.
- *
- * It existed four times before this — `sync`, `teamVaultSync`, `teamService`
- * and `auditService` — and they had drifted. `auditService`'s copy did neither
- * the pre-refresh nor the retry, so an audit page opened on a stale token
- * failed instead of refreshing rather than recovering. The only two real
- * differences between the others are the options above, which is why they are
- * options and not four near-copies.
- */
 export async function fetchAuth(
   url: string,
   init: RequestInit = {},
@@ -48,13 +36,10 @@ export async function fetchAuth(
   return res;
 }
 
-/** For the JSON APIs, whose callers all send and expect JSON. */
 export const fetchAuthJson = (url: string, init: RequestInit = {}): Promise<Response> =>
   fetchAuth(url, init, { json: true });
 
-/**
- * For the sync and team-vault routes, which set their own content types and are
- * the ones the server rate-limits.
- */
+// Not folded into fetchAuthJson: the sync and vault-key routes set their own
+// content types, and they are the ones the server rate-limits.
 export const fetchAuthRateLimited = (url: string, init: RequestInit = {}): Promise<Response> =>
   fetchAuth(url, init, { rateLimit: true });

--- a/src/services/deepLinkUrl.test.ts
+++ b/src/services/deepLinkUrl.test.ts
@@ -280,10 +280,7 @@ test("a plugin-install link naming an over-long source id is rejected", () => {
   expect(parseDeepLink("voltius://plugin-install?id=docker&src=" + "a".repeat(101))).toBeNull();
 });
 
-// ─── vault-join (issue #68) ───────────────────────────────────────────────────
-
 const GRANT = "1b4e28ba-2fa1-11d2-883f-0016d3cca427";
-/** 32 bytes as unpadded base64url — exactly what the server mints. */
 const SECRET = "A".repeat(43);
 
 test("a vault-join link round-trips through both forms", () => {
@@ -304,7 +301,6 @@ test("a vault-join link needs a real UUID and a well-formed secret", () => {
   expect(parseDeepLink(`voltius://vault-join?g=${GRANT}&k=`)).toBeNull();
   expect(parseDeepLink(`voltius://vault-join?g=${GRANT}&k=${"A".repeat(42)}`)).toBeNull();
   expect(parseDeepLink(`voltius://vault-join?g=${GRANT}&k=${"A".repeat(44)}`)).toBeNull();
-  // Padded or non-URL-safe base64 is not what the server mints.
   expect(parseDeepLink(`voltius://vault-join?g=${GRANT}&k=${"A".repeat(42)}%3D`)).toBeNull();
   expect(parseDeepLink(`voltius://vault-join?g=${GRANT}&k=${"A".repeat(42)}%2B`)).toBeNull();
 });
@@ -316,8 +312,6 @@ test("vault-join is a confirm route — it never acts unprompted", () => {
 });
 
 test("a vault-join link carries no account id", () => {
-  // account_id is the KDF salt for the user's password. The codec has exactly
-  // two parameters, so there is nowhere for one to be added by accident.
   const url = buildDeepLink({ route: "vault-join", grantId: GRANT, secret: SECRET }, "scheme");
   const params = new URLSearchParams(url.slice(url.indexOf("?") + 1));
   expect([...params.keys()].sort()).toEqual(["g", "k"]);

--- a/src/services/deepLinkUrl.ts
+++ b/src/services/deepLinkUrl.ts
@@ -10,11 +10,8 @@ export type SettingsIntent = { route: "settings"; section: SettingsSection };
 export type BillingIntent = { route: "billing" };
 export type SnippetInstallIntent = { route: "snippet-install"; entryId: string };
 export type PluginInstallIntent = { route: "plugin-install"; pluginId: string; sourceId: string };
-/**
- * An open join link for a team vault. Carries a grant id and that grant's
- * secret and nothing else — never key material, and never `account_id`, which
- * despite its name is the KDF salt for the user's password.
- */
+/** Carries a grant id and its secret only — never key material, never
+ *  `account_id`, which is the KDF salt for the user's password. */
 export type VaultJoinIntent = { route: "vault-join"; grantId: string; secret: string };
 export type DeepLinkIntent =
   | JoinIntent
@@ -91,11 +88,8 @@ const TRUST = {
   // the sheet names the plugin, its catalogue and its permissions before the
   // accept button does anything.
   "plugin-install": "confirm",
-  // Spends a use of a real grant and lands the tapper's account in someone
-  // else's team under a role its author chose. It carries no vault key — those
-  // are wrapped per member with X25519 and can never travel in a link — but
-  // membership is still a capability, and leaving again is a separate act. The
-  // sheet names the team, the role and the inviter before accept does anything.
+  // Membership is a capability even though no key travels in the link, and
+  // leaving again is a separate act.
   "vault-join": "confirm",
 } as const satisfies Record<Route, TrustClass>;
 
@@ -137,12 +131,7 @@ export const DEFAULT_PLUGIN_SOURCE_ID = "voltius";
 /** A source id is a catalogue key, not a URL; this only stops an absurd one. */
 const MAX_SOURCE_ID = 100;
 
-/**
- * A join-grant secret exactly as the server mints it (server:
- * `team_join_grants::generate_secret`) — 32 random bytes as unpadded base64url,
- * so 43 characters. Anything else is rejected here rather than spent as a
- * probe against the preview endpoint.
- */
+/** As the server mints it: 32 random bytes, unpadded base64url, 43 chars. */
 const GRANT_SECRET_RE = /^[A-Za-z0-9_-]{43}$/;
 
 /**

--- a/src/services/sessionId.ts
+++ b/src/services/sessionId.ts
@@ -1,9 +1,7 @@
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-/** Every server-issued id is a UUID: sessions, users, teams, join grants. */
 export function isUuid(value: string): boolean {
   return UUID_RE.test(value);
 }
 
-/** The same check under the name most call sites read it by. */
 export const isSessionId = isUuid;

--- a/src/services/teamJoin.ts
+++ b/src/services/teamJoin.ts
@@ -1,17 +1,9 @@
 import { useTeamStore } from "@/stores/teamStore";
 
-/**
- * The refresh every "I am now a member of this team" path owes, whether
- * membership came from accepting an invitation or from redeeming a join link.
- *
- * `joinAndLoadTeamVault` is called directly rather than left to the SSE
- * membership_changed handler: `loadTeams()` adds the team to the store before
- * that event is processed, so the handler sees a zero delta, skips
- * `onTeamAdded`, and the vault stays stuck at "forbidden".
- *
- * Imported lazily for the same reason it always was — `teamDataManager` pulls
- * in the sync stack, and a static edge here would close a cycle.
- */
+// joinAndLoadTeamVault is called directly rather than left to the SSE
+// membership_changed handler: loadTeams() adds the team first, so the handler
+// sees a zero delta and the vault stays stuck at "forbidden".
+// Imported lazily to avoid a cycle through teamDataManager's sync stack.
 export async function refreshAfterJoiningTeam(teamId: string): Promise<void> {
   const { joinAndLoadTeamVault } = await import("@/services/teamDataManager");
   await Promise.all([

--- a/src/services/teamJoinGrants.ts
+++ b/src/services/teamJoinGrants.ts
@@ -2,22 +2,11 @@ import i18n from "@/i18n";
 import { fetchAuthJson as fetchAuth } from "@/services/authFetch";
 import { getServerUrl } from "@/services/authTokens";
 
-/**
- * Team join grants — the client half of the link that admits someone into a
- * team vault (issue #68; server: `migrations/038_team_join_grants.sql`,
- * `src/routes/team_grants.rs`).
- *
- * A grant confers **membership only, never vault access**. The vault key is
- * wrapped per member with X25519, so it cannot travel in a link: it arrives
- * afterwards, when an online key-holder runs the normal distribution pass. A
- * redeemer therefore lands in `awaiting_key` (issue #41) until that happens,
- * which `TeamVaultStatePanel` already renders as an explicit waiting state.
- *
- * `account_id` appears nowhere here and must never be put in a link: despite
- * the name it is the KDF salt for the user's password.
- */
+// A grant confers team membership, never vault access: the vault key is wrapped
+// per member with X25519, so it follows separately and the redeemer sits in
+// `awaiting_key` until a key-holder wraps it.
 
-/** Roles a link may confer. `owner` is a 400 on the server, deliberately. */
+/** `owner` is absent deliberately — the server answers 400 for it. */
 export const GRANTABLE_ROLES = ["manager", "editor", "member", "connect-only"] as const;
 export type GrantableRole = (typeof GRANTABLE_ROLES)[number];
 
@@ -25,7 +14,7 @@ export function isGrantableRole(role: string): role is GrantableRole {
   return (GRANTABLE_ROLES as readonly string[]).includes(role);
 }
 
-/** Server clamps, mirrored so the form cannot ask for something it won't get. */
+/** Server-side clamps, mirrored so the form cannot ask for what it won't get. */
 export const MAX_USES_CEILING = 500;
 export const MIN_TTL_SECS = 60;
 export const MAX_TTL_SECS = 30 * 24 * 3600;
@@ -40,7 +29,7 @@ export interface JoinGrant {
   created_by: string;
 }
 
-/** The mint response. `secret` is returned exactly once and never re-fetchable. */
+/** `secret` is returned by this call only; the server stores just its sha256. */
 export interface MintedJoinGrant extends JoinGrant {
   secret: string;
 }
@@ -57,10 +46,6 @@ export interface JoinGrantRedemption {
   role: string;
 }
 
-/**
- * Why the server refused. Matched on `code`, never on the message: a message is
- * translated and a translated string is not a protocol.
- */
 export type JoinGrantErrorCode =
   | "not_found"
   | "revoked_or_expired"
@@ -69,6 +54,7 @@ export type JoinGrantErrorCode =
   | "no_public_key"
   | "unknown";
 
+/** Carries a code so callers never match on a translated message. */
 export class JoinGrantError extends Error {
   constructor(
     readonly code: JoinGrantErrorCode,
@@ -79,12 +65,8 @@ export class JoinGrantError extends Error {
   }
 }
 
-/**
- * The redeem/preview status contract, read off the server rather than the API
- * doc, which did not pin it: 404 wrong id *or* wrong secret (deliberately
- * indistinguishable), 410 revoked or expired, 409 exhausted, 402 seat cap,
- * 400 on redeem means the redeemer has no published public key.
- */
+// 404 covers a wrong id and a wrong secret alike, deliberately. 400 means
+// "no published public key" only when redeeming.
 function grantError(status: number, redeeming: boolean): JoinGrantError {
   switch (status) {
     case 404:
@@ -141,11 +123,7 @@ export async function revokeJoinGrant(teamId: string, grantId: string): Promise<
   if (!res.ok) throw grantError(res.status, false);
 }
 
-/**
- * What the link names, before the holder commits to joining. Read-only: it
- * consumes no use, and the server re-checks revocation and expiry again inside
- * the redemption transaction, so nothing here is cached as a decision.
- */
+/** Consumes no use; the server re-checks validity inside the redeem transaction. */
 export async function previewJoinGrant(grantId: string, secret: string): Promise<JoinGrantPreview> {
   const base = await serverUrl();
   const res = await fetchAuth(`${base}/v1/grants/${grantId}/preview`, {
@@ -156,12 +134,8 @@ export async function previewJoinGrant(grantId: string, secret: string): Promise
   return res.json();
 }
 
-/**
- * Redeem. `publicKey` fills a NULL on the user row and never overwrites one —
- * overwriting would orphan every vault key already wrapped to the old key — and
- * a redeemer who has published none is refused with a 400 rather than admitted
- * into a vault that could never fill.
- */
+// `public_key` fills a NULL only and never overwrites — overwriting would orphan
+// every vault key already wrapped to the old one.
 export async function redeemJoinGrant(
   grantId: string,
   secret: string,

--- a/src/services/vaultShare.ts
+++ b/src/services/vaultShare.ts
@@ -101,11 +101,6 @@ export async function inviteByEmailAddress(args: {
   });
 }
 
-/**
- * Remove a member. The toast wording lives here so both share surfaces say the
- * same thing; the Members page adds its own undo entry on top of this call,
- * which the popover deliberately has no room for.
- */
 export async function removeTeamMember(args: {
   teamId: string;
   userId: string;
@@ -120,7 +115,6 @@ export async function removeTeamMember(args: {
   });
 }
 
-/** Withdraw a pending invitation. */
 export async function revokeInvitation(args: {
   teamId: string;
   invitationId: string;
@@ -135,14 +129,8 @@ export async function revokeInvitation(args: {
   });
 }
 
-/**
- * Wrap the team vault key for one member who has none (issue #41).
- *
- * `distributeKeyToNewMember` returns quietly when this device cannot unwrap the
- * key itself, which is right for the background reconcile but wrong for a
- * button: a user who pressed "Grant now" and is told nothing assumes it worked.
- * The key-holder check is therefore made here, and a non-holder is told why.
- */
+// distributeKeyToNewMember returns quietly when this device cannot unwrap the
+// key, so the key-holder check happens here — a button must not fail silently.
 export async function grantVaultKeyToMember(args: {
   teamId: string;
   userId: string;
@@ -167,13 +155,8 @@ export async function grantVaultKeyToMember(args: {
   });
 }
 
-/**
- * The deep link that lands an invitee on their own inbox entry for a pending
- * invitation, where Accept and Decline already live. This is the *addressed*
- * vault invite link (issue #68): it carries no capability at all — the
- * invitation row is what confers anything, and it is already addressed to that
- * one user — so the route is `navigate`, not `confirm`.
- */
+/** Opens the invitee's own inbox entry. Carries no capability — the invitation
+ *  row is already bound to that user — so the route is `navigate`. */
 export function addressedInviteLink(invitationId: string): string {
   return buildDeepLink({ route: "notification", entryId: `invite:${invitationId}` });
 }


### PR DESCRIPTION
Follow-up to #226. That code narrated itself — block headers restating what the next lines do, multi-line rationale that belongs in the commit message, and JSDoc on obvious test helpers. It also matched the dense commenting of the surrounding `vault-share` files, which is not the style to copy.

**243 comment lines out, 54 in** (most of those the shortened replacements). No behaviour change.

What stays is the load-bearing kind only, one or two lines each:

- why the key-holder check lives in the button path rather than in `distributeKeyToNewMember`
- why the expiry unit floors but the count rounds
- why `vaultId` can be a team id
- why `fetchAuthRateLimited` is not folded into `fetchAuthJson`
- that a link carries membership and never the vault key
- the `account_id` / KDF-salt constraint on the deep-link codec

`tsc` clean; 1381 tests across `vault-share`, `terminal`, `layout`, `members` and `services` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gY5k7XbeR5zoTXdzsuWxF
