### PR TITLE
fix: stop macOS capitalising the first letter of SSH usernames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The username of a host and of a keychain identity no longer picks up a
+  capital first letter on macOS. Typing `abcd` and clicking away left `Abcd`
+  behind, and an SSH username is case-sensitive, so the host was saved with a
+  different login than the one that was typed. Fields you name yourself, such
+  as a connection or a snippet name, keep the normal macOS behaviour.
+
 ## [0.32.1] - 2026-09-07
 
 ### Fixed

--- a/src/components/connections/ConnectionForm.tsx
+++ b/src/components/connections/ConnectionForm.tsx
@@ -41,6 +41,7 @@ import {
   formInputStyle,
   formLabelClass,
   formLabelStyle,
+  formIdentifierProps,
 } from "@/components/shared/Panel";
 import { SecretInput, TagsAndFolderFields } from "@/components/shared/vaultObjectForm";
 import {
@@ -580,6 +581,7 @@ const ConnectionForm = forwardRef<ConnectionFormHandle, Props>(function Connecti
                     value={username}
                     onChange={(e) => { markDirty(); setUsername(e.target.value); }}
                     placeholder="root"
+                    {...formIdentifierProps}
                   />
                 </div>
 

--- a/src/components/connections/connectionForms.characterisation.test.tsx
+++ b/src/components/connections/connectionForms.characterisation.test.tsx
@@ -373,3 +373,15 @@ test("a dirty edit marks the form dirty on both forms", () => {
   fireEvent.click(document.querySelector("[data-tag-selector]")!);
   expect(serial.ref.current!.isDirty()).toBe(true);
 });
+
+// #252: macOS capitalised the first letter of the SSH username on blur, so
+// `abcd` was saved as `Abcd`, a different login on a case-sensitive host.
+// autocorrect and spellcheck are the two that actually stop it in WKWebView;
+// autocapitalize covers virtual keyboards on the Android build.
+test("the ssh username field opts out of OS capitalisation and autocorrect", () => {
+  renderSsh();
+  const username = screen.getByPlaceholderText("root");
+  expect(username.getAttribute("autocapitalize")).toBe("off");
+  expect(username.getAttribute("autocorrect")).toBe("off");
+  expect(username.getAttribute("spellcheck")).toBe("false");
+});

--- a/src/components/keychain/IdentityForm.tsx
+++ b/src/components/keychain/IdentityForm.tsx
@@ -21,7 +21,7 @@ import { useStoredSecrets } from "@/hooks/useStoredSecrets";
 import { StoredSecretsNote } from "@/components/shared/VaultUnavailableNote";
 import {
   PanelShell, PanelHeader, FormSection,
-  formInputClass, formInputStyle, formLabelClass, formLabelStyle,
+  formInputClass, formInputStyle, formLabelClass, formLabelStyle, formIdentifierProps,
 } from "@/components/shared/Panel";
 import { PanelActionsMenu } from "@/components/shared/PanelActionsMenu";
 import { PickerSurface } from "@/components/shared/PickerSurface";
@@ -311,6 +311,7 @@ export function IdentityForm({ initial, onSubmit, onClose, onDelete, flushRef, i
               value={username}
               onChange={(e) => { markDirty(); setUsername(e.target.value); }}
               placeholder="root"
+              {...formIdentifierProps}
             />
           </div>
 

--- a/src/components/keychain/keychainForms.characterisation.test.tsx
+++ b/src/components/keychain/keychainForms.characterisation.test.tsx
@@ -418,3 +418,13 @@ test("the identity form refuses to save inline key material with a bad public ha
   expect(onSubmit).not.toHaveBeenCalled();
   expect(screen.getByText("keychain.keyForm.invalidPublicKey")).toBeTruthy();
 });
+
+// #252, sibling of the SSH host form: a keychain identity feeds the same
+// case-sensitive SSH login, so it must opt out of OS text checking too.
+test("the identity username field opts out of OS capitalisation and autocorrect", () => {
+  renderIdentity();
+  const username = screen.getByPlaceholderText("root");
+  expect(username.getAttribute("autocapitalize")).toBe("off");
+  expect(username.getAttribute("autocorrect")).toBe("off");
+  expect(username.getAttribute("spellcheck")).toBe("false");
+});

--- a/src/components/shared/Panel.tsx
+++ b/src/components/shared/Panel.tsx
@@ -18,6 +18,32 @@ export const formLabelClass = "block text-xs font-medium mb-1.5";
 
 export const formLabelStyle: React.CSSProperties = { color: "var(--t-text-dim)" };
 
+/*
+  Spread onto any field holding a machine identifier the remote end compares
+  byte-for-byte, such as an SSH username, so the OS cannot rewrite
+  `abcd` into `Abcd` and change which account we log in as (#252).
+
+  All three are needed, and not for the reason the names suggest. Measured in a
+  bare WKWebView, the engine Tauri renders through, with macOS "Capitalize
+  words automatically" on:
+
+    autocapitalize="off"   still capitalised, no effect on a hardware keyboard
+    autocorrect="off"      stopped it
+    spellcheck="false"     stopped it
+
+  So macOS routes this through text checking, not through autocapitalize.
+  autocapitalize still earns its place: it is the attribute that governs
+  virtual keyboards, which is what the Android build gets typed into.
+
+  Free-text fields the user names themselves, such as connection names and
+  snippet titles, want the OS assistance and should not use this.
+*/
+export const formIdentifierProps = {
+  autoCapitalize: "off",
+  autoCorrect: "off",
+  spellCheck: false,
+} as const;
+
 // ─── Panel primitives ───────────────────────────────────────────────────────
 
 export function PanelShell({ children }: { children: React.ReactNode }) {

--- a/src/components/terminal/connection-overlay/UsernamePromptPanel.tsx
+++ b/src/components/terminal/connection-overlay/UsernamePromptPanel.tsx
@@ -7,6 +7,7 @@ import { useUIStore } from "@/stores/uiStore";
 import { resolveVaultIdForSave } from "@/hooks/useWritableVaultIds";
 import { selectVaultScopedItems } from "@/utils/vaultScopedItems";
 import IdentitySelector from "@/components/connections/IdentitySelector";
+import { formIdentifierProps } from "@/components/shared/Panel";
 import { DecisionPanel } from "./DecisionPanel";
 import type { ConnectRetryOverride } from "./types";
 
@@ -103,9 +104,7 @@ export function UsernamePromptPanel({
             onChange={(event) => setUsername(event.target.value)}
             placeholder={t("terminal.overlay.usernamePrompt.placeholder")}
             autoFocus
-            autoCapitalize="off"
-            autoCorrect="off"
-            spellCheck={false}
+            {...formIdentifierProps}
             className="w-full px-3 py-2 rounded-lg text-sm outline-hidden bg-(--t-bg-base) border border-(--t-border) text-(--t-text-primary) focus:border-(--t-accent)"
           />
         )}


### PR DESCRIPTION
Closes #252.

## What

macOS capitalises the first letter of a plain text input when it loses focus, so typing `abcd` into a host's Identity username and clicking away saved `Abcd`. An SSH username is case-sensitive, so the host was stored with a different login than the one that was typed, and the connection then failed for a reason nothing on screen explained.

The keychain identity form has the same field with the same defect, and a keychain identity feeds the same SSH login, so it is fixed here too.

## Which attribute actually fixes it

Worth reading before reviewing, because the obvious attribute is the one that does nothing.

`autocapitalize` is the attribute whose name matches the bug, and on its own it does not fix it. I measured all three in a bare `WKWebView`, the engine Tauri renders through, with the macOS "Capitalize words automatically" setting confirmed on (`NSAutomaticCapitalizationEnabled = 1`). Typed `abcd` into each field, clicked away, read the value back:

| Attribute on the input | Value after blur | |
| --- | --- | --- |
| none (control) | `Abcd` | capitalised |
| `autocapitalize="off"` | `Abcd` | **capitalised** |
| `autocorrect="off"` | `abcd` | left alone |
| `spellcheck="false"` | `abcd` | left alone |
| all three | `abcd` | left alone |

So macOS routes this through text checking, not through autocapitalize. That matches the MDN note that `autocapitalize` has no effect when typing on a hardware keyboard.

Two further things that fell out of measuring it:

- **Safari does not reproduce this at all.** The control stays `abcd` there even with the OS setting on, so Safari must be opting web content out of the text-checking pipeline. Anyone verifying this needs a WKWebView, not a browser tab.
- **`autocapitalize="off"` still earns its place**, just not on desktop. It is the attribute that governs virtual keyboards, which is what the Android build gets typed into.

Hence all three ship together rather than only the one that fixes macOS.

## How

`src/components/shared/Panel.tsx` gains a `formIdentifierProps` constant next to the existing `formInputClass` / `formInputStyle` exports:

```ts
export const formIdentifierProps = {
  autoCapitalize: "off",
  autoCorrect: "off",
  spellCheck: false,
} as const;
```

It is spread onto the username input of `ConnectionForm` and of `IdentityForm`. `UsernamePromptPanel` already carried these same three attributes written out inline, so it now uses the shared constant rather than leaving a third copy of the same shape, per the DRY rule in `CLAUDE.md`. The measured table above is recorded as a comment on the constant, so the next person does not have to re-derive why an apparently redundant attribute is there.

## Scope

Limited to usernames, because that is the only field where a capital letter changes what the app does rather than how it looks:

| Field | Capitalised | Effect |
| --- | --- | --- |
| Username | `abcd` to `Abcd` | Different SSH login. Fixed here. |
| Hostname | `srv` to `Srv` | Cosmetic. DNS is case-insensitive. Left alone. |
| Connection or snippet name | `prod` to `Prod` | Wanted. Left alone. |

Happy to widen it to hostnames in this PR if you would rather have them consistent.

## Testing

Please lean on CI. I do not have the toolchain set up locally, so **none of the required checks were run**: no `cargo fmt`, `cargo clippy`, `cargo build` or `pnpm run build`, and the two tests below have not been executed.

Added to the existing characterisation suites:

- `connectionForms.characterisation.test.tsx` asserts the SSH username input renders `autocapitalize="off"`, `autocorrect="off"` and `spellcheck="false"`.
- `keychainForms.characterisation.test.tsx` asserts the same for the identity username input.

All three are asserted deliberately. Since `autocorrect` and `spellcheck` are the two carrying the fix, a test that checked only `autocapitalize` would pass while the bug came straight back.

The change is attributes-only, with no behavioural code touched.
