### PR TITLE
fix(vaults): keep object ids when a team vault goes private (#241, #242, #243, #244)

### DIFF
--- a/src/components/layout/VaultHeader.tsx
+++ b/src/components/layout/VaultHeader.tsx
@@ -13,9 +13,8 @@ import { PickerSurface } from "@/components/shared/PickerSurface";
 import { getSyncState, onSyncStateChange } from "@/services/sync";
 import { useSubscriptionStore } from "@/stores/subscriptionStore";
 import { VaultShareSheet } from "@/components/vault-share/VaultShareSheet";
-import { ContextMenu } from "@/components/shared/ContextMenu";
 import { useVaultAdmin } from "@/components/vault-admin/useVaultAdmin";
-import { VaultAdminDialogs } from "@/components/vault-admin/VaultAdminDialogs";
+import { VaultAdminSurface } from "@/components/vault-admin/VaultAdminSurface";
 import type { VaultAdminTarget } from "@/components/vault-admin/vaultAdminTarget";
 
 // ─── Members stack ─────────────────────────────────────────────────────────
@@ -354,14 +353,7 @@ export default function VaultHeader() {
         )}
       </div>
 
-      {admin.pos && <ContextMenu items={admin.items} pos={admin.pos} onClose={admin.closeMenu} />}
-      {target && (
-        <VaultAdminDialogs
-          target={target}
-          dialog={admin.dialog}
-          onClose={() => admin.setDialog(null)}
-        />
-      )}
+      <VaultAdminSurface admin={admin} target={target} />
     </div>
   );
 }

--- a/src/components/layout/VaultSidebar.menu.test.tsx
+++ b/src/components/layout/VaultSidebar.menu.test.tsx
@@ -12,6 +12,8 @@ vi.mock("@/components/vault-admin/VaultAdminDialogs", () => ({
 }));
 vi.mock("@/services/teamDataManager", () => ({ onVaultSelect: vi.fn(async () => {}) }));
 vi.mock("./LogoBadge", () => ({ default: () => null }));
+const orphans = vi.hoisted(() => ({ ids: [] as string[] }));
+vi.mock("@/hooks/useAccessibleVaultIds", () => ({ useOrphanVaultIds: () => orphans.ids }));
 
 import VaultSidebar from "./VaultSidebar";
 import { useVaultStore } from "@/stores/vaultStore";
@@ -27,6 +29,7 @@ beforeEach(() => {
   useTeamStore.setState({ teams: [], myPendingInvitations: [], membersByTeam: {}, rolesByTeam: {} });
   useUIStore.setState({ homeView: true, vaultSharePending: false });
   useSubscriptionStore.setState({ accountMode: null });
+  orphans.ids = [];
 });
 afterEach(cleanup);
 
@@ -53,4 +56,47 @@ test("choosing Share switches to the vault and marks the header's share sheet pe
   expect(useVaultStore.getState().selectedVaultIds).toEqual(["v1"]);
   expect(useUIStore.getState().homeView).toBe(false);
   expect(useUIStore.getState().vaultSharePending).toBe(true);
+});
+
+test("right-clicking a standalone team row opens the same menu the header gives it", () => {
+  // An invited member with no local vault row: the rail is where they live, and
+  // Members/Roles is the whole reason they open this menu.
+  useVaultStore.setState({ vaults: [], selectedVaultIds: ["t9"] });
+  useTeamStore.setState({
+    teams: [{ id: "t9", name: "Shared", owner_id: "someone", owner_tier: "teams", created_at: "", role_ids: [] }],
+  });
+  render(<VaultSidebar />);
+
+  fireEvent.contextMenu(screen.getByTestId("vault-row-t9"));
+
+  expect(screen.getByText("layout.vaultMenu.members")).toBeTruthy();
+  expect(screen.getByText("layout.vaultMenu.roles")).toBeTruthy();
+  // No local row behind it, so nothing that edits one is offered.
+  expect(screen.queryByText("layout.vaultMenu.rename")).toBeNull();
+  expect(screen.queryByText("layout.vaultMenu.delete")).toBeNull();
+});
+
+test("choosing Members from a standalone team row activates that team, not the last one", () => {
+  useVaultStore.setState({ vaults: [{ id: "v1", name: "My Vault" }], selectedVaultIds: ["v1"] });
+  useTeamStore.setState({
+    teams: [{ id: "t9", name: "Shared", owner_id: "someone", owner_tier: "teams", created_at: "", role_ids: [] }],
+  });
+  render(<VaultSidebar />);
+
+  fireEvent.contextMenu(screen.getByTestId("vault-row-t9"));
+  fireEvent.click(screen.getByText("layout.vaultMenu.members"));
+
+  expect(useVaultStore.getState().selectedVaultIds).toEqual(["t9"]);
+  expect(useUIStore.getState().homeView).toBe(false);
+});
+
+test("an orphan row has no menu: there is no vault record for it to act on", () => {
+  useVaultStore.setState({ vaults: [], selectedVaultIds: ["ghost"] });
+  orphans.ids = ["ghost"];
+  render(<VaultSidebar />);
+
+  fireEvent.contextMenu(screen.getByTestId("vault-row-ghost"));
+
+  expect(screen.queryByText("layout.vaultMenu.rename")).toBeNull();
+  expect(screen.queryByText("layout.vaultMenu.share")).toBeNull();
 });

--- a/src/components/layout/VaultSidebar.tsx
+++ b/src/components/layout/VaultSidebar.tsx
@@ -18,9 +18,8 @@ import { openBillingCheckout } from "@/services/billingCheckout";
 import { getUpdaterState, onUpdaterStateChange, type UpdaterStatus } from "@/services/updater";
 import { acceptInvitation, declineInvitation } from "@/services/invitationActions";
 import type { MyPendingInvitation } from "@/stores/teamStore";
-import { ContextMenu } from "@/components/shared/ContextMenu";
 import { useVaultAdmin } from "@/components/vault-admin/useVaultAdmin";
-import { VaultAdminDialogs } from "@/components/vault-admin/VaultAdminDialogs";
+import { VaultAdminSurface } from "@/components/vault-admin/VaultAdminSurface";
 import type { VaultAdminTarget } from "@/components/vault-admin/vaultAdminTarget";
 
 function getInitials(name: string) {
@@ -66,30 +65,33 @@ export default function VaultSidebar() {
     if (vault.teamId) onVaultSelect(vault.teamId).catch(() => {});
   };
 
-  // One menu for the whole rail: only one vault row can be right-clicked at a
-  // time, so a menu per row would just multiply state for no benefit.
-  const [menuVaultId, setMenuVaultId] = useState<string | null>(null);
-  const menuVault = vaults.find((v) => v.id === menuVaultId) ?? null;
-  const adminTarget: VaultAdminTarget | null = menuVault
-    ? { kind: "local", vaultId: menuVault.id, teamId: menuVault.teamId ?? null, name: menuVault.name }
-    : null;
-  const admin = useVaultAdmin(adminTarget, {
+  // One menu for the whole rail: only one row can be right-clicked at a time, so
+  // a menu per row would just multiply state for no benefit. The target is held
+  // whole rather than as an id, because the rail's rows are not all local vaults
+  // — a standalone team row has no vault row to look the rest up from.
+  const [menuTarget, setMenuTarget] = useState<VaultAdminTarget | null>(null);
+  const activateMenuTarget = () => {
+    if (!menuTarget) return;
+    switchToVault({ id: menuTarget.vaultId ?? menuTarget.teamId!, teamId: menuTarget.teamId });
+    setMenuTarget(null);
+  };
+  const admin = useVaultAdmin(menuTarget, {
     // The rail has no share sheet of its own — switch to the vault so the
     // header's sheet (the app's one and only) can open for it instead.
     onShare: () => {
-      if (!menuVault) return;
-      switchToVault(menuVault);
+      activateMenuTarget();
       openVaultSharePending();
-      setMenuVaultId(null);
     },
     // Members/Roles nav is scoped to the ACTIVE vault, not the right-clicked
     // one — switch first so it opens for the vault the user actually chose.
-    onActivate: () => {
-      if (!menuVault) return;
-      switchToVault(menuVault);
-      setMenuVaultId(null);
-    },
+    onActivate: activateMenuTarget,
   });
+
+  /** Opens the vault menu for `target`. Rows with nothing to administer pass no handler. */
+  const menuFor = (target: VaultAdminTarget) => (e: React.MouseEvent) => {
+    setMenuTarget(target);
+    admin.openAtPointer(e);
+  };
 
   const handleAddVaultClick = () => {
     if (!isPro && vaults.length >= 1) {
@@ -129,14 +131,12 @@ export default function VaultSidebar() {
         {vaults.map((vault) => {
           const isActive = selectedVaultIds.includes(vault.id) && !homeView;
           return (
-            <div
+            <VaultRailRow
               key={vault.id}
-              data-testid={`vault-row-${vault.id}`}
-              className="relative flex items-center justify-center w-full shrink-0"
-              onContextMenu={(e) => {
-                setMenuVaultId(vault.id);
-                admin.openAtPointer(e);
-              }}
+              testId={`vault-row-${vault.id}`}
+              onContextMenu={menuFor({
+                kind: "local", vaultId: vault.id, teamId: vault.teamId ?? null, name: vault.name,
+              })}
             >
               <VaultButton
                 testId={`vault-button-${vault.id}`}
@@ -146,22 +146,29 @@ export default function VaultSidebar() {
                 onClick={() => switchToVault(vault)}
               />
               {vault.teamId && <TeamVaultBadge teamId={vault.teamId} />}
-            </div>
+            </VaultRailRow>
           );
         })}
 
         {/* Pending vault invitations */}
         {pendingInvites.map((inv) => (
-          <div key={inv.id} className="relative flex items-center justify-center w-full shrink-0">
+          <VaultRailRow key={inv.id}>
             <PendingInviteButton invite={inv} onClick={() => setSelectedInvite(inv)} />
-          </div>
+          </VaultRailRow>
         ))}
 
         {/* Standalone team vault buttons (invited members who have no linked local vault) */}
         {standaloneTeams.map((team) => {
           const isActive = selectedVaultIds.includes(team.id) && !homeView;
           return (
-            <div key={team.id} className="relative flex items-center justify-center w-full shrink-0">
+            // The members who most need Members and Roles are exactly the ones
+            // with no local vault row, so this menu is not optional: the header
+            // already builds the same cloud target for them.
+            <VaultRailRow
+              key={team.id}
+              testId={`vault-row-${team.id}`}
+              onContextMenu={menuFor({ kind: "cloud", vaultId: null, teamId: team.id, name: team.name })}
+            >
               <VaultButton
                 initial={getInitials(team.name)}
                 label={t("layout.vaultSidebar.cloudVaultLabel", { name: team.name })}
@@ -169,22 +176,24 @@ export default function VaultSidebar() {
                 onClick={() => switchToVault({ id: team.id, teamId: team.id })}
               />
               <TeamVaultBadge teamId={team.id} />
-            </div>
+            </VaultRailRow>
           );
         })}
 
-        {/* Unnamed vaults, kept visible so their hosts stay reachable */}
+        {/* Unnamed vaults, kept visible so their hosts stay reachable. No menu:
+            an orphan id has no vault record behind it, so every item the menu
+            offers — rename, share, delete, make private — would act on nothing. */}
         {orphanVaultIds.map((id) => {
           const isActive = selectedVaultIds.includes(id) && !homeView;
           return (
-            <div key={id} className="relative flex items-center justify-center w-full shrink-0">
+            <VaultRailRow key={id} testId={`vault-row-${id}`}>
               <VaultButton
                 initial="?"
                 label={unknownVaultLabel(id)}
                 isActive={isActive}
                 onClick={() => switchToVault({ id, teamId: null })}
               />
-            </div>
+            </VaultRailRow>
           );
         })}
 
@@ -192,17 +201,7 @@ export default function VaultSidebar() {
         <AddVaultButton onClick={handleAddVaultClick} />
       </div>
 
-      {admin.pos && <ContextMenu items={admin.items} pos={admin.pos} onClose={admin.closeMenu} />}
-      {adminTarget && (
-        <VaultAdminDialogs
-          target={adminTarget}
-          dialog={admin.dialog}
-          onClose={() => {
-            admin.setDialog(null);
-            setMenuVaultId(null);
-          }}
-        />
-      )}
+      <VaultAdminSurface admin={admin} target={menuTarget} onClose={() => setMenuTarget(null)} />
 
       {showCreateModal && (
         <CreateVaultModal
@@ -483,6 +482,33 @@ function ActivePip({ active }: { active: boolean }) {
         transition: "height 150ms ease",
       }}
     />
+  );
+}
+
+/**
+ * One rail slot. Every row in the scroll area is this wrapper plus its button,
+ * and binding `onContextMenu` here rather than per-row is what keeps the menu
+ * from reaching only the row kind that happened to be written first.
+ *
+ * `AppIconButton` keeps a wrapper of its own: it looks the same but is not a
+ * row — it sits outside the scroll area and drives a hover pip, so sharing this
+ * one would mean widening it with props no actual row uses.
+ */
+function VaultRailRow({
+  testId, onContextMenu, children,
+}: {
+  testId?: string;
+  onContextMenu?: (e: React.MouseEvent) => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      data-testid={testId}
+      className="relative flex items-center justify-center w-full shrink-0"
+      onContextMenu={onContextMenu}
+    >
+      {children}
+    </div>
   );
 }
 

--- a/src/components/vault-admin/VaultAdminDialogs.tsx
+++ b/src/components/vault-admin/VaultAdminDialogs.tsx
@@ -6,7 +6,7 @@ import { useTeamStore } from "@/stores/teamStore";
 import { useVaultContents } from "@/hooks/useVaultContents";
 import { useVaultAdminActions } from "./useVaultAdminActions";
 import { VaultSettingsBody } from "./VaultSettingsBody";
-import type { VaultAdminTarget } from "./vaultAdminTarget";
+import { makePrivateMemberMessage, type VaultAdminTarget } from "./vaultAdminTarget";
 
 export type VaultDialog = "rename" | "settings" | "makePrivate" | "delete" | null;
 
@@ -96,9 +96,10 @@ export function VaultAdminDialogs({
       <ConfirmModal
         tone="warning"
         title={t("settings.vaults.general.makePrivate.title")}
-        message={memberN > 1
-          ? t("settings.vaults.general.makePrivate.confirm", { count: memberN - 1 })
-          : t("settings.vaults.general.makePrivate.confirmAll")}
+        message={makePrivateMemberMessage(memberN, t, {
+          others: "settings.vaults.general.makePrivate.confirm",
+          alone: "settings.vaults.general.makePrivate.confirmAll",
+        })}
         confirmLabel={t("settings.vaults.general.makePrivate.confirmBtn")}
         busy={busy}
         busyLabel={t("settings.vaults.general.makePrivate.converting")}

--- a/src/components/vault-admin/VaultAdminSurface.tsx
+++ b/src/components/vault-admin/VaultAdminSurface.tsx
@@ -1,0 +1,35 @@
+import { ContextMenu } from "@/components/shared/ContextMenu";
+import { VaultAdminDialogs } from "./VaultAdminDialogs";
+import type { useVaultAdmin } from "./useVaultAdmin";
+import type { VaultAdminTarget } from "./vaultAdminTarget";
+
+/**
+ * The menu and the dialogs it opens, mounted as one thing.
+ *
+ * Every host that offers the vault menu needs both, always for the same target,
+ * and the two were previously written out side by side in each host. Pairing
+ * them here gives the trigger-independent behaviour one owner: the rail's
+ * Members/Roles once acted on the active vault rather than the right-clicked
+ * one precisely because no single place held the menu and its target together.
+ */
+export function VaultAdminSurface({
+  admin, target, onClose,
+}: {
+  admin: ReturnType<typeof useVaultAdmin>;
+  target: VaultAdminTarget | null;
+  /** Extra teardown a host needs once a dialog closes, e.g. dropping its menu target. */
+  onClose?: () => void;
+}) {
+  return (
+    <>
+      {admin.pos && <ContextMenu items={admin.items} pos={admin.pos} onClose={admin.closeMenu} />}
+      {target && (
+        <VaultAdminDialogs
+          target={target}
+          dialog={admin.dialog}
+          onClose={() => { admin.setDialog(null); onClose?.(); }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/vault-admin/useVaultAdminActions.test.tsx
+++ b/src/components/vault-admin/useVaultAdminActions.test.tsx
@@ -7,7 +7,7 @@ const h = vi.hoisted(() => ({
   fetchTeamData: vi.fn(async (_id: string) => {}),
   clearTeamKeyCache: vi.fn(),
   reloadLocalVaultObjectStores: vi.fn(async () => {}),
-  saveConnection: vi.fn(async (_c: unknown) => {}),
+  adoptConnection: vi.fn(async (_id: string, _c: unknown) => {}),
   clearTeamConnections: vi.fn(),
   setStatus: vi.fn(),
   setVaultTeamId: vi.fn(),
@@ -53,12 +53,17 @@ vi.mock("@/stores/notificationStore", () => ({
 // One team connection is enough to exercise the copy step; the other entity
 // kinds share the same Promise.allSettled and are left empty.
 vi.mock("@/stores/connectionStore", () => ({
+  connectionToFormData: (c: Record<string, unknown>) => {
+    const { id: _id, ...rest } = c;
+    return rest;
+  },
   useConnectionStore: {
     getState: () => ({
       teamConnections: {
         t1: [{
           id: "c1", name: "web", host: "h", port: 22, username: "u",
-          auth_type: "password", tags: [], identity_id: null, folder_id: null,
+          auth_type: "password", tags: [], identity_id: "i1", key_id: "k1", folder_id: "f1",
+          notes: "prod box", jump_hosts: [{ id: "j1", connection_id: "c9" }],
         }],
       },
       clearTeamConnections: h.clearTeamConnections,
@@ -89,14 +94,14 @@ vi.mock("@/stores/teamVaultStateStore", () => ({
     { getState: () => ({ setStatus: h.setStatus }) },
   ),
 }));
-vi.mock("@/services/connections", () => ({ saveConnection: h.saveConnection }));
-vi.mock("@/services/identities", () => ({ saveIdentity: vi.fn(async () => {}) }));
-vi.mock("@/services/keys", () => ({ saveKey: vi.fn(async () => {}) }));
-vi.mock("@/services/folders", () => ({ saveFolder: vi.fn(async () => {}) }));
+vi.mock("@/services/connections", () => ({ adoptConnection: h.adoptConnection }));
+vi.mock("@/services/identities", () => ({ adoptIdentity: vi.fn(async () => {}) }));
+vi.mock("@/services/keys", () => ({ adoptKey: vi.fn(async () => {}) }));
+vi.mock("@/services/folders", () => ({ adoptFolder: vi.fn(async () => {}) }));
 vi.mock("@/services/snippets", () => ({
-  createSnippet: vi.fn(async () => {}), createSnippetFolder: vi.fn(async () => {}),
+  adoptSnippet: vi.fn(async () => {}), adoptSnippetFolder: vi.fn(async () => {}),
 }));
-vi.mock("@/services/portForwardingRules", () => ({ createPfRule: vi.fn(async () => {}) }));
+vi.mock("@/services/portForwardingRules", () => ({ adoptPfRule: vi.fn(async () => {}) }));
 
 import { useVaultAdminActions } from "./useVaultAdminActions";
 import type { VaultAdminTarget } from "./vaultAdminTarget";
@@ -117,6 +122,17 @@ function Probe() {
   return <button onClick={() => void makePrivate()}>go</button>;
 }
 
+/**
+ * Fires make-private twice in one tick, the way Modal.tsx's Enter handler does:
+ * it stopPropagation()s but never preventDefault()s, so a focused Confirm button
+ * runs `onEnter` and its own native click before React re-renders `busy`.
+ */
+const doubled: Promise<void>[] = [];
+function DoubleProbe() {
+  const { makePrivate } = useVaultAdminActions(target, { onDone });
+  return <button onClick={() => { doubled.push(makePrivate(), makePrivate()); }}>twice</button>;
+}
+
 /** Runs the already-confirmed make-private action. */
 function clickMakePrivate() {
   render(<Probe />);
@@ -133,7 +149,7 @@ beforeEach(() => {
   h.deleteTeam.mockResolvedValue(undefined);
   h.fetchTeamData.mockResolvedValue(undefined);
   h.reloadLocalVaultObjectStores.mockResolvedValue(undefined);
-  h.saveConnection.mockResolvedValue(undefined);
+  h.adoptConnection.mockResolvedValue(undefined);
   h.t.mockImplementation((k: string) => k);
   onDone.mockReset();
   useVaultStore.setState({ setVaultTeamId: h.setVaultTeamId });
@@ -146,7 +162,7 @@ beforeEach(() => {
 afterEach(() => { cleanup(); vi.restoreAllMocks(); });
 
 test("a rejected entity write aborts before anything destructive and says so", async () => {
-  h.saveConnection.mockRejectedValue(new Error("disk full"));
+  h.adoptConnection.mockRejectedValue(new Error("disk full"));
 
   clickMakePrivate();
 
@@ -176,7 +192,7 @@ test("the happy path deletes the team, unlinks the vault and reports success", a
   clickMakePrivate();
 
   await waitFor(() => expect(onDone).toHaveBeenCalled());
-  expect(h.saveConnection).toHaveBeenCalledWith(expect.objectContaining({ name: "web", vault_id: "v1" }));
+  expect(h.adoptConnection).toHaveBeenCalledWith("c1", expect.objectContaining({ name: "web", vault_id: "v1" }));
   expect(h.deleteTeam).toHaveBeenCalledWith("t1");
   expect(h.setVaultTeamId).toHaveBeenCalledWith("v1", null);
   expect(h.clearTeamConnections).toHaveBeenCalledWith("t1");
@@ -210,4 +226,50 @@ test("a transport failure's raw URL never reaches the toast", async () => {
   expect(shown).toContain("settings.vaults.general.makePrivate.removeMembersFailedToast");
   expect(shown).not.toMatch(/http/i);
   expect(shown).not.toContain("v68-server");
+});
+
+test("a copied object keeps its own id and its every field", async () => {
+  clickMakePrivate();
+
+  await waitFor(() => expect(onDone).toHaveBeenCalled());
+  // A fresh id would orphan `password:c1` in the keychain and break every
+  // reference to it, so the id is the assertion — not just that a write happened.
+  const [id, payload] = h.adoptConnection.mock.calls[0] as [string, Record<string, unknown>];
+  expect(id).toBe("c1");
+  expect(payload).toMatchObject({
+    vault_id: "v1",
+    identity_id: "i1",
+    key_id: "k1",
+    folder_id: "f1",
+    notes: "prod box",
+    jump_hosts: [{ id: "j1", connection_id: "c9" }],
+  });
+});
+
+test("a second confirm in the same tick is a no-op, not a second pass", async () => {
+  // Asserted on timing, not call counts: an unguarded second call dies somewhere
+  // in the concurrent dynamic-import race, so `deleteTeam`/`fetchTeamData` counts
+  // read the same with the guard and without it. What only the guard produces is
+  // a second call that settles *before its first await* — while the first is
+  // still inside the copy pass, held here by a fetch that never resolves.
+  h.fetchTeamData.mockReturnValue(new Promise<void>(() => {}));
+  doubled.length = 0;
+  render(<DoubleProbe />);
+
+  fireEvent.click(screen.getByText("twice"));
+  const settled = [false, false];
+  doubled.forEach((p, i) => void p.then(() => { settled[i] = true; }));
+
+  // Let the first call run its import chain and reach the fetch that never
+  // resolves; a second call that was not turned away would get there too.
+  await waitFor(() => expect(h.fetchTeamData).toHaveBeenCalled());
+  for (let i = 0; i < 5; i++) await new Promise((r) => setTimeout(r, 0));
+
+  expect(doubled).toHaveLength(2);
+  expect(settled[1]).toBe(true);
+  expect(settled[0]).toBe(false);
+  // A second pass that got as far as running would show up as either a second
+  // copy attempt or the error toast its own failure raises.
+  expect(h.fetchTeamData).toHaveBeenCalledTimes(1);
+  expect(h.addToast).not.toHaveBeenCalled();
 });

--- a/src/components/vault-admin/useVaultAdminActions.ts
+++ b/src/components/vault-admin/useVaultAdminActions.ts
@@ -6,7 +6,7 @@ import { deleteTeam } from "@/services/teamService";
 import { userFacingReason } from "@/services/errorReason";
 import { reloadLocalVaultObjectStores } from "@/services/vaultTeamMigration";
 import { deleteVaultWithContents } from "@/services/vaultObjectStores";
-import type { VaultAdminTarget } from "./vaultAdminTarget";
+import { makePrivateMemberMessage, type VaultAdminTarget } from "./vaultAdminTarget";
 
 export interface VaultAdminCallbacks {
   onRenamed?: (name: string) => void;
@@ -25,7 +25,6 @@ async function vaultToast(message: string, severity: "info" | "error") {
 export function useVaultAdminActions(target: VaultAdminTarget, cb?: VaultAdminCallbacks) {
   const { t } = useTranslation();
   const { renameVault, setVaultTeamId } = useVaultStore();
-  const { membersByTeam } = useTeamStore();
   const [busy, setBusy] = useState(false);
   // Modal.tsx's Enter handler stopPropagation()s but never preventDefault()s, so
   // pressing Enter on a focused Confirm button fires both the keydown handler
@@ -87,7 +86,7 @@ export function useVaultAdminActions(target: VaultAdminTarget, cb?: VaultAdminCa
     await exclusive(async () => {
       try {
         const { fetchTeamData } = await import("@/services/teamVaultSync");
-        const { useConnectionStore } = await import("@/stores/connectionStore");
+        const { useConnectionStore, connectionToFormData } = await import("@/stores/connectionStore");
         const { useIdentityStore } = await import("@/stores/identityStore");
         const { useKeyStore } = await import("@/stores/keyStore");
         const { useFolderStore } = await import("@/stores/folderStore");
@@ -108,33 +107,32 @@ export function useVaultAdminActions(target: VaultAdminTarget, cb?: VaultAdminCa
 
         await fetchTeamData(teamId);
 
-        const now = new Date().toISOString();
-
-        // Move entities from team memory to local disk with personal vault_id
-        const conns = (useConnectionStore.getState().teamConnections[teamId] ?? [])
-          .map((c) => ({ ...c, vault_id: vaultId, updated_at: now }));
-        const identities = (useIdentityStore.getState().teamIdentities[teamId] ?? [])
-          .map((i) => ({ ...i, vault_id: vaultId, updated_at: now }));
-        const keys = (useKeyStore.getState().teamKeys[teamId] ?? [])
-          .map((k) => ({ ...k, vault_id: vaultId, updated_at: now }));
-        const folders = (useFolderStore.getState().teamFolders[teamId] ?? [])
-          .map((f) => ({ ...f, vault_id: vaultId, updated_at: now }));
-        const snippets = (useSnippetStore.getState().teamSnippets[teamId] ?? [])
-          .map((s) => ({ ...s, vault_id: vaultId, updated_at: now }));
-        const snippetFolders = (useSnippetFolderStore.getState().teamSnippetFolders[teamId] ?? [])
-          .map((f) => ({ ...f, vault_id: vaultId, updated_at: now }));
+        // Adopted under each object's own id, never a freshly minted one. The
+        // object's secrets live in the OS keychain under `password:<id>` /
+        // `key:<id>:private` / `identity:<id>:password`, and every cross-reference
+        // (identity_id, key_id, folder_id, parent_folder_id, connection_ids) names
+        // that id too, so a new id would silently strip the copy of its credentials
+        // and its links. `migrateVaultToTeam` preserves ids on the way in for the
+        // same reason. Adopt also replaces an id it has already written, which is
+        // what makes a retry after a partial failure repair the copy rather than
+        // duplicate it.
+        const conns = useConnectionStore.getState().teamConnections[teamId] ?? [];
+        const identities = useIdentityStore.getState().teamIdentities[teamId] ?? [];
+        const keys = useKeyStore.getState().teamKeys[teamId] ?? [];
+        const folders = useFolderStore.getState().teamFolders[teamId] ?? [];
+        const snippets = useSnippetStore.getState().teamSnippets[teamId] ?? [];
+        const snippetFolders = useSnippetFolderStore.getState().teamSnippetFolders[teamId] ?? [];
         const portRules = (usePortForwardingStore.getState().teamRules[teamId] ?? [])
-          .filter((r) => !r.deleted_at || r.updated_at > r.deleted_at)
-          .map((r) => ({ ...r, vault_id: vaultId, updated_at: now }));
+          .filter((r) => !r.deleted_at || r.updated_at > r.deleted_at);
 
         const writes = await Promise.allSettled([
-          ...conns.map((c) => connApi.saveConnection({ name: c.name, host: c.host, port: c.port, username: c.username, auth_type: c.auth_type, tags: c.tags, identity_id: c.identity_id, folder_id: c.folder_id, vault_id: vaultId })),
-          ...identities.map((i) => identApi.saveIdentity({ name: i.name, username: i.username, key_id: i.key_id, tags: i.tags, folder_id: i.folder_id, vault_id: vaultId })),
-          ...keys.map((k) => keyApi.saveKey({ name: k.name, key_type: k.key_type, tags: k.tags, folder_id: k.folder_id, vault_id: vaultId })),
-          ...folders.map((f) => folderApi.saveFolder({ name: f.name, object_type: f.object_type, parent_folder_id: f.parent_folder_id, vault_id: vaultId })),
-          ...snippets.map((s) => snippetApi.createSnippet({ name: s.name, steps: s.steps, description: s.description, tags: s.tags, folder_id: s.folder_id, favorite: s.favorite, only_for_connection_tags: s.only_for_connection_tags, only_for_distros: s.only_for_distros, vault_id: vaultId })),
-          ...snippetFolders.map((f) => snippetApi.createSnippetFolder({ name: f.name, object_type: f.object_type, parent_folder_id: f.parent_folder_id, vault_id: vaultId })),
-          ...portRules.map((r) => pfApi.createPfRule({ name: r.name, local_port: r.local_port, remote_port: r.remote_port, remote_host: r.remote_host, tunnel_type: r.tunnel_type, bind_host: r.bind_host, target_host: r.target_host, description: r.description, connection_ids: r.connection_ids, folder_id: r.folder_id, vault_id: vaultId })),
+          ...conns.map((c) => connApi.adoptConnection(c.id, { ...connectionToFormData(c), vault_id: vaultId })),
+          ...identities.map((i) => identApi.adoptIdentity(i.id, { name: i.name, username: i.username, key_id: i.key_id, tags: i.tags, folder_id: i.folder_id, pinned: i.pinned, vault_id: vaultId })),
+          ...keys.map((k) => keyApi.adoptKey(k.id, { name: k.name, key_type: k.key_type, tags: k.tags, folder_id: k.folder_id, pinned: k.pinned, vault_id: vaultId })),
+          ...folders.map((f) => folderApi.adoptFolder(f.id, { name: f.name, object_type: f.object_type, parent_folder_id: f.parent_folder_id, color: f.color, icon: f.icon, pinned: f.pinned, vault_id: vaultId })),
+          ...snippets.map((s) => snippetApi.adoptSnippet(s.id, { name: s.name, steps: s.steps, description: s.description, tags: s.tags, folder_id: s.folder_id, favorite: s.favorite, only_for_connection_tags: s.only_for_connection_tags, only_for_distros: s.only_for_distros, vault_id: vaultId })),
+          ...snippetFolders.map((f) => snippetApi.adoptSnippetFolder(f.id, { name: f.name, object_type: f.object_type, parent_folder_id: f.parent_folder_id, color: f.color, icon: f.icon, pinned: f.pinned, vault_id: vaultId })),
+          ...portRules.map((r) => pfApi.adoptPfRule(r.id, { name: r.name, local_port: r.local_port, remote_port: r.remote_port, remote_host: r.remote_host, tunnel_type: r.tunnel_type, bind_host: r.bind_host, target_host: r.target_host, description: r.description, connection_ids: r.connection_ids, folder_id: r.folder_id, vault_id: vaultId })),
         ]);
 
         // Whatever failed to land on disk still exists only inside the team, so
@@ -170,10 +168,14 @@ export function useVaultAdminActions(target: VaultAdminTarget, cb?: VaultAdminCa
 
         await reloadLocalVaultObjectStores();
 
-        const memberN = membersByTeam[teamId]?.length ?? 0;
-        await vaultToast(memberN > 1
-          ? t("settings.vaults.general.madePrivateToast", { count: memberN - 1 })
-          : t("settings.vaults.general.madePrivateToastEmpty"), "info");
+        // Read at toast time, not at render time: the roster this reports on is
+        // the one `fetchTeamData` just refreshed, and the confirm prompt the user
+        // answered was rendered from that same refreshed store.
+        const memberN = useTeamStore.getState().membersByTeam[teamId]?.length ?? 0;
+        await vaultToast(makePrivateMemberMessage(memberN, t, {
+          others: "settings.vaults.general.madePrivateToast",
+          alone: "settings.vaults.general.madePrivateToastEmpty",
+        }), "info");
 
         cb?.onDone?.();
       } catch (e) {

--- a/src/components/vault-admin/vaultAdminTarget.ts
+++ b/src/components/vault-admin/vaultAdminTarget.ts
@@ -51,3 +51,18 @@ export function vaultAdminCapabilities(
     canMakePrivate: isTeam && isOwner && isLocal && target.vaultId !== null,
   };
 }
+
+/**
+ * The one place the make-private copy decides between "N other people" and
+ * "nobody else". The confirm prompt and the success toast say the same thing
+ * about the same team from two different store reads, so the boundary — and the
+ * off-by-one that turns a member list into a count of *other* members — lives
+ * here rather than being written out at each call site.
+ */
+export function makePrivateMemberMessage(
+  memberCount: number,
+  t: (key: string, vars?: { count: number }) => string,
+  keys: { others: string; alone: string },
+): string {
+  return memberCount > 1 ? t(keys.others, { count: memberCount - 1 }) : t(keys.alone);
+}


### PR DESCRIPTION
Follow-ups from #222 / #239. Closes #241, #242, #243, #244.

## #241 — the verification question, answered

> The `rejected.length` guard assumes `saveConnection` / … **reject** on failure rather than resolving with an error result.

They reject. All seven are thin `invoke()` wrappers over `#[tauri::command] -> Result<T, String>`, and every create body is the one `vault_create_command!` macro (`src-tauri/src/commands/vault_object.rs:285`) that `?`-propagates `check_vault_write` and `save_json`. Tauri rejects on `Err`. Abort-before-destructive holds.

## …but the copy minted new ids

`migrateVaultToTeam` copies private → team **under each object's own id** (`src/services/vaultTeamMigration.ts:157`). `makePrivate` copied team → private with `saveConnection` etc., which `Uuid::new_v4()` a fresh one. Consequences:

- Secrets are keyed by object id — `password:<id>`, `passphrase:<id>`, `key:<id>:private`, `identity:<id>:password` (`teamVaultSync.ts:566`) — and the form data carries no secret fields. **Every password, passphrase and private key was orphaned.**
- `identity_id`, `key_id`, `folder_id`, `parent_folder_id`, `connection_ids` were copied verbatim and still named the old ids, which `clearTeam*` then dropped. **Every reference broke.**
- Retrying duplicated the copies, which is #241's remaining gap.
- The connection payload carried 9 of ~35 fields, so jump hosts, env vars, notes, pre/post commands, serial settings and the rest were dropped too.

`connection_adopt` exists for exactly this and names the bug in its own doc comment. Switching to `adopt*(item.id, …)` fixes the secret loss and the broken links, carries the full payload (`connectionToFormData` for connections, the missing `pinned`/`color`/`icon` added elsewhere), and makes a retry **repair** the copy rather than duplicate it.

## #242 — the rail menu reaches every row

`onContextMenu` was bound inside `vaults.map` only, so standalone team rows and orphan rows did nothing on right-click — and standalone team rows are exactly the invited members who have no local vault row and most need Members and Roles.

The four near-identical row wrappers are now one `VaultRailRow` that owns `onContextMenu`, and the rail holds a whole `VaultAdminTarget` instead of a vault id, so it can build the `kind: "cloud"` target `VaultHeader` already builds. Orphan rows stay menu-less on purpose: there is no vault record behind them for rename / share / delete / make-private to act on.

## #244 — two duplicated shapes

1. `VaultAdminSurface` mounts the menu and its dialogs as one thing for both hosts. As the issue argues, this gives trigger-independent behaviour one owner — the class of thing that went wrong once already. `VaultsSection` keeps its direct `VaultAdminDialogs` call; it has no context menu and no `useVaultAdmin`.
2. `makePrivateMemberMessage` derives the "N others" / "nobody else" message once. The toast now reads the roster from the store **after** `fetchTeamData`, not from a render-time closure, so it can no longer disagree with the prompt the user answered.

## #243 — the re-entrancy regression test

Asserted on **timing**, as the issue prescribed. Call counts are vacuous here: an unguarded second call dies in the concurrent dynamic-import race before reaching any mock. Holding the first call at a `fetchTeamData` that never resolves, only the guard produces a second call that settles at all.

Proven to discriminate: with `if (inFlight.current) return;` removed, it fails on `expect(settled[1]).toBe(true)`.

## Verification

- `src/components/layout` + `src/components/vault-admin` 101/101
- `src/stores` 459/459 · `src/services` 1170/1170
- `tsc --noEmit` exit 0
- Both new behavioural tests confirmed to fail against the old behaviour (id minting restored; standalone-row handler removed).

Not live-verified against a real two-account team vault — the id/secret path is the kind of thing worth a run through the team E2E harness before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P77tdVQCRa1zkDCCpqomgr