### PR TITLE
fix(terminal): restore minimap after maximize/minimize a split pane

### DIFF
--- a/src/components/terminal/TerminalMinimap.tsx
+++ b/src/components/terminal/TerminalMinimap.tsx
@@ -55,9 +55,22 @@ export function TerminalMinimap({ sessionId }: Props) {
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const observer = new ResizeObserver(() => setCanvasVersion((v) => v + 1));
-    observer.observe(canvas);
-    return () => observer.disconnect();
+    const bump = () => setCanvasVersion((v) => v + 1);
+    const resizeObserver = new ResizeObserver(bump);
+    resizeObserver.observe(canvas);
+    // Maximize/minimize toggles ancestor panes' display via a `hidden` class.
+    // ResizeObserver isn't reliable across that display:none <-> visible
+    // transition (WebKitGTK in particular can skip the notification), leaving
+    // the canvas stuck at its last-measured size. IntersectionObserver does
+    // report the re-appearance, so use it to force a re-measure.
+    const intersectionObserver = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) bump();
+    });
+    intersectionObserver.observe(canvas);
+    return () => {
+      resizeObserver.disconnect();
+      intersectionObserver.disconnect();
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Multi-pane split: maximizing a pane then minimizing it back left the other panes' scrollbar-minimap blank.
- Root cause: `PaneView` hides non-maximized panes via a `hidden` (display:none) class; `TerminalMinimap`'s canvas re-measure relied solely on a `ResizeObserver`, which doesn't reliably fire across that display:none <-> visible transition (confirmed on WebKitGTK) — canvas stayed stuck at its stale size.
- Fix: add an `IntersectionObserver` on the canvas alongside the existing `ResizeObserver` to force a redraw when the canvas re-enters view.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Live-reproduced on the headless build: 4-pane split, maximize + minimize one pane → 3 other minimaps went blank on the pre-fix code
- [x] Same repro with the fix applied → all 4 minimaps stay visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)