### PR TITLE
fix(vaults): stop make-private reporting itself as a removal (#249)

### DIFF
--- a/src/components/vault-admin/useVaultAdminActions.test.tsx
+++ b/src/components/vault-admin/useVaultAdminActions.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/re
 
 const h = vi.hoisted(() => ({
   deleteTeam: vi.fn(async (_id: string) => {}),
+  markSelfDeparture: vi.fn(),
   addToast: vi.fn(),
   fetchTeamData: vi.fn(async (_id: string) => {}),
   clearTeamKeyCache: vi.fn(),
@@ -34,6 +35,7 @@ vi.mock("@/services/teamService", () => ({
   listPendingInvitations: vi.fn(async () => []),
   revokePendingInvitation: vi.fn(),
 }));
+vi.mock("@/services/teamOffboarding", () => ({ markSelfDeparture: h.markSelfDeparture }));
 vi.mock("@/hooks/useVaultContents", () => ({ useVaultContents: () => [] }));
 vi.mock("@/hooks/useUIContributions", () => ({ useUIContributions: () => [] }));
 vi.mock("@/components/shared/ContentCounts", () => ({ ContentCounts: () => null }));
@@ -198,6 +200,33 @@ test("the happy path deletes the team, unlinks the vault and reports success", a
   expect(h.clearTeamConnections).toHaveBeenCalledWith("t1");
   expect(h.clearTeamKeyCache).toHaveBeenCalled();
   expect(messages()).toEqual(["settings.vaults.general.madePrivateToastEmpty"]);
+});
+
+test("the team's own store slices go with it", async () => {
+  // The offboarding path used to drop these, and it no longer runs for a team
+  // its owner deleted (#249); the roster the toast reports on is read first.
+  useTeamStore.setState({
+    membersByTeam: { t1: [{ user_id: "me" } as never, { user_id: "ana" } as never] },
+  });
+
+  clickMakePrivate();
+
+  await waitFor(() => expect(onDone).toHaveBeenCalled());
+  expect(useTeamStore.getState().teams).toEqual([]);
+  expect(useTeamStore.getState().membersByTeam.t1).toBeUndefined();
+  expect(messages()).toEqual(["settings.vaults.general.madePrivateToast"]);
+});
+
+test("the delete is marked as this client's own before it is sent", async () => {
+  // Unmarked, the server's echo of this delete reads as a kick: the wrong
+  // notice, and an offboarding wipe aimed at the copies just adopted under the
+  // same ids. Marking after the round trip would be too late (#249).
+  clickMakePrivate();
+
+  await waitFor(() => expect(h.deleteTeam).toHaveBeenCalled());
+  expect(h.markSelfDeparture).toHaveBeenCalledWith("t1", "self-deleted");
+  expect(h.markSelfDeparture.mock.invocationCallOrder[0])
+    .toBeLessThan(h.deleteTeam.mock.invocationCallOrder[0]);
 });
 
 test("an unexpected failure surfaces as an error toast, not just a console line", async () => {

--- a/src/components/vault-admin/useVaultAdminActions.ts
+++ b/src/components/vault-admin/useVaultAdminActions.ts
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useVaultStore } from "@/stores/vaultStore";
 import { useTeamStore } from "@/stores/teamStore";
 import { deleteTeam } from "@/services/teamService";
+import { markSelfDeparture } from "@/services/teamOffboarding";
 import { userFacingReason } from "@/services/errorReason";
 import { reloadLocalVaultObjectStores } from "@/services/vaultTeamMigration";
 import { deleteVaultWithContents } from "@/services/vaultObjectStores";
@@ -148,6 +149,11 @@ export function useVaultAdminActions(target: VaultAdminTarget, cb?: VaultAdminCa
         // local teardown: unlinking first would report a private vault to a user
         // whose members can all still open it.
         try {
+          // Marked before the request, not after: the server echoes the delete
+          // back as a membership_changed, and an unmarked one reads as this user
+          // being kicked — the wrong notice, and an offboarding wipe aimed at the
+          // copies just adopted under those same ids (#249).
+          markSelfDeparture(teamId, "self-deleted");
           await deleteTeam(teamId);
         } catch (e) {
           await failToast("settings.vaults.general.makePrivate.removeMembersFailedToast", e);
@@ -172,6 +178,12 @@ export function useVaultAdminActions(target: VaultAdminTarget, cb?: VaultAdminCa
         // the one `fetchTeamData` just refreshed, and the confirm prompt the user
         // answered was rendered from that same refreshed store.
         const memberN = useTeamStore.getState().membersByTeam[teamId]?.length ?? 0;
+
+        // Own the whole teardown: the offboarding path used to drop these
+        // slices, and it no longer runs for a team its owner deleted (#249).
+        // After the toast has read the roster, never before it.
+        useTeamStore.getState().removeTeam(teamId);
+
         await vaultToast(makePrivateMemberMessage(memberN, t, {
           others: "settings.vaults.general.madePrivateToast",
           alone: "settings.vaults.general.madePrivateToastEmpty",

--- a/src/services/sync.teamRemovedFailures.test.ts
+++ b/src/services/sync.teamRemovedFailures.test.ts
@@ -4,6 +4,7 @@ const h = vi.hoisted(() => ({
   deleted: [] as string[],
   failing: new Set<string>(),
   notWiped: [] as string[],
+  departures: new Map<string, string>(),
 }));
 
 vi.mock("@/services/vault", () => ({
@@ -29,9 +30,9 @@ vi.mock("@/services/teamDataManager", () => ({
 }));
 
 // Its real module graph reaches back into the mocked vault store; only the
-// kick-vs-leave answer matters here, and this event is a kick.
+// why-did-this-team-go answer matters here, and an unmarked team is a kick.
 vi.mock("@/services/teamOffboarding", () => ({
-  departedVoluntarily: vi.fn(() => false),
+  selfDeparture: vi.fn((tid: string) => h.departures.get(tid)),
 }));
 
 vi.mock("@/services/teamInbox", () => ({
@@ -58,14 +59,17 @@ import { useConnectionStore } from "@/stores/connectionStore";
 import { useKeyStore } from "@/stores/keyStore";
 import { useIdentityStore } from "@/stores/identityStore";
 import { useTeamStore } from "@/stores/teamStore";
-import { notifySecretsNotWiped } from "@/services/teamInbox";
+import { notifyMembershipEnded, notifySecretsNotWiped } from "@/services/teamInbox";
 
 beforeEach(() => {
   h.deleted = [];
   h.failing = new Set();
   h.notWiped = [];
+  h.departures = new Map();
+  vi.mocked(notifyMembershipEnded).mockClear();
   vi.mocked(notifySecretsNotWiped).mockClear();
   usePendingSecretWipeStore.getState().clearAll();
+  useTeamStore.setState({ teams: [] });
   useConnectionStore.setState({ teamConnections: {} });
   useKeyStore.setState({ teamKeys: {} });
   useIdentityStore.setState({ teamIdentities: {} });
@@ -77,11 +81,18 @@ beforeEach(() => {
  * the next test's stores.
  */
 function seedTeam(tid: string): void {
-  useTeamStore.setState({ teams: [{ id: tid, name: `team-${tid}`, role_ids: [] } as never] });
-  useConnectionStore.setState({
-    teamConnections: { [tid]: [{ id: `c-${tid}`, name: "web", host: "h", port: 22 } as never] },
-  });
-  useKeyStore.setState({ teamKeys: { [tid]: [{ id: `k-${tid}`, name: "deploy" } as never] } });
+  useTeamStore.setState((s) => ({
+    teams: [...s.teams, { id: tid, name: `team-${tid}`, role_ids: [] } as never],
+  }));
+  useConnectionStore.setState((s) => ({
+    teamConnections: {
+      ...s.teamConnections,
+      [tid]: [{ id: `c-${tid}`, name: "web", host: "h", port: 22 } as never],
+    },
+  }));
+  useKeyStore.setState((s) => ({
+    teamKeys: { ...s.teamKeys, [tid]: [{ id: `k-${tid}`, name: "deploy" } as never] },
+  }));
 }
 
 test("wipes the keychain even when a later offboarding step throws", async () => {
@@ -114,4 +125,34 @@ test("says nothing when the wipe succeeded", async () => {
   await vi.waitFor(() => expect(h.deleted).toContain("password:c-t3"));
   expect(usePendingSecretWipeStore.getState().keysByTeamId).toEqual({});
   expect(notifySecretsNotWiped).not.toHaveBeenCalled();
+});
+
+test("a team this client deleted as owner is not offboarded at all", async () => {
+  // Make-private deletes the team and re-adopts its objects locally under the
+  // same ids, so the wipe would name the user's own live credentials and the
+  // notice would announce a removal that never happened (#249).
+  //
+  // ctl is the control: both removals start in the same tick, and the marked
+  // team's path is strictly shorter than the wipe, so the control's deletes
+  // landing means an unsuppressed wipe of t4 would already have landed too.
+  seedTeam("t4");
+  seedTeam("ctl");
+  h.departures.set("t4", "self-deleted");
+
+  await handleRealtimeEvent("membership_changed", "device-1");
+
+  await vi.waitFor(() => expect(h.deleted).toContain("password:c-ctl"));
+  expect(h.deleted.filter((k) => k.includes("t4"))).toEqual([]);
+  expect(notifyMembershipEnded).toHaveBeenCalledTimes(1);
+  expect(notifyMembershipEnded).toHaveBeenCalledWith("team-ctl");
+});
+
+test("a voluntary leave still wipes, and only the notice is suppressed", async () => {
+  seedTeam("t5");
+  h.departures.set("t5", "leave");
+
+  await handleRealtimeEvent("membership_changed", "device-1");
+
+  await vi.waitFor(() => expect(h.deleted).toContain("password:c-t5"));
+  expect(notifyMembershipEnded).not.toHaveBeenCalled();
 });

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -840,6 +840,20 @@ async function offboardFromTeam(tid: string, teamName: string): Promise<void> {
   const step = <T,>(what: string, fn: () => Promise<T> | T) =>
     guarded(`offboarding ${tid}: ${what}`, fn);
 
+  // membership_changed carries no reason, so a departure this client caused
+  // itself is only recognisable from the marker it left behind.
+  const departure = await step("read the departure marker", async () => {
+    const { selfDeparture } = await import("@/services/teamOffboarding");
+    return selfDeparture(tid);
+  });
+
+  // A team this client deleted while owning it is not an offboarding at all.
+  // Make-private has already adopted its objects locally under the *same* ids,
+  // so the wipe below would name the user's own live credentials, the vault
+  // would be marked forbidden, and the notice would announce a removal that
+  // never happened (#249). The caller has already torn down what it owns.
+  if (departure === "self-deleted") return;
+
   // Evict the in-memory vault key immediately so the kicked member can't use a
   // cached key to decrypt data after losing access.
   await step("evict the vault key", async () => {
@@ -887,11 +901,9 @@ async function offboardFromTeam(tid: string, teamName: string): Promise<void> {
   });
 
   await step("notify", async () => {
-    const { departedVoluntarily } = await import("@/services/teamOffboarding");
     const { notifyMembershipEnded, notifySecretsNotWiped } = await import("@/services/teamInbox");
-    // membership_changed cannot tell a kick from a departure, so the leaver's
-    // own client marks its intent before the round trip.
-    if (!departedVoluntarily(tid)) notifyMembershipEnded(teamName);
+    // Only a removal the user did not ask for is news to them.
+    if (departure === undefined) notifyMembershipEnded(teamName);
     // Credentials the user thinks are gone are still readable on this device.
     // That is the one offboarding failure they need to hear about.
     if (leftoverSecrets === undefined || survivors.length > 0) {

--- a/src/services/teamOffboarding.test.ts
+++ b/src/services/teamOffboarding.test.ts
@@ -29,7 +29,7 @@ vi.mock("@/stores/historyStore", () => ({
   useHistoryStore: { getState: () => ({ push: h.push }) },
 }));
 
-import { departMembers, departConsequences, departedVoluntarily } from "./teamOffboarding";
+import { departMembers, departConsequences, markSelfDeparture, selfDeparture } from "./teamOffboarding";
 
 const member = (id: string): TeamMember => ({
   team_id: "t1",
@@ -118,8 +118,17 @@ test("consequences state that a departing member keeps what they already saw", (
 
 test("a voluntary leave is marked so the removal notice can be suppressed", async () => {
   await departMembers("t9", [member("me")], { mode: "leave" });
-  expect(departedVoluntarily("t9")).toBe(true);
+  expect(selfDeparture("t9")).toBe("leave");
 
   await departMembers("t8", [member("ana")], { mode: "remove" });
-  expect(departedVoluntarily("t8")).toBe(false);
+  expect(selfDeparture("t8")).toBeUndefined();
+});
+
+test("a team deleted by its own owner is marked apart from a leave", async () => {
+  // The two are not interchangeable: a leave still needs the full offboarding,
+  // a self-delete needs none of it (#249).
+  markSelfDeparture("t7", "self-deleted");
+
+  expect(selfDeparture("t7")).toBe("self-deleted");
+  expect(selfDeparture("t6")).toBeUndefined();
 });

--- a/src/services/teamOffboarding.ts
+++ b/src/services/teamOffboarding.ts
@@ -13,14 +13,33 @@ export interface DepartConsequences {
   confirmLabel: string;
 }
 
-// Set between calling the removal endpoint for yourself and the server's
-// membership_changed arriving back, so the "you were removed" notice does not
-// fire at someone who left on purpose.
-const voluntaryDepartures = new Set<string>();
+/**
+ * Why a team disappeared from this client's own list, when this client is the
+ * one that caused it.
+ *
+ * - `leave` still needs the full offboarding — the vault really has left this
+ *   device — and only suppresses the "you were removed" notice.
+ * - `self-deleted` is a team this client destroyed while owning it (make
+ *   private, or a rolled-back conversion). Nothing was taken away: the objects
+ *   now live locally under the *same* ids, so an offboarding would wipe the
+ *   user's own credentials and tell them they were kicked (#249).
+ */
+export type SelfDeparture = "leave" | "self-deleted";
 
-/** True while a leave this client initiated is still echoing back from the server. */
-export function departedVoluntarily(teamId: string): boolean {
-  return voluntaryDepartures.has(teamId);
+// Held between the request and the server's membership_changed arriving back:
+// that event carries no reason, so intent has to be recorded locally.
+const selfDepartures = new Map<string, SelfDeparture>();
+
+/** The kind of self-inflicted departure still echoing back, if any. */
+export function selfDeparture(teamId: string): SelfDeparture | undefined {
+  return selfDepartures.get(teamId);
+}
+
+export function markSelfDeparture(teamId: string, kind: SelfDeparture): void {
+  selfDepartures.set(teamId, kind);
+  // A stale marker would only suppress a later genuine removal notice, so it
+  // must not outlive the round trip.
+  setTimeout(() => selfDepartures.delete(teamId), 30_000);
 }
 
 /**
@@ -70,12 +89,7 @@ export async function departMembers(
   const names = members.map((m) => m.handle ?? "").join(", ");
   const store = () => useTeamStore.getState();
 
-  if (opts.mode === "leave") {
-    voluntaryDepartures.add(teamId);
-    // A stale marker would only suppress a later genuine removal notice, so it
-    // must not outlive the round trip.
-    setTimeout(() => voluntaryDepartures.delete(teamId), 30_000);
-  }
+  if (opts.mode === "leave") markSelfDeparture(teamId, "leave");
 
   await runTeamAction({
     pending: opts.mode === "leave"

--- a/src/services/teamSecretWipe.test.ts
+++ b/src/services/teamSecretWipe.test.ts
@@ -26,8 +26,8 @@ beforeEach(() => {
   h.deleted = [];
   h.failing = new Set();
   usePendingSecretWipeStore.getState().clearAll();
-  useConnectionStore.setState({ teamConnections: {} });
-  useKeyStore.setState({ teamKeys: {} });
+  useConnectionStore.setState({ teamConnections: {}, connections: [] });
+  useKeyStore.setState({ teamKeys: {}, keys: [] });
   useTeamStore.setState({ teams: [] });
 });
 
@@ -82,4 +82,19 @@ test("drain drops queued keys for a team the user has rejoined", async () => {
 
   expect(h.deleted).toEqual([]);
   expect(usePendingSecretWipeStore.getState().keysByTeamId).toEqual({});
+});
+
+test("never wipes a secret a local object of the same id still owns", async () => {
+  // Make-private adopts a team's objects locally under their original ids, so
+  // the two stores can name the same keychain entries — and those entries are
+  // now the user's own (#249). Only the objects with no local twin are wiped.
+  seed();
+  useConnectionStore.setState({
+    connections: [{ id: "c1", name: "web", host: "h", port: 22 } as never],
+  });
+
+  expect(await clearTeamStoresAndSecrets("t1")).toEqual([]);
+
+  expect(h.deleted).not.toContain("password:c1");
+  expect(h.deleted).toContain("key:k1:private");
 });

--- a/src/services/teamVaultSync.ts
+++ b/src/services/teamVaultSync.ts
@@ -559,9 +559,21 @@ export async function clearTeamStoresAndSecrets(teamId: string): Promise<string[
   const { usePortForwardingStore } = await import("@/stores/portForwardingStore");
 
   // Wipe secrets from disk before clearing in-memory state so we still have the IDs.
-  const conns = useConnectionStore.getState().teamConnections[teamId] ?? [];
-  const keys = useKeyStore.getState().teamKeys[teamId] ?? [];
-  const identities = useIdentityStore.getState().teamIdentities[teamId] ?? [];
+  // A local object holding the same id owns those same keychain entries, so
+  // wiping them would destroy credentials the user still has every right to:
+  // make-private adopts a team's objects locally under their original ids
+  // (#249). No genuine removal reaches this filter — a member losing access has
+  // no local copy of the team's objects.
+  const localIds = new Set<string>([
+    ...useConnectionStore.getState().connections.map((c) => c.id),
+    ...useKeyStore.getState().keys.map((k) => k.id),
+    ...useIdentityStore.getState().identities.map((i) => i.id),
+  ]);
+  const teamOnly = <T extends { id: string }>(items: T[]) => items.filter((i) => !localIds.has(i.id));
+
+  const conns = teamOnly(useConnectionStore.getState().teamConnections[teamId] ?? []);
+  const keys = teamOnly(useKeyStore.getState().teamKeys[teamId] ?? []);
+  const identities = teamOnly(useIdentityStore.getState().teamIdentities[teamId] ?? []);
   const failedKeys = await deleteSecrets([
     ...conns.flatMap((c) => [`key:${c.id}`, `password:${c.id}`, `passphrase:${c.id}`]),
     ...keys.flatMap((k) => [`key:${k.id}:private`, `key:${k.id}:public`, `key:${k.id}:passphrase`]),

--- a/src/services/vaultConvert.test.ts
+++ b/src/services/vaultConvert.test.ts
@@ -3,6 +3,7 @@ import { test, expect, vi, beforeEach } from "vitest";
 const h = vi.hoisted(() => ({
   createTeam: vi.fn(async (name: string) => ({ id: "team-1", name, owner_id: "u1", owner_tier: "pro", created_at: "", role_ids: [] })),
   deleteTeam: vi.fn(async () => {}),
+  markSelfDeparture: vi.fn(),
   migrateVaultToTeam: vi.fn(async () => {}),
   initTeamVaultKey: vi.fn(async () => {}),
   invoke: vi.fn(async () => null),
@@ -13,6 +14,7 @@ const h = vi.hoisted(() => ({
 vi.mock("@tauri-apps/api/core", () => ({ invoke: h.invoke }));
 vi.mock("@/i18n", () => ({ default: { t: (k: string) => k } }));
 vi.mock("@/services/teamService", () => ({ createTeam: h.createTeam, deleteTeam: h.deleteTeam }));
+vi.mock("@/services/teamOffboarding", () => ({ markSelfDeparture: h.markSelfDeparture }));
 vi.mock("@/services/vaultTeamMigration", () => ({ migrateVaultToTeam: h.migrateVaultToTeam }));
 vi.mock("@/services/teamVaultSync", () => ({ initTeamVaultKey: h.initTeamVaultKey }));
 vi.mock("@/stores/notificationStore", () => ({
@@ -71,6 +73,18 @@ test("a failed key init surfaces rather than leaving a silent half-conversion", 
 
   expect(h.migrateVaultToTeam).not.toHaveBeenCalled();
   expect(useVaultStore.getState().vaults[0].teamId).toBeUndefined();
+});
+
+test("the rollback delete is marked as this client's own", async () => {
+  // The objects it uploaded still exist locally under the same ids, so this
+  // deletion must not come back as an offboarding and wipe them (#249).
+  h.migrateVaultToTeam.mockRejectedValueOnce(new Error("upload failed"));
+
+  await expect(convertVaultToTeam(VAULT, "Ops")).rejects.toThrow("upload failed");
+
+  expect(h.markSelfDeparture).toHaveBeenCalledWith("team-1", "self-deleted");
+  expect(h.markSelfDeparture.mock.invocationCallOrder[0])
+    .toBeLessThan(h.deleteTeam.mock.invocationCallOrder[0]);
 });
 
 test("a team the server refuses to delete still leaves the vault private", async () => {

--- a/src/services/vaultConvert.ts
+++ b/src/services/vaultConvert.ts
@@ -6,6 +6,7 @@ import { runTeamAction } from "@/services/teamActionFeedback";
 import { markTeamVaultLoadedAfterLocalActivation } from "@/services/teamVaultActivation";
 import { migrateVaultToTeam } from "@/services/vaultTeamMigration";
 import { deleteTeam } from "@/services/teamService";
+import { markSelfDeparture } from "@/services/teamOffboarding";
 
 /**
  * Turn a private vault into a team vault, carrying its existing contents over.
@@ -28,6 +29,10 @@ export async function createTeamVaultFromVault(vaultId: string, vaultName: strin
   } catch (e) {
     useVaultStore.getState().setVaultTeamId(vaultId, null);
     useTeamStore.getState().removeTeam(team.id);
+    // Same reason as make-private: this deletion is the rollback of a
+    // conversion whose objects still exist locally under the same ids, so it
+    // must not come back as an offboarding (#249).
+    markSelfDeparture(team.id, "self-deleted");
     await deleteTeam(team.id).catch(() => {});
     throw e;
   }


### PR DESCRIPTION
Fixes #249.

## The wrong notice

Make-private deletes the team, the server echoes it back as a `membership_changed`, and the team-list diff read this client's own deletion as a kick — so the owner got `notifications.inbox.membershipEnded.message`: *"You were removed from **E2E Vault**. Its hosts, keys and snippets are gone from this device, and credentials you used there should be rotated."* Every clause is false for the user who just took those objects private.

## The wipe

`offboardFromTeam` runs `clearTeamStoresAndSecrets` before anything else, and that derives its keychain keys from the object ids still in the team store slices. Since #247 the local copies live under exactly those ids, so that key list was a list of the user's own live credentials. They survived only because `makePrivate` cleared the slices in the same tick `deleteTeam` resolved — correctness by ordering between an `await` continuation and a sync poll.

## The change

- `voluntaryDepartures` becomes `selfDepartures`, a map of `"leave" | "self-deleted"`. A `leave` behaves exactly as before: full offboarding, notice suppressed. A `self-deleted` team is not an offboarding at all — no wipe, no `forbidden` status, no notice.
- `makePrivate` marks `self-deleted` **before** `deleteTeam`, and now drops the team's own store slices (`removeTeam`) itself rather than leaving that to the sync poll — read after the toast has read the roster, never before.
- `vaultConvert`'s rollback delete is marked the same way, for the same reason: the objects it uploaded still exist locally under those ids.
- Defence in depth: `clearTeamStoresAndSecrets` never wipes a keychain entry a *local* object of the same id still owns. A genuine removal never reaches that filter — a member losing access holds no local copy of the team's objects.

## Tests

Each new test was verified by reverting its fix and watching it fail:

- `sync.teamRemovedFailures` — a self-deleted team is not offboarded, with an unmarked control team in the same event proving the harness would have caught a wipe; and a `leave` still wipes with only the notice suppressed.
- `teamSecretWipe` — never wipes a secret a local object of the same id owns.
- `useVaultAdminActions` — the delete is marked before it is sent; the team's store slices go with it, after the roster is read.
- `vaultConvert` — the rollback delete is marked too.

`services` 1175, `stores` 459, `components` 910, `tsc --noEmit` exit 0.
