### PR TITLE
test(teams): guard the #216 keychain wipe at the caller, not just the callee

### DIFF
--- a/src/services/sync.teamRemoved.test.ts
+++ b/src/services/sync.teamRemoved.test.ts
@@ -12,24 +12,46 @@ vi.mock("@/services/vault", () => ({
   }),
 }));
 
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn(async () => null) }));
+
+// The removal path re-reads the team list to compute the membership delta; an
+// empty list is what "you were removed from t1" looks like on the wire.
+vi.mock("@/services/teamService", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/teamService")>()),
+  listTeams: vi.fn(async () => []),
+}));
+
+vi.mock("@/services/teamDataManager", () => ({
+  refreshAwaitingKeyTeams: vi.fn(async () => {}),
+  joinAndLoadTeamVault: vi.fn(async () => {}),
+  onTeamLogin: vi.fn(async () => {}),
+}));
+
 import { clearTeamStoresAndSecrets } from "./teamVaultSync";
+import { handleRealtimeEvent } from "./sync";
 import { useConnectionStore } from "@/stores/connectionStore";
 import { useKeyStore } from "@/stores/keyStore";
 import { useIdentityStore } from "@/stores/identityStore";
+import { useTeamStore } from "@/stores/teamStore";
 
 beforeEach(() => {
   h.deleted = [];
   useConnectionStore.setState({ teamConnections: {} });
   useKeyStore.setState({ teamKeys: {} });
   useIdentityStore.setState({ teamIdentities: {} });
+  useTeamStore.setState({ teams: [] });
 });
 
-test("deletes every team secret from the keychain and empties the stores", async () => {
+function seedTeamObjects(): void {
   useConnectionStore.setState({
     teamConnections: { t1: [{ id: "c1", name: "web", host: "h", port: 22 } as never] },
   });
   useKeyStore.setState({ teamKeys: { t1: [{ id: "k1", name: "deploy" } as never] } });
   useIdentityStore.setState({ teamIdentities: { t1: [{ id: "i1", name: "root" } as never] } });
+}
+
+test("deletes every team secret from the keychain and empties the stores", async () => {
+  seedTeamObjects();
 
   await clearTeamStoresAndSecrets("t1");
 
@@ -50,9 +72,29 @@ test("deletes every team secret from the keychain and empties the stores", async
 });
 
 test("deletes nothing when the stores were already emptied first", async () => {
-  // Guards the ordering: the wipe builds its keys from the object IDs, so
-  // clearing memory before it runs silently loses them (#216).
+  // The wipe builds its keys from the object IDs, so empty stores mean nothing
+  // to delete. This pins that shape; the caller's ordering is covered below.
   await clearTeamStoresAndSecrets("t1");
 
   expect(h.deleted).toEqual([]);
+});
+
+test("wipes the keychain before onTeamRemoved empties the stores", async () => {
+  // The wipe derives its keychain keys from the object IDs held in the stores,
+  // so onTeamRemoved must call it while those stores are still populated. The
+  // two tests above exercise clearTeamStoresAndSecrets in isolation and pass
+  // against either ordering; this one drives the real removal path (#216).
+  useTeamStore.setState({ teams: [{ id: "t1", name: "Ops", role_ids: [] } as never] });
+  seedTeamObjects();
+
+  await handleRealtimeEvent("membership_changed", "device-1");
+
+  // The handler kicks the membership delta off without awaiting it, so the
+  // removal lands a few ticks after the event returns.
+  await vi.waitFor(() =>
+    expect(h.deleted).toEqual(
+      expect.arrayContaining(["password:c1", "key:k1:private", "identity:i1:password"]),
+    ),
+  );
+  expect(useConnectionStore.getState().teamConnections.t1 ?? []).toEqual([]);
 });

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -820,7 +820,7 @@ async function refetchActiveSessions(): Promise<void> {
   await useTeamSessionStore.getState().fetchActiveSessions().catch(() => {});
 }
 
-async function handleRealtimeEvent(eventData: string, myDeviceId: string): Promise<void> {
+export async function handleRealtimeEvent(eventData: string, myDeviceId: string): Promise<void> {
   if (eventData.startsWith("team:")) {
     const teamId = eventData.slice(5);
     _teamEventListeners.forEach((fn) => fn(teamId));


### PR DESCRIPTION
Follow-up to #225. The fix for #216 is correct; its regression test does not guard it.

## The gap

`src/services/sync.teamRemoved.test.ts` never imports `sync.ts`. Both of its tests call `clearTeamStoresAndSecrets("t1")` directly, and #216 was never a bug in that function — it was `onTeamRemoved` clearing the stores before calling it, leaving the wipe with no object IDs to build its keychain keys from.

Put those clears back above `src/services/sync.ts:896` and the departed member keeps the team's plaintext passwords and private keys, with the suite green. That is the exact failure mode #216 called out:

> a test that only checks the secrets are gone at the end would pass against the broken code if the calls were merely reordered wrong

## The test

Drives the real path — `handleRealtimeEvent("membership_changed", …)` with `listTeams()` returning an empty list, which is what "you were removed" looks like on the wire — and asserts `password:c1`, `key:k1:private` and `identity:i1:password` reach `deleteSecret`.

| | existing tests | new test |
|---|---|---|
| `dev` as it stands | pass | pass |
| ordering bug reintroduced | pass | **fail** (`h.deleted` is `[]`) |

## Notes

- `handleRealtimeEvent` is exported so the test can reach it. That is the only production change.
- Test 2's comment claimed to guard the ordering; reworded to say what it actually pins.
- `vi.waitFor` is needed because `handleMembershipChangedEvent(...)` is fire-and-forget in `sync.ts` — not awaited, and `.catch(() => {})`. Worth noting separately that this silently swallows every error in the removal path, keychain wipe included.

## Verification

- `tsc --noEmit` — exit 0
- `vitest run` on the six `sync*` / `syncExclusion` / `syncStatus` files — 47 passed
- `vitest run` on all 25 `src/services/team*.test.ts` — 226 passed