### PR TITLE
feat(teams): rotate the team DEK on membership change — client (#217)

### DIFF
--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -114,6 +114,8 @@
       "failedToDeleteTeam": "Failed to delete team: {{status}}",
       "failedToListMembers": "Failed to list members: {{status}}",
       "failedToListVaultKeyHolders": "Failed to list vault key holders: {{status}}",
+      "failedToCheckRotationStatus": "Failed to check rotation status: {{status}}",
+      "failedToRotateVaultKey": "Failed to rotate vault key: {{status}}",
       "failedToAddMember": "Failed to add member: {{status}}",
       "failedToRemoveMember": "Failed to remove member: {{status}}",
       "failedToAssignRole": "Failed to assign role: {{status}}",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -114,6 +114,8 @@
       "failedToDeleteTeam": "Échec de la suppression de l'équipe : {{status}}",
       "failedToListMembers": "Échec du chargement des membres : {{status}}",
       "failedToListVaultKeyHolders": "Échec du chargement des détenteurs de clé de coffre : {{status}}",
+      "failedToCheckRotationStatus": "Échec de la vérification de l'état de rotation : {{status}}",
+      "failedToRotateVaultKey": "Échec de la rotation de la clé de coffre : {{status}}",
       "failedToAddMember": "Échec de l'ajout du membre : {{status}}",
       "failedToRemoveMember": "Échec de la suppression du membre : {{status}}",
       "failedToAssignRole": "Échec de l'attribution du rôle : {{status}}",

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -114,6 +114,8 @@
       "failedToDeleteTeam": "Не удалось удалить команду: {{status}}",
       "failedToListMembers": "Не удалось получить список участников: {{status}}",
       "failedToListVaultKeyHolders": "Не удалось получить список владельцев ключа хранилища: {{status}}",
+      "failedToCheckRotationStatus": "Не удалось проверить статус ротации: {{status}}",
+      "failedToRotateVaultKey": "Не удалось выполнить ротацию ключа хранилища: {{status}}",
       "failedToAddMember": "Не удалось добавить участника: {{status}}",
       "failedToRemoveMember": "Не удалось удалить участника: {{status}}",
       "failedToAssignRole": "Не удалось назначить роль: {{status}}",

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -114,6 +114,8 @@
       "failedToDeleteTeam": "删除团队失败：{{status}}",
       "failedToListMembers": "获取成员列表失败：{{status}}",
       "failedToListVaultKeyHolders": "获取保险库密钥持有者列表失败：{{status}}",
+      "failedToCheckRotationStatus": "检查密钥轮换状态失败：{{status}}",
+      "failedToRotateVaultKey": "轮换保险库密钥失败：{{status}}",
       "failedToAddMember": "添加成员失败：{{status}}",
       "failedToRemoveMember": "移除成员失败：{{status}}",
       "failedToAssignRole": "分配角色失败：{{status}}",

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -88,3 +88,16 @@ export function installGlobalErrorLogging(): void {
 export function logFailure(context: string): (e: unknown) => void {
   return (e) => log.warn(`${context} failed:`, e instanceof Error ? e.message : safeJson(e));
 }
+
+/**
+ * Logs every rejected entry of a `Promise.allSettled` result via logFailure,
+ * so a batch of independent per-item work (a keychain wipe, a decrypt pass)
+ * never drops a failure silently just because the batch itself "succeeded".
+ * `contextFor(i)` gets the same index used to build `results`, so callers can
+ * name the item (its id, key, etc.) in the log line.
+ */
+export function logSettledFailures<T>(results: PromiseSettledResult<T>[], contextFor: (index: number) => string): void {
+  results.forEach((r, i) => {
+    if (r.status === "rejected") logFailure(contextFor(i))(r.reason);
+  });
+}

--- a/src/services/sync.teamMembers.test.ts
+++ b/src/services/sync.teamMembers.test.ts
@@ -1,0 +1,43 @@
+import { test, expect, vi, beforeEach } from "vitest";
+
+const h = vi.hoisted(() => ({
+  reconcileTeamVaultKeys: vi.fn(async () => {}),
+  checkAndRotateTeamKey: vi.fn(async () => {}),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn(async () => null) }));
+
+// The team_members: branch reloads teams/members/roles/pending-invitations
+// through the real teamStore actions; stubbing the underlying teamService
+// calls (rather than the store) keeps that reload harmless without having to
+// re-mock every store action.
+vi.mock("@/services/teamService", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/teamService")>()),
+  listTeams: vi.fn(async () => []),
+  listMembers: vi.fn(async () => []),
+  listRoles: vi.fn(async () => []),
+  listPendingInvitations: vi.fn(async () => []),
+}));
+
+vi.mock("@/services/teamVaultSync", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/teamVaultSync")>()),
+  reconcileTeamVaultKeys: h.reconcileTeamVaultKeys,
+}));
+
+vi.mock("@/services/teamKeyRotation", () => ({
+  checkAndRotateTeamKey: h.checkAndRotateTeamKey,
+}));
+
+import { handleRealtimeEvent } from "./sync";
+
+beforeEach(() => {
+  h.reconcileTeamVaultKeys.mockClear();
+  h.checkAndRotateTeamKey.mockClear();
+});
+
+test("a team_members event checks for a DEK rotation alongside key reconciliation", async () => {
+  await handleRealtimeEvent("team_members:t1", "device-1");
+
+  expect(h.reconcileTeamVaultKeys).toHaveBeenCalledWith("t1");
+  expect(h.checkAndRotateTeamKey).toHaveBeenCalledWith("t1");
+});

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -920,6 +920,12 @@ export async function handleRealtimeEvent(eventData: string, myDeviceId: string)
     // old diff saw zero newcomers and skipped distribution (issue #41).
     const { reconcileTeamVaultKeys } = await import("@/services/teamVaultSync");
     await reconcileTeamVaultKeys(teamId).catch(logFailure(`team_members: reconcileTeamVaultKeys team=${teamId}`));
+    // Opportunistic rotate-and-drain (#217): reconcileTeamVaultKeys only ever
+    // adds keys for new members: it does nothing on a removal, because the
+    // removed member's key row is already gone by the time this event fires,
+    // so "missing" stays empty. This is the only place rotation gets checked.
+    const { checkAndRotateTeamKey } = await import("@/services/teamKeyRotation");
+    checkAndRotateTeamKey(teamId).catch(logFailure(`team_members: checkAndRotateTeamKey team=${teamId}`));
     useTeamStore.getState().loadPendingInvitations(teamId).catch(logFailure(`team_members: loadPendingInvitations team=${teamId}`));
   } else if (eventData.startsWith("pending_invitations_changed:")) {
     useTeamStore.getState().loadMyPendingInvitations().catch(logFailure("pending_invitations_changed: loadMyPendingInvitations"));

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -923,7 +923,8 @@ export async function handleRealtimeEvent(eventData: string, myDeviceId: string)
     // Opportunistic rotate-and-drain (#217): reconcileTeamVaultKeys only ever
     // adds keys for new members: it does nothing on a removal, because the
     // removed member's key row is already gone by the time this event fires,
-    // so "missing" stays empty. This is the only place rotation gets checked.
+    // so "missing" stays empty. onTeamLogin (teamDataManager.ts) also checks
+    // this, for a client that was offline when the realtime event fired.
     const { checkAndRotateTeamKey } = await import("@/services/teamKeyRotation");
     checkAndRotateTeamKey(teamId).catch(logFailure(`team_members: checkAndRotateTeamKey team=${teamId}`));
     useTeamStore.getState().loadPendingInvitations(teamId).catch(logFailure(`team_members: loadPendingInvitations team=${teamId}`));

--- a/src/services/teamDataManager.onTeamLogin.test.ts
+++ b/src/services/teamDataManager.onTeamLogin.test.ts
@@ -1,0 +1,53 @@
+import { test, expect, vi, beforeEach } from "vitest";
+
+const h = vi.hoisted(() => ({
+  fetchTeamData: vi.fn(async (_teamId: string) => {}),
+  clearTeamKeyCache: vi.fn(),
+  reconcileTeamVaultKeys: vi.fn(async (_teamId: string) => {}),
+  drainPendingSecretWipes: vi.fn(async () => {}),
+  checkAndRotateTeamKey: vi.fn(async (_teamId: string) => {}),
+  teams: [] as { id: string }[],
+}));
+
+vi.mock("@/services/teamVaultSync", () => ({
+  fetchTeamData: h.fetchTeamData,
+  clearTeamKeyCache: h.clearTeamKeyCache,
+  reconcileTeamVaultKeys: h.reconcileTeamVaultKeys,
+  drainPendingSecretWipes: h.drainPendingSecretWipes,
+}));
+vi.mock("@/services/teamKeyRotation", () => ({
+  checkAndRotateTeamKey: h.checkAndRotateTeamKey,
+}));
+vi.mock("@/stores/teamStore", () => ({
+  useTeamStore: { getState: () => ({ teams: h.teams }) },
+}));
+
+import { onTeamLogin } from "./teamDataManager";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.teams = [];
+});
+
+// #217: the realtime team_members handler (sync.ts) is the only other place
+// rotation gets checked. A client offline when a member was removed never
+// receives that event, so login must also check — otherwise the team stays
+// permanently un-rotated / stuck draining until some unrelated event fires.
+test("onTeamLogin checks rotation for every team the user belongs to", async () => {
+  h.teams = [{ id: "t1" }, { id: "t2" }];
+
+  await onTeamLogin();
+
+  expect(h.checkAndRotateTeamKey.mock.calls.map((c) => c[0]).sort()).toEqual(["t1", "t2"]);
+});
+
+test("a rotation-check failure for one team does not block the others (allSettled)", async () => {
+  h.teams = [{ id: "t1" }, { id: "t2" }];
+  h.checkAndRotateTeamKey.mockImplementation(async (teamId: string) => {
+    if (teamId === "t1") throw new Error("offline");
+  });
+
+  await expect(onTeamLogin()).resolves.toBeUndefined();
+
+  expect(h.checkAndRotateTeamKey).toHaveBeenCalledWith("t2");
+});

--- a/src/services/teamDataManager.ts
+++ b/src/services/teamDataManager.ts
@@ -20,6 +20,7 @@ import { useFolderStore } from "@/stores/folderStore";
 import { useSnippetStore } from "@/stores/snippetStore";
 import { useSnippetFolderStore } from "@/stores/snippetFolderStore";
 import { fetchTeamData, clearTeamKeyCache, reconcileTeamVaultKeys, drainPendingSecretWipes } from "@/services/teamVaultSync";
+import { checkAndRotateTeamKey } from "@/services/teamKeyRotation";
 import { logFailure } from "@/lib/logger";
 
 // Statuses that warrant a retry (transient — key not yet distributed)
@@ -44,6 +45,11 @@ export async function onTeamLogin(): Promise<void> {
       // offline — self-heals the async invite-acceptance lockout (issue #41).
       // No-op for non-holders (they can't unwrap the key to redistribute).
       await reconcileTeamVaultKeys(teamId);
+      // The realtime team_members handler (sync.ts) is the only other place
+      // rotation gets checked, so a client offline when a member was removed
+      // would otherwise never rotate or resume draining until some other,
+      // unrelated membership event happened to fire (#217).
+      await checkAndRotateTeamKey(teamId).catch(logFailure(`onTeamLogin: checkAndRotateTeamKey team=${teamId}`));
     }),
   );
 }

--- a/src/services/teamKeyRotation.test.ts
+++ b/src/services/teamKeyRotation.test.ts
@@ -66,7 +66,7 @@ vi.mock("@/services/teamVaultSyncCore", () => ({
 }));
 
 import { checkAndRotateTeamKey } from "./teamKeyRotation";
-import { getTeamVaultKeyAtVersion } from "@/services/teamVaultSync";
+import { getTeamVaultKeyAtVersion, getCachedTeamKeyVersion } from "@/services/teamVaultSync";
 
 beforeEach(() => {
   h.status = { stale: false, draining: false };
@@ -178,4 +178,52 @@ test("draining: does not touch a secret already at or ahead of the current versi
   await checkAndRotateTeamKey("t1");
 
   expect(h.reencryptSecretCalls).toHaveLength(0);
+});
+
+test("draining: a legacy secret with no key_version fetches epoch 1, not vault-key/undefined", async () => {
+  // The team has already rotated once (current epoch 2), so an undefined
+  // key_version (epoch 1) is genuinely stale and must be re-encrypted.
+  vi.mocked(getCachedTeamKeyVersion).mockReturnValueOnce(2);
+  h.status = { stale: false, draining: true };
+  h.objects = [
+    { object_id: "c1", object_type: "connection", metadata: { v: 2, enc: "old", kv: 2 } },
+  ];
+  h.secrets = [
+    // key_version is undefined here (a pre-#217 row).
+    { secret_id: "s1", object_id: "c1", ciphertext: "b64(old-cipher)" } as never,
+  ];
+
+  await checkAndRotateTeamKey("t1");
+
+  expect(getTeamVaultKeyAtVersion).toHaveBeenCalledWith("t1", 1);
+});
+
+test("draining: does not re-encrypt a secret belonging to a soft-deleted object", async () => {
+  h.status = { stale: false, draining: true };
+  h.objects = [
+    { object_id: "c1", object_type: "connection", metadata: { v: 2, enc: "old", kv: 0 }, deleted_at: "2026-01-01" },
+  ];
+  h.secrets = [
+    { secret_id: "s1", object_id: "c1", ciphertext: "b64(old-cipher)", key_version: 0 },
+  ];
+
+  await checkAndRotateTeamKey("t1");
+
+  expect(h.reencryptSecretCalls).toHaveLength(0);
+});
+
+test("draining: a failing object batch write does not block the secrets batch that follows", async () => {
+  h.status = { stale: false, draining: true };
+  h.objects = [
+    { object_id: "c1", object_type: "connection", metadata: { v: 2, enc: "old", kv: 0 } },
+  ];
+  h.secrets = [
+    { secret_id: "s1", object_id: "c1", ciphertext: "b64(old-cipher)", key_version: 0 },
+  ];
+  const { reencryptTeamObjects } = await import("@/services/teamObjects");
+  vi.mocked(reencryptTeamObjects).mockRejectedValueOnce(new Error("PUT 500"));
+
+  await expect(checkAndRotateTeamKey("t1")).resolves.toBeUndefined();
+
+  expect(h.reencryptSecretCalls).toHaveLength(1);
 });

--- a/src/services/teamKeyRotation.test.ts
+++ b/src/services/teamKeyRotation.test.ts
@@ -11,6 +11,7 @@ const h = vi.hoisted(() => ({
   reencryptSecretCalls: [] as unknown[],
   getTeamVaultKeyAtVersionCalls: [] as unknown[][],
   deleteTeamKeyCalls: [] as string[],
+  reencryptLegacyBlobCalls: [] as unknown[][],
 }));
 
 vi.mock("@/services/teamService", () => ({
@@ -21,6 +22,7 @@ vi.mock("@/services/teamService", () => ({
 }));
 vi.mock("@/services/multiplayerService", () => ({
   wrapSessionKeyForUser: vi.fn(async (_bytes: Uint8Array, pk: string) => `wrapped-for-${pk}`),
+  publishMyPublicKey: vi.fn(async () => "me-published-pk"),
 }));
 vi.mock("@/services/teamVaultSync", () => ({
   getTeamVaultKey: vi.fn(async () => [1, 2, 3]),
@@ -30,6 +32,7 @@ vi.mock("@/services/teamVaultSync", () => ({
     return [7, 7, 7];
   }),
   deleteTeamKey: vi.fn((teamId: string) => { h.deleteTeamKeyCalls.push(teamId); }),
+  reencryptLegacyBlobIfStale: vi.fn(async (...args: unknown[]) => { h.reencryptLegacyBlobCalls.push(args); }),
 }));
 vi.mock("@/services/teamObjects", () => ({
   listTeamObjects: vi.fn(async () => h.objects),
@@ -76,6 +79,7 @@ beforeEach(() => {
   h.reencryptSecretCalls = [];
   h.getTeamVaultKeyAtVersionCalls = [];
   h.deleteTeamKeyCalls = [];
+  h.reencryptLegacyBlobCalls = [];
 });
 
 test("neither stale nor draining: does nothing", async () => {
@@ -97,6 +101,12 @@ test("stale and not draining: rotates, wrapping for every member with a public k
   expect(h.rotateCalls).toHaveLength(1);
   const sent = h.rotateCalls[0].map((k) => k.user_id).sort();
   expect(sent).toEqual(["me", "other"]);
+
+  // Self must be wrapped against the freshly-published public key
+  // (mocked to "me-published-pk"), not listMembers' own cached "me-pk" for
+  // the calling user — a stale cached key here caused #66/#228 (I-B).
+  const selfEntry = h.rotateCalls[0].find((k) => k.user_id === "me");
+  expect(selfEntry?.wrapped_key).toBe("wrapped-for-me-published-pk");
 });
 
 test("draining: does not rotate again, and re-encrypts only editable object types", async () => {
@@ -146,6 +156,14 @@ test("draining: re-encrypts a stale secret by decrypting with its OLD key versio
   expect(h.reencryptSecretCalls.flat()).toEqual([
     { secret_id: "s1", ciphertext: "b64(9,9,9)", key_version: 1 },
   ]);
+});
+
+test("draining: reencrypts the legacy blob if stale, using the resolved current key/version (C-B)", async () => {
+  h.status = { stale: false, draining: true };
+
+  await checkAndRotateTeamKey("t1");
+
+  expect(h.reencryptLegacyBlobCalls).toEqual([["t1", 1, [1, 2, 3]]]);
 });
 
 test("draining: does not touch a secret already at or ahead of the current version", async () => {

--- a/src/services/teamKeyRotation.test.ts
+++ b/src/services/teamKeyRotation.test.ts
@@ -1,0 +1,106 @@
+import { test, expect, vi, beforeEach } from "vitest";
+
+const h = vi.hoisted(() => ({
+  status: { stale: false, draining: false } as { stale: boolean; draining: boolean },
+  rotateCalls: [] as { user_id: string; wrapped_key: string }[][],
+  members: [] as { user_id: string; public_key: string }[],
+  allowed: new Set<string>(),
+  objects: [] as { object_id: string; object_type: string; metadata: unknown }[],
+  secrets: [] as { secret_id: string; object_id: string; ciphertext: string; key_version: number }[],
+  reencryptObjectCalls: [] as unknown[],
+  reencryptSecretCalls: [] as unknown[],
+}));
+
+vi.mock("@/services/teamService", () => ({
+  getRotationStatus: vi.fn(async () => h.status),
+  rotateVaultKey: vi.fn(async (_teamId: string, keys: unknown) => { h.rotateCalls.push(keys as never); }),
+  listMembers: vi.fn(async () => h.members),
+  getMyUserId: vi.fn(async () => "me"),
+}));
+vi.mock("@/services/multiplayerService", () => ({
+  wrapSessionKeyForUser: vi.fn(async (_bytes: Uint8Array, pk: string) => `wrapped-for-${pk}`),
+}));
+vi.mock("@/services/teamVaultSync", () => ({
+  getTeamVaultKey: vi.fn(async () => [1, 2, 3]),
+  getCachedTeamKeyVersion: vi.fn(() => 1),
+}));
+vi.mock("@/services/teamObjects", () => ({
+  listTeamObjects: vi.fn(async () => h.objects),
+  reencryptTeamObjects: vi.fn(async (_teamId: string, items: unknown) => { h.reencryptObjectCalls.push(items); }),
+  listTeamSecrets: vi.fn(async () => h.secrets),
+  reencryptTeamSecrets: vi.fn(async (_teamId: string, items: unknown) => { h.reencryptSecretCalls.push(items); }),
+}));
+vi.mock("@/services/teamObjectEnvelope", () => ({
+  isEncryptedEnvelope: (m: unknown) =>
+    typeof m === "object" && m !== null && (m as Record<string, unknown>).v === 2,
+  encodeObjectMetadata: vi.fn(async (_teamId: string, _item: object) => ({ v: 2, enc: "reenc", kv: 1 })),
+}));
+vi.mock("@/services/teamObjectEditPermission", () => ({
+  buildEditPermissionSnapshot: vi.fn(async () => ({})),
+  // Uses the real `objectType` argument (not just a fixed "connection" check)
+  // so the "draining" test below can actually distinguish an editable type
+  // ("connection") from one the caller cannot edit ("key").
+  canEditObjectType: vi.fn((_snapshot: unknown, _teamId: string, objectType: string) => h.allowed.has(objectType)),
+}));
+
+import { checkAndRotateTeamKey } from "./teamKeyRotation";
+
+beforeEach(() => {
+  h.status = { stale: false, draining: false };
+  h.rotateCalls = [];
+  h.members = [];
+  h.allowed = new Set(["connection"]);
+  h.objects = [];
+  h.secrets = [];
+  h.reencryptObjectCalls = [];
+  h.reencryptSecretCalls = [];
+});
+
+test("neither stale nor draining: does nothing", async () => {
+  await checkAndRotateTeamKey("t1");
+  expect(h.rotateCalls).toHaveLength(0);
+  expect(h.reencryptObjectCalls).toHaveLength(0);
+});
+
+test("stale and not draining: rotates, wrapping for every member with a public key", async () => {
+  h.status = { stale: true, draining: false };
+  h.members = [
+    { user_id: "me", public_key: "me-pk" },
+    { user_id: "other", public_key: "other-pk" },
+    { user_id: "keyless", public_key: "" },
+  ];
+
+  await checkAndRotateTeamKey("t1");
+
+  expect(h.rotateCalls).toHaveLength(1);
+  const sent = h.rotateCalls[0].map((k) => k.user_id).sort();
+  expect(sent).toEqual(["me", "other"]);
+});
+
+test("draining: does not rotate again, and re-encrypts only editable object types", async () => {
+  h.status = { stale: false, draining: true };
+  h.objects = [
+    { object_id: "c1", object_type: "connection", metadata: { v: 2, enc: "old", kv: 0 } },
+    { object_id: "k1", object_type: "key", metadata: { v: 2, enc: "old", kv: 0 } },
+  ];
+
+  await checkAndRotateTeamKey("t1");
+
+  expect(h.rotateCalls).toHaveLength(0);
+  expect(h.reencryptObjectCalls.flat().map((i: unknown) => (i as { object_id: string }).object_id)).toEqual(["c1"]);
+});
+
+test("stale and draining: drains, does not also rotate (serialization rule)", async () => {
+  h.status = { stale: true, draining: true };
+  await checkAndRotateTeamKey("t1");
+  expect(h.rotateCalls).toHaveLength(0);
+});
+
+test("concurrent calls for the same team dedup to one pass", async () => {
+  h.status = { stale: true, draining: false };
+  h.members = [{ user_id: "me", public_key: "me-pk" }];
+
+  await Promise.all([checkAndRotateTeamKey("t1"), checkAndRotateTeamKey("t1")]);
+
+  expect(h.rotateCalls).toHaveLength(1);
+});

--- a/src/services/teamKeyRotation.test.ts
+++ b/src/services/teamKeyRotation.test.ts
@@ -5,10 +5,12 @@ const h = vi.hoisted(() => ({
   rotateCalls: [] as { user_id: string; wrapped_key: string }[][],
   members: [] as { user_id: string; public_key: string }[],
   allowed: new Set<string>(),
-  objects: [] as { object_id: string; object_type: string; metadata: unknown }[],
+  objects: [] as { object_id: string; object_type: string; metadata: unknown; deleted_at?: string }[],
   secrets: [] as { secret_id: string; object_id: string; ciphertext: string; key_version: number }[],
   reencryptObjectCalls: [] as unknown[],
   reencryptSecretCalls: [] as unknown[],
+  getTeamVaultKeyAtVersionCalls: [] as unknown[][],
+  deleteTeamKeyCalls: [] as string[],
 }));
 
 vi.mock("@/services/teamService", () => ({
@@ -23,6 +25,11 @@ vi.mock("@/services/multiplayerService", () => ({
 vi.mock("@/services/teamVaultSync", () => ({
   getTeamVaultKey: vi.fn(async () => [1, 2, 3]),
   getCachedTeamKeyVersion: vi.fn(() => 1),
+  getTeamVaultKeyAtVersion: vi.fn(async (teamId: string, version: number) => {
+    h.getTeamVaultKeyAtVersionCalls.push([teamId, version]);
+    return [7, 7, 7];
+  }),
+  deleteTeamKey: vi.fn((teamId: string) => { h.deleteTeamKeyCalls.push(teamId); }),
 }));
 vi.mock("@/services/teamObjects", () => ({
   listTeamObjects: vi.fn(async () => h.objects),
@@ -34,6 +41,7 @@ vi.mock("@/services/teamObjectEnvelope", () => ({
   isEncryptedEnvelope: (m: unknown) =>
     typeof m === "object" && m !== null && (m as Record<string, unknown>).v === 2,
   encodeObjectMetadata: vi.fn(async (_teamId: string, _item: object) => ({ v: 2, enc: "reenc", kv: 1 })),
+  decodeObjectMetadata: vi.fn(async (_teamId: string, metadata: unknown) => metadata),
 }));
 vi.mock("@/services/teamObjectEditPermission", () => ({
   buildEditPermissionSnapshot: vi.fn(async () => ({})),
@@ -42,8 +50,20 @@ vi.mock("@/services/teamObjectEditPermission", () => ({
   // ("connection") from one the caller cannot edit ("key").
   canEditObjectType: vi.fn((_snapshot: unknown, _teamId: string, objectType: string) => h.allowed.has(objectType)),
 }));
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(async (cmd: string, _args: Record<string, unknown>) => {
+    if (cmd === "backup_decrypt") return { secrets: { "password:c1": "hunter2" } };
+    if (cmd === "encrypt_payload") return [9, 9, 9];
+    throw new Error(`unexpected invoke ${cmd}`);
+  }),
+}));
+vi.mock("@/services/teamVaultSyncCore", () => ({
+  bytesToBase64: (b: number[]) => `b64(${b.join(",")})`,
+  base64ToBytes: (_s: string) => [1, 2, 3],
+}));
 
 import { checkAndRotateTeamKey } from "./teamKeyRotation";
+import { getTeamVaultKeyAtVersion } from "@/services/teamVaultSync";
 
 beforeEach(() => {
   h.status = { stale: false, draining: false };
@@ -54,6 +74,8 @@ beforeEach(() => {
   h.secrets = [];
   h.reencryptObjectCalls = [];
   h.reencryptSecretCalls = [];
+  h.getTeamVaultKeyAtVersionCalls = [];
+  h.deleteTeamKeyCalls = [];
 });
 
 test("neither stale nor draining: does nothing", async () => {
@@ -103,4 +125,39 @@ test("concurrent calls for the same team dedup to one pass", async () => {
   await Promise.all([checkAndRotateTeamKey("t1"), checkAndRotateTeamKey("t1")]);
 
   expect(h.rotateCalls).toHaveLength(1);
+});
+
+test("draining: re-encrypts a stale secret by decrypting with its OLD key version and re-wrapping under current", async () => {
+  h.status = { stale: false, draining: true };
+  h.objects = [
+    { object_id: "c1", object_type: "connection", metadata: { v: 2, enc: "old", kv: 0 } },
+  ];
+  h.secrets = [
+    { secret_id: "s1", object_id: "c1", ciphertext: "b64(old-cipher)", key_version: 0 },
+  ];
+
+  await checkAndRotateTeamKey("t1");
+
+  // Decrypted using the secret's own (stale) key_version, never the new one.
+  expect(getTeamVaultKeyAtVersion).toHaveBeenCalledWith("t1", 0);
+
+  // Re-wrapped under the current epoch (mocked getCachedTeamKeyVersion === 1),
+  // with ciphertext reflecting the fresh encrypt_payload call ([9,9,9]).
+  expect(h.reencryptSecretCalls.flat()).toEqual([
+    { secret_id: "s1", ciphertext: "b64(9,9,9)", key_version: 1 },
+  ]);
+});
+
+test("draining: does not touch a secret already at or ahead of the current version", async () => {
+  h.status = { stale: false, draining: true };
+  h.objects = [
+    { object_id: "c1", object_type: "connection", metadata: { v: 2, enc: "old", kv: 1 } },
+  ];
+  h.secrets = [
+    { secret_id: "s1", object_id: "c1", ciphertext: "b64(current-cipher)", key_version: 1 },
+  ];
+
+  await checkAndRotateTeamKey("t1");
+
+  expect(h.reencryptSecretCalls).toHaveLength(0);
 });

--- a/src/services/teamKeyRotation.ts
+++ b/src/services/teamKeyRotation.ts
@@ -1,0 +1,151 @@
+import { getRotationStatus, rotateVaultKey, listMembers } from "@/services/teamService";
+import { wrapSessionKeyForUser } from "@/services/multiplayerService";
+import { getTeamVaultKey, getCachedTeamKeyVersion, getTeamVaultKeyAtVersion } from "@/services/teamVaultSync";
+import {
+  listTeamObjects, reencryptTeamObjects,
+  listTeamSecrets, reencryptTeamSecrets,
+} from "@/services/teamObjects";
+import { isEncryptedEnvelope, encodeObjectMetadata } from "@/services/teamObjectEnvelope";
+import { buildEditPermissionSnapshot, canEditObjectType } from "@/services/teamObjectEditPermission";
+import { invoke } from "@tauri-apps/api/core";
+import { bytesToBase64, base64ToBytes } from "@/services/teamVaultSyncCore";
+
+const BATCH_SIZE = 50;
+
+/** A row/envelope not yet on the current epoch. Missing kv/key_version is
+ * epoch 1, matching the server's COALESCE(...,1) treatment (see #217 spec). */
+function epochOf(kv: number | undefined): number {
+  return kv ?? 1;
+}
+
+/**
+ * Opportunistic rotate-and-drain, mirroring runReencryptionPass's shape:
+ * recomputed from data each call, executed by whichever connected member
+ * holds the right permission, deduplicated per team so a burst of
+ * team_members events collapses into one pass.
+ *
+ * Never rotates and drains in the same call — serialization rule from the
+ * spec: a rotation that lands while a previous one is still draining relies
+ * on the existing removal flow (member + key rows already deleted) for its
+ * own cutoff, not a second epoch.
+ */
+const _rotationPassInFlight = new Map<string, Promise<void>>();
+
+export function checkAndRotateTeamKey(teamId: string): Promise<void> {
+  const existing = _rotationPassInFlight.get(teamId);
+  if (existing) return existing;
+
+  const run = _checkAndRotateTeamKey(teamId);
+  _rotationPassInFlight.set(teamId, run);
+  run.finally(() => _rotationPassInFlight.delete(teamId)).catch(() => {});
+  return run;
+}
+
+async function _checkAndRotateTeamKey(teamId: string): Promise<void> {
+  let status;
+  try {
+    status = await getRotationStatus(teamId);
+  } catch {
+    return; // offline, forbidden (no VIEW_SECRETS/COPY_SECRETS), etc. — try again next event
+  }
+
+  if (status.draining) {
+    await _drainTeamKeyRotation(teamId).catch(() => {});
+    return;
+  }
+
+  if (status.stale) {
+    await _rotateTeamKey(teamId).catch(() => {});
+  }
+}
+
+async function _rotateTeamKey(teamId: string): Promise<void> {
+  const rawKeyBytes = new Uint8Array(await getTeamVaultKey(teamId));
+  const members = await listMembers(teamId);
+
+  // getTeamVaultKey(teamId) above already required this caller to hold the
+  // key themselves, so `me` (if present) in `members` with a public key gets
+  // wrapped for like anyone else — no special-casing needed.
+  const keys = await Promise.all(
+    members
+      .filter((m) => !!m.public_key)
+      .map(async (m) => ({
+        user_id: m.user_id,
+        wrapped_key: await wrapSessionKeyForUser(rawKeyBytes, m.public_key),
+      })),
+  );
+
+  await rotateVaultKey(teamId, keys);
+  await _drainTeamKeyRotation(teamId).catch(() => {});
+}
+
+async function _drainTeamKeyRotation(teamId: string): Promise<void> {
+  const currentVersion = getCachedTeamKeyVersion(teamId);
+  if (currentVersion === undefined) return; // ensure a key fetch has happened first
+
+  const [objects, secrets] = await Promise.all([listTeamObjects(teamId), listTeamSecrets(teamId)]);
+  const snapshot = await buildEditPermissionSnapshot();
+
+  const objectTypeById = new Map(objects.map((o) => [o.object_id, o.object_type] as const));
+
+  const staleObjects = objects.filter((o) => {
+    if (o.deleted_at) return false;
+    if (!isEncryptedEnvelope(o.metadata)) return false; // #229's own migration pass handles these
+    const kv = (o.metadata as { kv?: number }).kv;
+    return epochOf(kv) !== currentVersion && canEditObjectType(snapshot, teamId, o.object_type);
+  });
+
+  const staleSecrets = secrets.filter((s) => {
+    if (s.key_version === currentVersion) return false;
+    const objectType = objectTypeById.get(s.object_id);
+    return objectType !== undefined && canEditObjectType(snapshot, teamId, objectType);
+  });
+
+  for (let i = 0; i < staleObjects.length; i += BATCH_SIZE) {
+    const slice = staleObjects.slice(i, i + BATCH_SIZE);
+    const items = await Promise.all(
+      slice.map(async (o) => ({
+        object_id: o.object_id,
+        metadata: await encodeObjectMetadata(teamId, o.metadata as object),
+      })),
+    );
+    await reencryptTeamObjects(teamId, items);
+  }
+
+  // Secrets carry opaque ciphertext, not a JSON object to re-derive the way
+  // objects' metadata does — the *value* doesn't change on rotation, only
+  // which key wraps it, so this needs the plaintext momentarily. Routes
+  // through the same encrypt_payload/backup_decrypt pair
+  // saveTeamVaultSecret/hydrateTeamVaultSecrets already use, rather than a
+  // third bespoke pairing.
+  for (let i = 0; i < staleSecrets.length; i += BATCH_SIZE) {
+    const slice = staleSecrets.slice(i, i + BATCH_SIZE);
+    const items = await Promise.all(slice.map(async (s) => {
+      const oldKey = await getTeamVaultKeyAtVersion(teamId, s.key_version);
+      const decrypted = await invoke<{ secrets: Record<string, string> }>("backup_decrypt", {
+        encKey: oldKey,
+        blob: base64ToBytes(s.ciphertext),
+      });
+      // The secret's own localKey namespacing (password:<id>, key:<id>:private,
+      // etc.) round-trips through the same encrypt_payload "secrets" map the
+      // ciphertext was written with (saveTeamVaultSecret) — there is exactly
+      // one entry, whatever its key name, so re-wrap it under the same name.
+      const [localKey, value] = Object.entries(decrypted.secrets)[0] ?? [];
+      if (!localKey) throw new Error(`empty secret payload for ${s.secret_id}`);
+      const newKey = await getTeamVaultKey(teamId);
+      const reencrypted: number[] = await invoke("encrypt_payload", {
+        encKey: newKey,
+        files: {},
+        secrets: { [localKey]: value },
+      });
+      return {
+        secret_id: s.secret_id,
+        ciphertext: bytesToBase64(reencrypted),
+        key_version: currentVersion,
+      };
+    }));
+    await reencryptTeamSecrets(teamId, items);
+  }
+}
+
+export { _drainTeamKeyRotation as __testOnly_drainTeamKeyRotation };

--- a/src/services/teamKeyRotation.ts
+++ b/src/services/teamKeyRotation.ts
@@ -46,7 +46,7 @@ async function settleInBatches<T, R>(
       logFailure(logContext)(r.reason);
       return [];
     });
-    if (settled.length > 0) await onBatch(settled);
+    if (settled.length > 0) await onBatch(settled).catch(logFailure(`${logContext}: batch write`));
   }
 }
 
@@ -135,15 +135,20 @@ async function _drainTeamKeyRotation(teamId: string): Promise<void> {
   if (currentVersion === undefined) return; // couldn't fetch (offline/forbidden) — try again next event
 
   // Step 4 of the spec's reencrypt pass: the legacy whole-blob some older
-  // teams still carry. Independent of the object/secret loops below, so its
-  // failure doesn't block them (or vice versa).
-  await reencryptLegacyBlobIfStale(teamId, currentVersion, currentKey)
-    .catch(logFailure(`teamKeyRotation: reencrypt legacy blob team=${teamId}`));
-
-  const [objects, secrets] = await Promise.all([listTeamObjects(teamId), listTeamSecrets(teamId)]);
+  // teams still carry. Independent of the object/secret loops below (already
+  // .catch'd so its failure can't fail this Promise.all), so all three run
+  // concurrently instead of paying its round-trip serially first.
+  const [, objects, secrets] = await Promise.all([
+    reencryptLegacyBlobIfStale(teamId, currentVersion, currentKey)
+      .catch(logFailure(`teamKeyRotation: reencrypt legacy blob team=${teamId}`)),
+    listTeamObjects(teamId),
+    listTeamSecrets(teamId),
+  ]);
   const snapshot = await buildEditPermissionSnapshot();
 
-  const objectTypeById = new Map(objects.map((o) => [o.object_id, o.object_type] as const));
+  const objectTypeById = new Map(
+    objects.filter((o) => !o.deleted_at).map((o) => [o.object_id, o.object_type] as const),
+  );
 
   // Strictly behind current, never equal-or-ahead: a row already on or ahead
   // of this client's freshly-resolved "current" must never be rewritten
@@ -186,7 +191,7 @@ async function _drainTeamKeyRotation(teamId: string): Promise<void> {
     staleSecrets,
     BATCH_SIZE,
     async (s) => {
-      const oldKey = await getTeamVaultKeyAtVersion(teamId, s.key_version);
+      const oldKey = await getTeamVaultKeyAtVersion(teamId, epochOf(s.key_version));
       const decrypted = await invoke<{ secrets: Record<string, string> }>("backup_decrypt", {
         encKey: oldKey,
         blob: base64ToBytes(s.ciphertext),

--- a/src/services/teamKeyRotation.ts
+++ b/src/services/teamKeyRotation.ts
@@ -1,7 +1,8 @@
-import { getRotationStatus, rotateVaultKey, listMembers } from "@/services/teamService";
-import { wrapSessionKeyForUser } from "@/services/multiplayerService";
+import { getRotationStatus, rotateVaultKey, listMembers, getMyUserId } from "@/services/teamService";
+import { wrapSessionKeyForUser, publishMyPublicKey } from "@/services/multiplayerService";
 import {
   getTeamVaultKey, getCachedTeamKeyVersion, getTeamVaultKeyAtVersion, deleteTeamKey,
+  reencryptLegacyBlobIfStale,
 } from "@/services/teamVaultSync";
 import {
   listTeamObjects, reencryptTeamObjects,
@@ -99,22 +100,26 @@ async function _rotateTeamKey(teamId: string): Promise<void> {
   // #217 exists to prevent. Matches initTeamVaultKey's own first-time-key
   // pattern in teamVaultSync.ts.
   const rawKeyBytes = crypto.getRandomValues(new Uint8Array(32));
-  const members = await listMembers(teamId);
+  // Publish first and wrap for self against that, not against whatever
+  // public_key listMembers happens to have cached for the caller — a stale
+  // cached key here has repeatedly caused real lockouts (#66, #228). Mirrors
+  // initTeamVaultKey's own pattern in teamVaultSync.ts.
+  const myPublicKey = await publishMyPublicKey();
+  const myUserId = await getMyUserId();
+  if (!myUserId) return; // not authenticated — try again next event
 
+  const members = await listMembers(teamId);
   const keys = await Promise.all(
     members
-      .filter((m) => !!m.public_key)
+      .filter((m) => m.user_id !== myUserId && !!m.public_key)
       .map(async (m) => ({
         user_id: m.user_id,
         wrapped_key: await wrapSessionKeyForUser(rawKeyBytes, m.public_key),
       })),
   );
+  keys.push({ user_id: myUserId, wrapped_key: await wrapSessionKeyForUser(rawKeyBytes, myPublicKey) });
 
   await rotateVaultKey(teamId, keys);
-  // Evict so the drain below (and any concurrent reader) is forced to fetch
-  // the just-rotated key instead of serving this client's stale pre-rotation
-  // cache entry.
-  deleteTeamKey(teamId);
   await _drainTeamKeyRotation(teamId).catch(logFailure(`teamKeyRotation: drain team=${teamId}`));
 }
 
@@ -128,6 +133,12 @@ async function _drainTeamKeyRotation(teamId: string): Promise<void> {
   const currentKey = await getTeamVaultKey(teamId); // forces a fresh network fetch, primes both caches
   const currentVersion = getCachedTeamKeyVersion(teamId);
   if (currentVersion === undefined) return; // couldn't fetch (offline/forbidden) — try again next event
+
+  // Step 4 of the spec's reencrypt pass: the legacy whole-blob some older
+  // teams still carry. Independent of the object/secret loops below, so its
+  // failure doesn't block them (or vice versa).
+  await reencryptLegacyBlobIfStale(teamId, currentVersion, currentKey)
+    .catch(logFailure(`teamKeyRotation: reencrypt legacy blob team=${teamId}`));
 
   const [objects, secrets] = await Promise.all([listTeamObjects(teamId), listTeamSecrets(teamId)]);
   const snapshot = await buildEditPermissionSnapshot();

--- a/src/services/teamKeyRotation.ts
+++ b/src/services/teamKeyRotation.ts
@@ -1,14 +1,17 @@
 import { getRotationStatus, rotateVaultKey, listMembers } from "@/services/teamService";
 import { wrapSessionKeyForUser } from "@/services/multiplayerService";
-import { getTeamVaultKey, getCachedTeamKeyVersion, getTeamVaultKeyAtVersion } from "@/services/teamVaultSync";
+import {
+  getTeamVaultKey, getCachedTeamKeyVersion, getTeamVaultKeyAtVersion, deleteTeamKey,
+} from "@/services/teamVaultSync";
 import {
   listTeamObjects, reencryptTeamObjects,
   listTeamSecrets, reencryptTeamSecrets,
 } from "@/services/teamObjects";
-import { isEncryptedEnvelope, encodeObjectMetadata } from "@/services/teamObjectEnvelope";
+import { isEncryptedEnvelope, encodeObjectMetadata, decodeObjectMetadata } from "@/services/teamObjectEnvelope";
 import { buildEditPermissionSnapshot, canEditObjectType } from "@/services/teamObjectEditPermission";
 import { invoke } from "@tauri-apps/api/core";
 import { bytesToBase64, base64ToBytes } from "@/services/teamVaultSyncCore";
+import { logFailure } from "@/lib/logger";
 
 const BATCH_SIZE = 50;
 
@@ -16,6 +19,34 @@ const BATCH_SIZE = 50;
  * epoch 1, matching the server's COALESCE(...,1) treatment (see #217 spec). */
 function epochOf(kv: number | undefined): number {
   return kv ?? 1;
+}
+
+/**
+ * Runs `mapFn` over `items` in `batchSize` chunks, settling each chunk rather
+ * than aborting it on the first rejection: a single poisoned row (a 404 on a
+ * historical key, a malformed payload) would otherwise abort the whole batch,
+ * and since this work is recomputed fresh every pass, that same row would
+ * fail identically forever, permanently blocking every other row behind it.
+ * Failed rows are logged and dropped; `onBatch` only runs when a chunk has at
+ * least one surviving item.
+ */
+async function settleInBatches<T, R>(
+  items: T[],
+  batchSize: number,
+  mapFn: (item: T) => Promise<R>,
+  logContext: string,
+  onBatch: (settled: R[]) => Promise<void>,
+): Promise<void> {
+  for (let i = 0; i < items.length; i += batchSize) {
+    const slice = items.slice(i, i + batchSize);
+    const results = await Promise.allSettled(slice.map(mapFn));
+    const settled = results.flatMap((r) => {
+      if (r.status === "fulfilled") return [r.value];
+      logFailure(logContext)(r.reason);
+      return [];
+    });
+    if (settled.length > 0) await onBatch(settled);
+  }
 }
 
 /**
@@ -37,7 +68,7 @@ export function checkAndRotateTeamKey(teamId: string): Promise<void> {
 
   const run = _checkAndRotateTeamKey(teamId);
   _rotationPassInFlight.set(teamId, run);
-  run.finally(() => _rotationPassInFlight.delete(teamId)).catch(() => {});
+  run.finally(() => _rotationPassInFlight.delete(teamId)).catch(logFailure(`teamKeyRotation: pass team=${teamId}`));
   return run;
 }
 
@@ -45,27 +76,31 @@ async function _checkAndRotateTeamKey(teamId: string): Promise<void> {
   let status;
   try {
     status = await getRotationStatus(teamId);
-  } catch {
+  } catch (e) {
+    logFailure(`teamKeyRotation: getRotationStatus team=${teamId}`)(e);
     return; // offline, forbidden (no VIEW_SECRETS/COPY_SECRETS), etc. — try again next event
   }
 
   if (status.draining) {
-    await _drainTeamKeyRotation(teamId).catch(() => {});
+    await _drainTeamKeyRotation(teamId).catch(logFailure(`teamKeyRotation: drain team=${teamId}`));
     return;
   }
 
   if (status.stale) {
-    await _rotateTeamKey(teamId).catch(() => {});
+    await _rotateTeamKey(teamId).catch(logFailure(`teamKeyRotation: rotate team=${teamId}`));
   }
 }
 
 async function _rotateTeamKey(teamId: string): Promise<void> {
-  const rawKeyBytes = new Uint8Array(await getTeamVaultKey(teamId));
+  // Fresh DEK per rotation (spec), not a re-wrap of the current one: wrapping
+  // only needs each member's public key, never the sender's possession of any
+  // prior DEK. Re-wrapping the existing key would leave a removed member's
+  // already-cached copy able to decrypt everything forever — the exact thing
+  // #217 exists to prevent. Matches initTeamVaultKey's own first-time-key
+  // pattern in teamVaultSync.ts.
+  const rawKeyBytes = crypto.getRandomValues(new Uint8Array(32));
   const members = await listMembers(teamId);
 
-  // getTeamVaultKey(teamId) above already required this caller to hold the
-  // key themselves, so `me` (if present) in `members` with a public key gets
-  // wrapped for like anyone else — no special-casing needed.
   const keys = await Promise.all(
     members
       .filter((m) => !!m.public_key)
@@ -76,41 +111,59 @@ async function _rotateTeamKey(teamId: string): Promise<void> {
   );
 
   await rotateVaultKey(teamId, keys);
-  await _drainTeamKeyRotation(teamId).catch(() => {});
+  // Evict so the drain below (and any concurrent reader) is forced to fetch
+  // the just-rotated key instead of serving this client's stale pre-rotation
+  // cache entry.
+  deleteTeamKey(teamId);
+  await _drainTeamKeyRotation(teamId).catch(logFailure(`teamKeyRotation: drain team=${teamId}`));
 }
 
 async function _drainTeamKeyRotation(teamId: string): Promise<void> {
+  // The cache is not trustworthy as "current epoch" on its own: it can be
+  // stale right after this client's own rotation (until evicted) or when a
+  // different client rotated and this one is draining only because
+  // rotation-status said draining:true. Force a fresh fetch so "current"
+  // always means the server's current, never this client's last-known.
+  deleteTeamKey(teamId);
+  const currentKey = await getTeamVaultKey(teamId); // forces a fresh network fetch, primes both caches
   const currentVersion = getCachedTeamKeyVersion(teamId);
-  if (currentVersion === undefined) return; // ensure a key fetch has happened first
+  if (currentVersion === undefined) return; // couldn't fetch (offline/forbidden) — try again next event
 
   const [objects, secrets] = await Promise.all([listTeamObjects(teamId), listTeamSecrets(teamId)]);
   const snapshot = await buildEditPermissionSnapshot();
 
   const objectTypeById = new Map(objects.map((o) => [o.object_id, o.object_type] as const));
 
+  // Strictly behind current, never equal-or-ahead: a row already on or ahead
+  // of this client's freshly-resolved "current" must never be rewritten
+  // backward onto an older key.
   const staleObjects = objects.filter((o) => {
     if (o.deleted_at) return false;
     if (!isEncryptedEnvelope(o.metadata)) return false; // #229's own migration pass handles these
     const kv = (o.metadata as { kv?: number }).kv;
-    return epochOf(kv) !== currentVersion && canEditObjectType(snapshot, teamId, o.object_type);
+    return epochOf(kv) < currentVersion && canEditObjectType(snapshot, teamId, o.object_type);
   });
 
   const staleSecrets = secrets.filter((s) => {
-    if (s.key_version === currentVersion) return false;
+    if (epochOf(s.key_version) >= currentVersion) return false;
     const objectType = objectTypeById.get(s.object_id);
     return objectType !== undefined && canEditObjectType(snapshot, teamId, objectType);
   });
 
-  for (let i = 0; i < staleObjects.length; i += BATCH_SIZE) {
-    const slice = staleObjects.slice(i, i + BATCH_SIZE);
-    const items = await Promise.all(
-      slice.map(async (o) => ({
-        object_id: o.object_id,
-        metadata: await encodeObjectMetadata(teamId, o.metadata as object),
-      })),
-    );
-    await reencryptTeamObjects(teamId, items);
-  }
+  await settleInBatches(
+    staleObjects,
+    BATCH_SIZE,
+    async (o) => ({
+      object_id: o.object_id,
+      // Must decode under the OLD (per-row) key before re-encoding under the
+      // current one — encodeObjectMetadata just JSON.stringifies whatever
+      // it's given, so skipping this step would encrypt the ciphertext
+      // envelope itself, not the underlying fields.
+      metadata: await encodeObjectMetadata(teamId, await decodeObjectMetadata(teamId, o.metadata)),
+    }),
+    `teamKeyRotation: skip poisoned object row team=${teamId}`,
+    (items) => reencryptTeamObjects(teamId, items),
+  );
 
   // Secrets carry opaque ciphertext, not a JSON object to re-derive the way
   // objects' metadata does — the *value* doesn't change on rotation, only
@@ -118,9 +171,10 @@ async function _drainTeamKeyRotation(teamId: string): Promise<void> {
   // through the same encrypt_payload/backup_decrypt pair
   // saveTeamVaultSecret/hydrateTeamVaultSecrets already use, rather than a
   // third bespoke pairing.
-  for (let i = 0; i < staleSecrets.length; i += BATCH_SIZE) {
-    const slice = staleSecrets.slice(i, i + BATCH_SIZE);
-    const items = await Promise.all(slice.map(async (s) => {
+  await settleInBatches(
+    staleSecrets,
+    BATCH_SIZE,
+    async (s) => {
       const oldKey = await getTeamVaultKeyAtVersion(teamId, s.key_version);
       const decrypted = await invoke<{ secrets: Record<string, string> }>("backup_decrypt", {
         encKey: oldKey,
@@ -132,9 +186,8 @@ async function _drainTeamKeyRotation(teamId: string): Promise<void> {
       // one entry, whatever its key name, so re-wrap it under the same name.
       const [localKey, value] = Object.entries(decrypted.secrets)[0] ?? [];
       if (!localKey) throw new Error(`empty secret payload for ${s.secret_id}`);
-      const newKey = await getTeamVaultKey(teamId);
       const reencrypted: number[] = await invoke("encrypt_payload", {
-        encKey: newKey,
+        encKey: currentKey,
         files: {},
         secrets: { [localKey]: value },
       });
@@ -143,9 +196,10 @@ async function _drainTeamKeyRotation(teamId: string): Promise<void> {
         ciphertext: bytesToBase64(reencrypted),
         key_version: currentVersion,
       };
-    }));
-    await reencryptTeamSecrets(teamId, items);
-  }
+    },
+    `teamKeyRotation: skip poisoned secret row team=${teamId}`,
+    (items) => reencryptTeamSecrets(teamId, items),
+  );
 }
 
 export { _drainTeamKeyRotation as __testOnly_drainTeamKeyRotation };

--- a/src/services/teamObjectEditPermission.test.ts
+++ b/src/services/teamObjectEditPermission.test.ts
@@ -1,0 +1,25 @@
+import { test, expect, vi } from "vitest";
+
+const h = vi.hoisted(() => ({ allowed: new Set<string>() }));
+vi.mock("@/services/permissions", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/services/permissions")>()),
+  resolveCan: vi.fn((_snapshot: unknown, permission: string) => h.allowed.has(permission)),
+}));
+vi.mock("@/services/teamService", () => ({ getMyUserId: vi.fn(async () => "u1") }));
+
+import { buildEditPermissionSnapshot, canEditObjectType } from "./teamObjectEditPermission";
+
+test("canEditObjectType is true only for a permission the snapshot grants", async () => {
+  h.allowed = new Set(["EDIT_CONNECTIONS"]);
+  const snapshot = await buildEditPermissionSnapshot();
+
+  expect(canEditObjectType(snapshot, "t1", "connection")).toBe(true);
+  expect(canEditObjectType(snapshot, "t1", "key")).toBe(false);
+});
+
+test("an object type with no edit-permission mapping is never editable", async () => {
+  h.allowed = new Set(["EDIT_CONNECTIONS", "EDIT_KEYS", "EDIT_IDENTITIES", "EDIT_FOLDERS", "EDIT_SNIPPETS"]);
+  const snapshot = await buildEditPermissionSnapshot();
+
+  expect(canEditObjectType(snapshot, "t1", "not_a_real_type")).toBe(false);
+});

--- a/src/services/teamObjectEditPermission.ts
+++ b/src/services/teamObjectEditPermission.ts
@@ -1,0 +1,53 @@
+import { resolveCan, type Permission } from "@/services/permissions";
+import { useTeamStore } from "@/stores/teamStore";
+import { useVaultStore } from "@/stores/vaultStore";
+import { getMyUserId } from "@/services/teamService";
+import type { TeamObjectType } from "@/services/teamObjects";
+
+/** Server-side truth is `edit_permission_for_str` in routes/team_objects.rs. */
+const EDIT_PERMISSION: Record<string, Permission> = {
+  connection: "EDIT_CONNECTIONS",
+  port_forwarding_rule: "EDIT_CONNECTIONS",
+  snippet: "EDIT_SNIPPETS",
+  identity: "EDIT_IDENTITIES",
+  key: "EDIT_KEYS",
+  folder: "EDIT_FOLDERS",
+  snippet_folder: "EDIT_FOLDERS",
+};
+
+export interface EditPermissionSnapshot {
+  myUserId: string;
+  teams: ReturnType<typeof useTeamStore.getState>["teams"];
+  membersByTeam: ReturnType<typeof useTeamStore.getState>["membersByTeam"];
+  rolesByTeam: ReturnType<typeof useTeamStore.getState>["rolesByTeam"];
+  vaults: ReturnType<typeof useVaultStore.getState>["vaults"];
+}
+
+/** A point-in-time snapshot of what the caller may edit, built once per pass
+ * rather than re-reading the stores per object (both the #229 migration pass
+ * and the #217 rotation pass need this identical shape). */
+export async function buildEditPermissionSnapshot(): Promise<EditPermissionSnapshot> {
+  let myUserId = "";
+  try {
+    myUserId = (await getMyUserId()) ?? "";
+  } catch {
+    // ignore — resolveCan treats a blank id as "no access"
+  }
+
+  return {
+    myUserId,
+    teams: useTeamStore.getState().teams,
+    membersByTeam: useTeamStore.getState().membersByTeam,
+    rolesByTeam: useTeamStore.getState().rolesByTeam,
+    vaults: useVaultStore.getState().vaults,
+  };
+}
+
+export function canEditObjectType(
+  snapshot: EditPermissionSnapshot,
+  teamId: string,
+  objectType: TeamObjectType | string,
+): boolean {
+  const permission = EDIT_PERMISSION[objectType];
+  return permission !== undefined && resolveCan(snapshot, permission, teamId);
+}

--- a/src/services/teamObjectEnvelope.test.ts
+++ b/src/services/teamObjectEnvelope.test.ts
@@ -21,8 +21,11 @@ vi.mock("@tauri-apps/api/core", () => ({
   }),
 }));
 
+const h2 = vi.hoisted(() => ({ cachedVersion: undefined as number | undefined }));
 vi.mock("@/services/teamVaultSync", () => ({
   getTeamVaultKey: vi.fn(async () => new Array(32).fill(7)),
+  getCachedTeamKeyVersion: vi.fn((_teamId: string) => h2.cachedVersion),
+  getTeamVaultKeyAtVersion: vi.fn(async (_teamId: string, _version: number) => new Array(32).fill(9)),
 }));
 
 import {
@@ -30,9 +33,12 @@ import {
   decodeObjectMetadata,
   isEncryptedEnvelope,
 } from "./teamObjectEnvelope";
+import { getTeamVaultKeyAtVersion } from "@/services/teamVaultSync";
 
 beforeEach(() => {
   h.encrypted = [];
+  h2.cachedVersion = undefined;
+  vi.mocked(getTeamVaultKeyAtVersion).mockClear();
 });
 
 test("round-trips an object through the envelope", async () => {
@@ -75,4 +81,39 @@ test("decoding a payload with no metadata key throws instead of returning a phan
   vi.mocked(invoke).mockImplementationOnce(async () => ({ files: {}, secrets: {} }));
 
   await expect(decodeObjectMetadata("t1", { v: 2, enc: "anything" })).rejects.toThrow();
+});
+
+test("encodeObjectMetadata stamps the current cached key version", async () => {
+  h2.cachedVersion = 3;
+  const envelope = await encodeObjectMetadata("t1", { host: "example" });
+  expect(envelope.kv).toBe(3);
+});
+
+test("encodeObjectMetadata stamps epoch 1 when nothing is cached yet", async () => {
+  h2.cachedVersion = undefined;
+  const envelope = await encodeObjectMetadata("t1", { host: "example" });
+  expect(envelope.kv).toBe(1);
+});
+
+test("decodeObjectMetadata treats a missing kv as epoch 1 and round-trips normally", async () => {
+  h2.cachedVersion = 1;
+  // A row written before this feature: {v:2, enc} with no kv field at all.
+  const item = { id: "c1", host: "10.0.0.1" };
+  const envelope = await encodeObjectMetadata("t1", item);
+  const { kv: _drop, ...withoutKv } = envelope as typeof envelope & { kv?: number };
+  void _drop;
+
+  const decoded = await decodeObjectMetadata("t1", withoutKv);
+  expect(decoded).toEqual(item);
+  expect(getTeamVaultKeyAtVersion).not.toHaveBeenCalled();
+});
+
+test("decodeObjectMetadata reaches for the historical key when kv is behind current", async () => {
+  h2.cachedVersion = 1;
+  const envelope = await encodeObjectMetadata("t1", { id: "c1" }); // stamped kv:1
+  h2.cachedVersion = 3; // team has since rotated to epoch 3
+
+  await decodeObjectMetadata("t1", envelope);
+
+  expect(getTeamVaultKeyAtVersion).toHaveBeenCalledWith("t1", 1);
 });

--- a/src/services/teamObjectEnvelope.test.ts
+++ b/src/services/teamObjectEnvelope.test.ts
@@ -117,3 +117,27 @@ test("decodeObjectMetadata reaches for the historical key when kv is behind curr
 
   expect(getTeamVaultKeyAtVersion).toHaveBeenCalledWith("t1", 1);
 });
+
+test("decodeObjectMetadata primes a cold cache via getTeamVaultKey BEFORE checking it, still reaching the historical key (C-A)", async () => {
+  h2.cachedVersion = 1;
+  const envelope = await encodeObjectMetadata("t1", { id: "c1" }); // stamped kv:1
+
+  // Simulate a cold cache at decode time: nothing cached yet. getTeamVaultKey
+  // is what primes _teamKeyVersionCache in the real module — reproduce that
+  // side effect here, landing on epoch 3 (the team has since rotated).
+  h2.cachedVersion = undefined;
+  const { getTeamVaultKey } = await import("@/services/teamVaultSync");
+  vi.mocked(getTeamVaultKey).mockImplementationOnce(async () => {
+    h2.cachedVersion = 3;
+    return new Array(32).fill(7);
+  });
+
+  await decodeObjectMetadata("t1", envelope);
+
+  // The old, buggy ordering read getCachedTeamKeyVersion synchronously before
+  // awaiting getTeamVaultKey, saw `undefined`, and fell through to "use the
+  // current key" — never reaching the historical fetch below. The fix awaits
+  // getTeamVaultKey (which primes the cache to 3) before reading the cache,
+  // so kv:1 is correctly seen as behind and the historical key is fetched.
+  expect(getTeamVaultKeyAtVersion).toHaveBeenCalledWith("t1", 1);
+});

--- a/src/services/teamObjectEnvelope.ts
+++ b/src/services/teamObjectEnvelope.ts
@@ -47,10 +47,11 @@ export async function decodeObjectMetadata(teamId: string, metadata: unknown): P
   if (!isEncryptedEnvelope(metadata)) return (metadata ?? {}) as object;
 
   const targetVersion = metadata.kv ?? 1;
+  const currentKey = await getTeamVaultKey(teamId); // always resolves first; primes the version cache
   const currentVersion = getCachedTeamKeyVersion(teamId);
   const encKey = currentVersion !== undefined && targetVersion !== currentVersion
     ? await getTeamVaultKeyAtVersion(teamId, targetVersion)
-    : await getTeamVaultKey(teamId); // also primes the current-version cache for next time
+    : currentKey;
   const payload = await invoke<{ files: Record<string, string> }>("backup_decrypt", {
     encKey,
     blob: base64ToBytes(metadata.enc),

--- a/src/services/teamObjectEnvelope.ts
+++ b/src/services/teamObjectEnvelope.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { getTeamVaultKey } from "@/services/teamVaultSync";
+import { getTeamVaultKey, getCachedTeamKeyVersion, getTeamVaultKeyAtVersion } from "@/services/teamVaultSync";
 import { bytesToBase64, base64ToBytes } from "@/services/teamVaultSyncCore";
 
 /**
@@ -11,6 +11,10 @@ import { bytesToBase64, base64ToBytes } from "@/services/teamVaultSyncCore";
 export interface EncryptedEnvelope {
   v: 2;
   enc: string;
+  /** The key epoch `enc` was encrypted under. Absent on any row written
+   * before #217 — those predate epochs entirely and are always epoch 1,
+   * matching the server's own COALESCE(..., 1) treatment of the same rows. */
+  kv?: number;
 }
 
 /** The key under which the object JSON travels inside the encrypted payload. */
@@ -24,22 +28,29 @@ export function isEncryptedEnvelope(metadata: unknown): metadata is EncryptedEnv
 
 export async function encodeObjectMetadata(teamId: string, item: object): Promise<EncryptedEnvelope> {
   const encKey = await getTeamVaultKey(teamId);
+  const kv = getCachedTeamKeyVersion(teamId) ?? 1;
   const blob: number[] = await invoke("encrypt_payload", {
     encKey,
     files: { [METADATA_FILE]: JSON.stringify(item) },
     secrets: {},
   });
-  return { v: 2, enc: bytesToBase64(blob) };
+  return { v: 2, enc: bytesToBase64(blob), kv };
 }
 
 /**
  * Returns the object. Rows written before #229 are plaintext and pass straight
- * through, which is what lets a client read a team mid-migration.
+ * through, which is what lets a client read a team mid-migration. A row's `kv`
+ * that is behind the team's current epoch (rotation, #217) is decrypted with
+ * the matching historical key instead of the current one.
  */
 export async function decodeObjectMetadata(teamId: string, metadata: unknown): Promise<object> {
   if (!isEncryptedEnvelope(metadata)) return (metadata ?? {}) as object;
 
-  const encKey = await getTeamVaultKey(teamId);
+  const targetVersion = metadata.kv ?? 1;
+  const currentVersion = getCachedTeamKeyVersion(teamId);
+  const encKey = currentVersion !== undefined && targetVersion !== currentVersion
+    ? await getTeamVaultKeyAtVersion(teamId, targetVersion)
+    : await getTeamVaultKey(teamId); // also primes the current-version cache for next time
   const payload = await invoke<{ files: Record<string, string> }>("backup_decrypt", {
     encKey,
     blob: base64ToBytes(metadata.enc),

--- a/src/services/teamObjectReencrypt.ts
+++ b/src/services/teamObjectReencrypt.ts
@@ -1,22 +1,8 @@
 import { isEncryptedEnvelope, encodeObjectMetadata } from "@/services/teamObjectEnvelope";
 import { reencryptTeamObjects } from "@/services/teamObjects";
-import { resolveCan, type Permission } from "@/services/permissions";
-import { useTeamStore } from "@/stores/teamStore";
-import { useVaultStore } from "@/stores/vaultStore";
+import { buildEditPermissionSnapshot, canEditObjectType } from "@/services/teamObjectEditPermission";
 import { useTeamVaultStateStore } from "@/stores/teamVaultStateStore";
-import { getMyUserId } from "@/services/teamService";
 import type { TeamObjectRecord } from "@/services/teamObjects";
-
-/** Server-side truth is `edit_permission_for_str` in routes/team_objects.rs. */
-const EDIT_PERMISSION: Record<string, Permission> = {
-  connection: "EDIT_CONNECTIONS",
-  port_forwarding_rule: "EDIT_CONNECTIONS",
-  snippet: "EDIT_SNIPPETS",
-  identity: "EDIT_IDENTITIES",
-  key: "EDIT_KEYS",
-  folder: "EDIT_FOLDERS",
-  snippet_folder: "EDIT_FOLDERS",
-};
 
 /** A live row whose metadata predates #229 and is still stored in the clear. */
 function isStillPlaintext(o: TeamObjectRecord): boolean {
@@ -70,28 +56,11 @@ async function _runReencryptionPass(
   let done = 0;
 
   try {
-    // getMyUserId() reads the JWT via the keychain bridge and can reject (no
-    // session, not running under Tauri); best-effort like the rest of this
-    // background pass — an empty id just resolves every permission to false.
-    let myUserId = "";
-    try {
-      myUserId = (await getMyUserId()) ?? "";
-    } catch {
-      // ignore — resolveCan treats a blank id as "no access"
-    }
-
-    const snapshot = {
-      myUserId,
-      teams: useTeamStore.getState().teams,
-      membersByTeam: useTeamStore.getState().membersByTeam,
-      rolesByTeam: useTeamStore.getState().rolesByTeam,
-      vaults: useVaultStore.getState().vaults,
-    };
+    const snapshot = await buildEditPermissionSnapshot();
 
     const pending = objects.filter((o) => {
       if (!isStillPlaintext(o)) return false;
-      const permission = EDIT_PERMISSION[o.object_type];
-      return permission !== undefined && resolveCan(snapshot, permission, teamId);
+      return canEditObjectType(snapshot, teamId, o.object_type);
     });
 
     for (let i = 0; i < pending.length; i += BATCH_SIZE) {

--- a/src/services/teamObjects.test.ts
+++ b/src/services/teamObjects.test.ts
@@ -105,12 +105,12 @@ test("upsertTeamObject shapes PUT with Content-Type + body", async () => {
 test("upsertTeamSecret shapes PUT to /secrets", async () => {
   connected();
   h.appFetch.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) });
-  await upsertTeamSecret("t1", { secret_id: "s1", object_id: "o1", secret_type: "connection_password", ciphertext: "cc" });
+  await upsertTeamSecret("t1", { secret_id: "s1", object_id: "o1", secret_type: "connection_password", ciphertext: "cc", key_version: 1 });
   const [url, init] = h.appFetch.mock.calls[0];
   expect(url).toBe("https://s/v1/teams/t1/secrets");
   expect(init.method).toBe("PUT");
   expect(init.headers["Content-Type"]).toBe("application/json");
-  expect(JSON.parse(init.body)).toEqual({ secret_id: "s1", object_id: "o1", secret_type: "connection_password", ciphertext: "cc" });
+  expect(JSON.parse(init.body)).toEqual({ secret_id: "s1", object_id: "o1", secret_type: "connection_password", ciphertext: "cc", key_version: 1 });
 });
 
 // Secret ids are local keychain keys ("key:<id>:private"), so the colons have to

--- a/src/services/teamObjects.ts
+++ b/src/services/teamObjects.ts
@@ -219,3 +219,19 @@ export async function deleteTeamSecret(teamId: string, secretId: string): Promis
   });
   await ensureOk(res, "common.error.failedToDeleteTeamSecret", { ignoreStatus: 404 });
 }
+
+/**
+ * Rotation's secrets-side bulk rewrite: updates ciphertext + key_version only,
+ * no audit stamp, one broadcast per batch. Sibling of reencryptTeamObjects.
+ */
+export async function reencryptTeamSecrets(
+  teamId: string,
+  items: { secret_id: string; ciphertext: string; key_version: number }[],
+): Promise<void> {
+  const res = await fetchTeamApi(`/v1/teams/${teamId}/secrets/reencrypt`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(items),
+  });
+  await ensureOk(res, "common.error.failedToSaveTeamSecret");
+}

--- a/src/services/teamObjects.ts
+++ b/src/services/teamObjects.ts
@@ -43,6 +43,7 @@ export interface TeamSecretRecord {
   object_id: string;
   secret_type: string;
   ciphertext: string;
+  key_version: number;
   updated_at: string;
 }
 
@@ -59,6 +60,7 @@ export interface UpsertTeamSecret {
   object_id: string;
   secret_type: string;
   ciphertext: string;
+  key_version: number;
 }
 
 /**

--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -86,6 +86,32 @@ export async function getVaultKeyHolders(teamId: string): Promise<string[]> {
   return res.json();
 }
 
+export interface RotationStatus {
+  stale: boolean;
+  draining: boolean;
+}
+
+export async function getRotationStatus(teamId: string): Promise<RotationStatus> {
+  const serverUrl = await getServerUrl();
+  if (!serverUrl) throw new Error(i18n.t("common.error.notConnectedToServer"));
+  const res = await fetchAuth(`${serverUrl}/v1/teams/${teamId}/vault-key/rotation-status`);
+  if (!res.ok) throw new Error(i18n.t("common.error.failedToCheckRotationStatus", { status: res.status }));
+  return res.json();
+}
+
+export async function rotateVaultKey(
+  teamId: string,
+  keys: { user_id: string; wrapped_key: string }[],
+): Promise<void> {
+  const serverUrl = await getServerUrl();
+  if (!serverUrl) throw new Error(i18n.t("common.error.notConnectedToServer"));
+  const res = await fetchAuth(`${serverUrl}/v1/teams/${teamId}/vault-key/rotate`, {
+    method: "POST",
+    body: JSON.stringify({ keys }),
+  });
+  if (!res.ok) throw new Error(i18n.t("common.error.failedToRotateVaultKey", { status: res.status }));
+}
+
 export async function addMember(
   teamId: string,
   email: string,

--- a/src/services/teamVaultSecrets.test.ts
+++ b/src/services/teamVaultSecrets.test.ts
@@ -220,6 +220,25 @@ test("hydrateTeamVaultSecrets isolates a failing record (allSettled) so siblings
   expect(h.storeSecret).toHaveBeenCalledWith("password:good", "ok");
 });
 
+// I-F: a rejected record must leave a trace instead of vanishing silently —
+// the only prior signal was "some connections disappeared," nothing in the logs.
+test("hydrateTeamVaultSecrets logs a rejected record, naming the team and secret (I-F)", async () => {
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  h.listTeamSecrets.mockResolvedValue([
+    { secret_id: "s-poisoned", object_id: "bad", secret_type: "connection_password", ciphertext: bytesToBase64([1]), key_version: 1 },
+  ]);
+  h.invoke.mockRejectedValue(new Error("decrypt failed"));
+
+  await hydrateTeamVaultSecrets("t-log");
+
+  expect(console.warn).toHaveBeenCalled();
+  const logged = vi.mocked(console.warn).mock.calls.flat().join(" ");
+  expect(logged).toContain("t-log");
+  expect(logged).toContain("s-poisoned");
+
+  vi.restoreAllMocks();
+});
+
 test("hydrateTeamVaultSecrets does not store when the decrypted payload lacks the expected key", async () => {
   h.listTeamSecrets.mockResolvedValue([
     { object_id: "c1", secret_type: "connection_password", ciphertext: bytesToBase64([1]), key_version: 1 },

--- a/src/services/teamVaultSecrets.test.ts
+++ b/src/services/teamVaultSecrets.test.ts
@@ -6,6 +6,8 @@ const h = vi.hoisted(() => ({
   getSecret: vi.fn(),
   storeSecret: vi.fn(),
   getTeamVaultKey: vi.fn(),
+  getCachedTeamKeyVersion: vi.fn(),
+  getTeamVaultKeyAtVersion: vi.fn(),
   listTeamSecrets: vi.fn(),
   upsertTeamSecret: vi.fn(),
   deleteTeamSecret: vi.fn(),
@@ -19,7 +21,11 @@ const h = vi.hoisted(() => ({
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke: h.invoke }));
 vi.mock("@/services/vault", () => ({ getSecret: h.getSecret, storeSecret: h.storeSecret }));
-vi.mock("@/services/teamVaultSync", () => ({ getTeamVaultKey: h.getTeamVaultKey }));
+vi.mock("@/services/teamVaultSync", () => ({
+  getTeamVaultKey: h.getTeamVaultKey,
+  getCachedTeamKeyVersion: h.getCachedTeamKeyVersion,
+  getTeamVaultKeyAtVersion: h.getTeamVaultKeyAtVersion,
+}));
 vi.mock("@/services/teamObjects", () => ({
   listTeamSecrets: h.listTeamSecrets,
   upsertTeamSecret: h.upsertTeamSecret,
@@ -54,6 +60,8 @@ beforeEach(() => {
   h.teamIdentities = {};
   h.teamKeys = {};
   h.getTeamVaultKey.mockResolvedValue("ENCKEY");
+  h.getCachedTeamKeyVersion.mockReturnValue(1);
+  h.getTeamVaultKeyAtVersion.mockResolvedValue("OLD-ENCKEY");
 });
 
 // ─── saveTeamVaultSecret ────────────────────────────────────────────────────
@@ -74,6 +82,7 @@ test("saveTeamVaultSecret encrypts a single-secret payload and upserts the parse
     object_id: "conn-9",
     secret_type: "connection_password",
     ciphertext: bytesToBase64([1, 2, 3]),
+    key_version: 1,
   });
 });
 
@@ -175,7 +184,7 @@ test("deleteTeamVaultSecretForVault propagates a failure", async () => {
 
 test("hydrateTeamVaultSecrets decrypts each record and stores the recovered local secret", async () => {
   h.listTeamSecrets.mockResolvedValue([
-    { object_id: "c1", secret_type: "connection_password", ciphertext: bytesToBase64([1]) },
+    { object_id: "c1", secret_type: "connection_password", ciphertext: bytesToBase64([1]), key_version: 1 },
   ]);
   h.invoke.mockResolvedValue({ files: {}, secrets: { "password:c1": "recovered" } });
 
@@ -187,7 +196,7 @@ test("hydrateTeamVaultSecrets decrypts each record and stores the recovered loca
 
 test("hydrateTeamVaultSecrets skips records whose secret_type has no local-key mapping", async () => {
   h.listTeamSecrets.mockResolvedValue([
-    { object_id: "c1", secret_type: "bogus_type", ciphertext: bytesToBase64([1]) },
+    { object_id: "c1", secret_type: "bogus_type", ciphertext: bytesToBase64([1]), key_version: 1 },
   ]);
 
   await hydrateTeamVaultSecrets("t1");
@@ -198,8 +207,8 @@ test("hydrateTeamVaultSecrets skips records whose secret_type has no local-key m
 
 test("hydrateTeamVaultSecrets isolates a failing record (allSettled) so siblings still hydrate", async () => {
   h.listTeamSecrets.mockResolvedValue([
-    { object_id: "bad", secret_type: "connection_password", ciphertext: bytesToBase64([1]) },
-    { object_id: "good", secret_type: "connection_password", ciphertext: bytesToBase64([2]) },
+    { object_id: "bad", secret_type: "connection_password", ciphertext: bytesToBase64([1]), key_version: 1 },
+    { object_id: "good", secret_type: "connection_password", ciphertext: bytesToBase64([2]), key_version: 1 },
   ]);
   h.invoke.mockImplementation(async (_cmd: string, args: { blob: number[] }) => {
     if (args.blob[0] === 1) throw new Error("decrypt failed");
@@ -213,12 +222,47 @@ test("hydrateTeamVaultSecrets isolates a failing record (allSettled) so siblings
 
 test("hydrateTeamVaultSecrets does not store when the decrypted payload lacks the expected key", async () => {
   h.listTeamSecrets.mockResolvedValue([
-    { object_id: "c1", secret_type: "connection_password", ciphertext: bytesToBase64([1]) },
+    { object_id: "c1", secret_type: "connection_password", ciphertext: bytesToBase64([1]), key_version: 1 },
   ]);
   h.invoke.mockResolvedValue({ files: {}, secrets: {} });
 
   await hydrateTeamVaultSecrets("t1");
   expect(h.storeSecret).not.toHaveBeenCalled();
+});
+
+test("saveTeamVaultSecret includes the current cached key_version", async () => {
+  h.getCachedTeamKeyVersion.mockReturnValue(3);
+  h.invoke.mockResolvedValue([1, 2, 3]);
+
+  await saveTeamVaultSecret("t1", "password:c1", "hunter2");
+
+  expect(h.upsertTeamSecret).toHaveBeenCalledWith("t1", expect.objectContaining({ key_version: 3 }));
+});
+
+test("hydrateTeamVaultSecrets uses the historical key for a record behind the current epoch", async () => {
+  h.getCachedTeamKeyVersion.mockReturnValue(3);
+  h.listTeamSecrets.mockResolvedValue([
+    { secret_id: "s1", object_id: "c1", secret_type: "connection_password", ciphertext: "AQID", key_version: 1 },
+  ]);
+  h.invoke.mockResolvedValue({ secrets: { "password:c1": "hunter2" } });
+
+  await hydrateTeamVaultSecrets("t1");
+
+  expect(h.getTeamVaultKeyAtVersion).toHaveBeenCalledWith("t1", 1);
+  expect(h.invoke).toHaveBeenCalledWith("backup_decrypt", expect.objectContaining({ encKey: "OLD-ENCKEY" }));
+});
+
+test("hydrateTeamVaultSecrets uses the plain current key for a record already on the current epoch", async () => {
+  h.getCachedTeamKeyVersion.mockReturnValue(1);
+  h.listTeamSecrets.mockResolvedValue([
+    { secret_id: "s1", object_id: "c1", secret_type: "connection_password", ciphertext: "AQID", key_version: 1 },
+  ]);
+  h.invoke.mockResolvedValue({ secrets: { "password:c1": "hunter2" } });
+
+  await hydrateTeamVaultSecrets("t1");
+
+  expect(h.getTeamVaultKeyAtVersion).not.toHaveBeenCalled();
+  expect(h.invoke).toHaveBeenCalledWith("backup_decrypt", expect.objectContaining({ encKey: "ENCKEY" }));
 });
 
 // ─── backfillExistingTeamVaultSecrets ────────────────────────────────────────

--- a/src/services/teamVaultSecrets.test.ts
+++ b/src/services/teamVaultSecrets.test.ts
@@ -284,6 +284,19 @@ test("hydrateTeamVaultSecrets uses the plain current key for a record already on
   expect(h.invoke).toHaveBeenCalledWith("backup_decrypt", expect.objectContaining({ encKey: "ENCKEY" }));
 });
 
+test("hydrateTeamVaultSecrets treats a missing key_version as epoch 1, not a literal undefined fetch", async () => {
+  h.getCachedTeamKeyVersion.mockReturnValue(3);
+  h.listTeamSecrets.mockResolvedValue([
+    // A pre-#217 record with no key_version at all.
+    { secret_id: "s1", object_id: "c1", secret_type: "connection_password", ciphertext: "AQID" },
+  ]);
+  h.invoke.mockResolvedValue({ secrets: { "password:c1": "hunter2" } });
+
+  await hydrateTeamVaultSecrets("t1");
+
+  expect(h.getTeamVaultKeyAtVersion).toHaveBeenCalledWith("t1", 1);
+});
+
 // ─── backfillExistingTeamVaultSecrets ────────────────────────────────────────
 
 test("backfillExistingTeamVaultSecrets fans out over connections, identities, and keys with the expected local-key shapes", async () => {

--- a/src/services/teamVaultSecrets.ts
+++ b/src/services/teamVaultSecrets.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { getSecret, storeSecret } from "@/services/vault";
-import { getTeamVaultKey } from "@/services/teamVaultSync";
+import { getTeamVaultKey, getCachedTeamKeyVersion, getTeamVaultKeyAtVersion } from "@/services/teamVaultSync";
 import { deleteTeamSecret, listTeamSecrets, upsertTeamSecret } from "@/services/teamObjects";
 import { useTeamStore } from "@/stores/teamStore";
 import { useVaultStore } from "@/stores/vaultStore";
@@ -21,6 +21,7 @@ export async function saveTeamVaultSecret(teamId: string, localKey: string, valu
   if (!parts) return;
 
   const encKey = await getTeamVaultKey(teamId);
+  const keyVersion = getCachedTeamKeyVersion(teamId) ?? 1;
   const encryptedBlob: number[] = await invoke("encrypt_payload", {
     encKey,
     files: {},
@@ -32,6 +33,7 @@ export async function saveTeamVaultSecret(teamId: string, localKey: string, valu
     object_id: parts.objectId,
     secret_type: parts.secretType,
     ciphertext: bytesToBase64(encryptedBlob),
+    key_version: keyVersion,
   });
 }
 
@@ -75,11 +77,15 @@ export async function deleteTeamVaultSecretForVault(
 }
 
 export async function hydrateTeamVaultSecrets(teamId: string): Promise<void> {
-  const [encKey, records] = await Promise.all([getTeamVaultKey(teamId), listTeamSecrets(teamId)]);
+  const [currentKey, records] = await Promise.all([getTeamVaultKey(teamId), listTeamSecrets(teamId)]);
+  const currentVersion = getCachedTeamKeyVersion(teamId);
 
   await Promise.allSettled(records.map(async (record) => {
     const localKey = localSecretKeyFromTeamSecret(record.object_id, record.secret_type);
     if (!localKey) return;
+    const encKey = currentVersion !== undefined && record.key_version !== currentVersion
+      ? await getTeamVaultKeyAtVersion(teamId, record.key_version)
+      : currentKey;
     const blob = base64ToBytes(record.ciphertext);
     const payload = await invoke<BlobPayload>("backup_decrypt", { encKey, blob });
     const value = payload.secrets?.[localKey];

--- a/src/services/teamVaultSecrets.ts
+++ b/src/services/teamVaultSecrets.ts
@@ -84,8 +84,12 @@ export async function hydrateTeamVaultSecrets(teamId: string): Promise<void> {
   const results = await Promise.allSettled(records.map(async (record) => {
     const localKey = localSecretKeyFromTeamSecret(record.object_id, record.secret_type);
     if (!localKey) return;
-    const encKey = currentVersion !== undefined && record.key_version !== currentVersion
-      ? await getTeamVaultKeyAtVersion(teamId, record.key_version)
+    // A pre-#217 row's key_version is undefined, which is epoch 1 (matching
+    // the server's own COALESCE(...,1) treatment) — never a literal
+    // "undefined" fetch against vault-key/undefined.
+    const recordVersion = record.key_version ?? 1;
+    const encKey = currentVersion !== undefined && recordVersion !== currentVersion
+      ? await getTeamVaultKeyAtVersion(teamId, recordVersion)
       : currentKey;
     const blob = base64ToBytes(record.ciphertext);
     const payload = await invoke<BlobPayload>("backup_decrypt", { encKey, blob });

--- a/src/services/teamVaultSecrets.ts
+++ b/src/services/teamVaultSecrets.ts
@@ -10,6 +10,7 @@ import {
   teamSecretFromLocalKey,
 } from "@/services/teamVaultSecretKeys";
 import { bytesToBase64, base64ToBytes } from "@/services/teamVaultSyncCore";
+import { logSettledFailures } from "@/lib/logger";
 
 interface BlobPayload {
   files: Record<string, string>;
@@ -80,7 +81,7 @@ export async function hydrateTeamVaultSecrets(teamId: string): Promise<void> {
   const [currentKey, records] = await Promise.all([getTeamVaultKey(teamId), listTeamSecrets(teamId)]);
   const currentVersion = getCachedTeamKeyVersion(teamId);
 
-  await Promise.allSettled(records.map(async (record) => {
+  const results = await Promise.allSettled(records.map(async (record) => {
     const localKey = localSecretKeyFromTeamSecret(record.object_id, record.secret_type);
     if (!localKey) return;
     const encKey = currentVersion !== undefined && record.key_version !== currentVersion
@@ -91,6 +92,7 @@ export async function hydrateTeamVaultSecrets(teamId: string): Promise<void> {
     const value = payload.secrets?.[localKey];
     if (value) await storeSecret(localKey, value);
   }));
+  logSettledFailures(results, (i) => `teamVaultSecrets: hydrate team=${teamId} secret=${records[i].secret_id}`);
 }
 
 export async function backfillExistingTeamVaultSecrets(teamId: string): Promise<void> {

--- a/src/services/teamVaultSync.data.test.ts
+++ b/src/services/teamVaultSync.data.test.ts
@@ -3,7 +3,7 @@ import { test, expect, vi, beforeEach, afterEach } from "vitest";
 const h = vi.hoisted(() => ({
   invoke: vi.fn(),
   appFetch: vi.fn(),
-  listMembers: vi.fn(),
+  getUserPublicKey: vi.fn(),
   unwrap: vi.fn(),
   getSecret: vi.fn(),
   storeSecret: vi.fn(),
@@ -11,7 +11,7 @@ const h = vi.hoisted(() => ({
 }));
 vi.mock("@tauri-apps/api/core", () => ({ invoke: h.invoke }));
 vi.mock("@/services/http", () => ({ appFetch: h.appFetch }));
-vi.mock("@/services/teamService", () => ({ listMembers: h.listMembers }));
+vi.mock("@/services/teamService", () => ({ getUserPublicKey: h.getUserPublicKey }));
 vi.mock("@/services/multiplayerService", () => ({
   unwrapSessionKey: h.unwrap,
   wrapSessionKeyForUser: vi.fn(),
@@ -53,7 +53,7 @@ const res = (status: number, body: unknown = {}) =>
 beforeEach(() => {
   h.invoke.mockReset();
   h.appFetch.mockReset();
-  h.listMembers.mockReset();
+  h.getUserPublicKey.mockReset();
   h.unwrap.mockReset();
   h.getSecret.mockReset();
   h.storeSecret.mockReset();
@@ -85,7 +85,7 @@ test("clearing a team vault deletes every secret it owns, passphrases included",
     if (url.endsWith("/sync-blob")) return res(404);
     throw new Error(`unexpected fetch ${url}`);
   });
-  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "u1", handle: "u1", public_key: "pk" });
   h.unwrap.mockResolvedValue(new Uint8Array([9, 9, 9]));
 
   await fetchTeamData(teamId);
@@ -129,7 +129,7 @@ test("fetchTeamData decrypts the legacy blob and populates the seven store slice
     if (url.endsWith("/sync-blob")) return res(200, { blob: btoa("ignored-bytes"), updated_at: "" });
     throw new Error(`unexpected fetch ${url}`);
   });
-  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "u1", handle: "u1", public_key: "pk" });
   h.unwrap.mockResolvedValue(new Uint8Array([9, 9, 9]));
 
   await fetchTeamData(teamId);
@@ -167,7 +167,7 @@ test("fetchTeamData decrypts the legacy blob with the historical key when its ke
     if (url.endsWith("/sync-blob")) return res(200, { blob: btoa("ignored-bytes"), updated_at: "", key_version: 1 });
     throw new Error(`unexpected fetch ${url}`);
   });
-  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "u1", handle: "u1", public_key: "pk" });
   h.unwrap.mockImplementation(async (wrappedKey: string) =>
     wrappedKey === "wk-old" ? new Uint8Array([1]) : new Uint8Array([9, 9, 9]),
   );

--- a/src/services/teamVaultSync.data.test.ts
+++ b/src/services/teamVaultSync.data.test.ts
@@ -145,6 +145,40 @@ test("fetchTeamData decrypts the legacy blob and populates the seven store slice
 });
 
 /**
+ * The legacy blob route gains `key_version` alongside the object routes (#217).
+ * A blob written before the team's most recent rotation must be decrypted with
+ * the epoch it was actually encrypted under, not the current one.
+ */
+test("fetchTeamData decrypts the legacy blob with the historical key when its key_version is behind the team's current epoch", async () => {
+  const teamId = "t-fetch-rotated";
+  keychain({ server_url: "https://s", jwt: futureJwt() });
+  h.invoke.mockImplementation(async (cmd: string, args: Record<string, unknown>) => {
+    if (cmd === "keychain_get") return args.key === "server_url" ? "https://s" : futureJwt();
+    if (cmd === "backup_decrypt") {
+      const encKey = args.encKey as number[];
+      if (encKey[0] !== 1) throw new Error("decrypted with the wrong epoch's key");
+      return { files: { "connections.json": JSON.stringify([{ id: "c1" }]) }, secrets: {} };
+    }
+    return null;
+  });
+  h.appFetch.mockImplementation(async (url: string) => {
+    if (url.endsWith("/vault-key")) return res(200, { wrapped_key: "wk-current", wrapped_by_user_id: "u1", key_version: 3 });
+    if (url.endsWith("/vault-key/1")) return res(200, { wrapped_key: "wk-old", wrapped_by_user_id: "u1", key_version: 1 });
+    if (url.endsWith("/sync-blob")) return res(200, { blob: btoa("ignored-bytes"), updated_at: "", key_version: 1 });
+    throw new Error(`unexpected fetch ${url}`);
+  });
+  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.unwrap.mockImplementation(async (wrappedKey: string) =>
+    wrappedKey === "wk-old" ? new Uint8Array([1]) : new Uint8Array([9, 9, 9]),
+  );
+
+  await fetchTeamData(teamId);
+
+  expect(useConnectionStore.getState().teamConnections[teamId]).toEqual([{ id: "c1" }]);
+  expect(useTeamVaultStateStore.getState().statusByTeamId[teamId]).toBe("loaded");
+});
+
+/**
  * connect-only members hold no VIEW_SECRETS, so `GET /vault-key` 403s for them.
  * On an empty team vault — the one a joiner meets right after conversion — that
  * used to surface as "Access revoked" (issue #187). They were never revoked:

--- a/src/services/teamVaultSync.getTeamVaultKey.test.ts
+++ b/src/services/teamVaultSync.getTeamVaultKey.test.ts
@@ -1,9 +1,9 @@
 import { test, expect, vi, beforeEach, afterEach } from "vitest";
 
-const h = vi.hoisted(() => ({ invoke: vi.fn(), appFetch: vi.fn(), listMembers: vi.fn(), unwrap: vi.fn() }));
+const h = vi.hoisted(() => ({ invoke: vi.fn(), appFetch: vi.fn(), getUserPublicKey: vi.fn(), unwrap: vi.fn() }));
 vi.mock("@tauri-apps/api/core", () => ({ invoke: h.invoke }));
 vi.mock("@/services/http", () => ({ appFetch: h.appFetch }));
-vi.mock("@/services/teamService", () => ({ listMembers: h.listMembers }));
+vi.mock("@/services/teamService", () => ({ getUserPublicKey: h.getUserPublicKey }));
 vi.mock("@/services/multiplayerService", () => ({
   unwrapSessionKey: h.unwrap,
   wrapSessionKeyForUser: vi.fn(),
@@ -25,7 +25,7 @@ const res = (status: number, body: unknown = {}) =>
   ({ status, ok: status >= 200 && status < 300, json: async () => body, headers: { get: () => null } });
 
 beforeEach(() => {
-  h.invoke.mockReset(); h.appFetch.mockReset(); h.listMembers.mockReset(); h.unwrap.mockReset();
+  h.invoke.mockReset(); h.appFetch.mockReset(); h.getUserPublicKey.mockReset(); h.unwrap.mockReset();
   clearTeamKeyCache();
 });
 afterEach(() => {
@@ -49,7 +49,7 @@ test("403 → forbidden, 402 → payment_required, 404 → awaiting_key", async 
 test("success unwraps the wrapped key, returns bytes, and caches (no 2nd fetch)", async () => {
   keychain({ server_url: "https://s", jwt: futureJwt() });
   h.appFetch.mockResolvedValue(res(200, { wrapped_key: "wk", wrapped_by_user_id: "u1" }));
-  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "u1", handle: "u1", public_key: "pk" });
   h.unwrap.mockResolvedValue(new Uint8Array([1, 2, 3]));
 
   const key = await getTeamVaultKey("t1");
@@ -64,7 +64,7 @@ test("success unwraps the wrapped key, returns bytes, and caches (no 2nd fetch)"
 test("caches the key_version alongside the key", async () => {
   keychain({ server_url: "https://s", jwt: futureJwt() });
   h.appFetch.mockResolvedValue(res(200, { wrapped_key: "wk", wrapped_by_user_id: "u1", key_version: 3 }));
-  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "u1", handle: "u1", public_key: "pk" });
   h.unwrap.mockResolvedValue(new Uint8Array([1, 2, 3]));
 
   await getTeamVaultKey("t1");
@@ -74,7 +74,7 @@ test("caches the key_version alongside the key", async () => {
 test("clearTeamKeyCache/deleteTeamKey also clear the cached version", async () => {
   keychain({ server_url: "https://s", jwt: futureJwt() });
   h.appFetch.mockResolvedValue(res(200, { wrapped_key: "wk", wrapped_by_user_id: "u1", key_version: 2 }));
-  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "u1", handle: "u1", public_key: "pk" });
   h.unwrap.mockResolvedValue(new Uint8Array([1]));
 
   await getTeamVaultKey("t1");
@@ -87,7 +87,7 @@ test("clearTeamKeyCache/deleteTeamKey also clear the cached version", async () =
 test("a local unwrap failure → 'key_mismatch', not 'error'", async () => {
   keychain({ server_url: "https://s", jwt: futureJwt() });
   h.appFetch.mockResolvedValue(res(200, { wrapped_key: "wk", wrapped_by_user_id: "u1" }));
-  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "u1", handle: "u1", public_key: "pk" });
   h.unwrap.mockRejectedValue(new Error("aead::Error"));
   await expect(getTeamVaultKey("t1")).rejects.toBe("key_mismatch");
 });
@@ -95,7 +95,7 @@ test("a local unwrap failure → 'key_mismatch', not 'error'", async () => {
 test("wrapping member missing → 'error'", async () => {
   keychain({ server_url: "https://s", jwt: futureJwt() });
   h.appFetch.mockResolvedValue(res(200, { wrapped_key: "wk", wrapped_by_user_id: "ghost" }));
-  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.getUserPublicKey.mockResolvedValue(null); // 404: the wrapping user no longer resolves
   await expect(getTeamVaultKey("t1")).rejects.toBe("error");
 });
 
@@ -105,14 +105,14 @@ test("wrapping member missing → 'error'", async () => {
 test("N concurrent calls on a cold cache share a single underlying fetch", async () => {
   keychain({ server_url: "https://s", jwt: futureJwt() });
   h.appFetch.mockResolvedValue(res(200, { wrapped_key: "wk", wrapped_by_user_id: "u1" }));
-  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "u1", handle: "u1", public_key: "pk" });
   h.unwrap.mockResolvedValue(new Uint8Array([1, 2, 3]));
 
   const keys = await Promise.all(Array.from({ length: 5 }, () => getTeamVaultKey("t1")));
 
   expect(keys).toEqual(Array(5).fill([1, 2, 3]));
   expect(h.appFetch).toHaveBeenCalledTimes(1);
-  expect(h.listMembers).toHaveBeenCalledTimes(1);
+  expect(h.getUserPublicKey).toHaveBeenCalledTimes(1);
 });
 
 test("a rejected fetch clears the cache entry so a later call can retry, not poison the session", async () => {
@@ -122,7 +122,7 @@ test("a rejected fetch clears the cache entry so a later call can retry, not poi
   await expect(getTeamVaultKey("t1")).rejects.toBe("error");
 
   h.appFetch.mockResolvedValueOnce(res(200, { wrapped_key: "wk", wrapped_by_user_id: "u1" }));
-  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "u1", handle: "u1", public_key: "pk" });
   h.unwrap.mockResolvedValue(new Uint8Array([4, 5, 6]));
 
   const key = await getTeamVaultKey("t1");
@@ -138,7 +138,7 @@ test("a rejected fetch clears the cache entry so a later call can retry, not poi
 // to.
 test("an eviction that lands mid-fetch is not resurrected into the cache", async () => {
   keychain({ server_url: "https://s", jwt: futureJwt() });
-  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "u1", handle: "u1", public_key: "pk" });
   h.unwrap.mockResolvedValue(new Uint8Array([1, 2, 3]));
 
   let resolveFetch!: (value: unknown) => void;

--- a/src/services/teamVaultSync.getTeamVaultKey.test.ts
+++ b/src/services/teamVaultSync.getTeamVaultKey.test.ts
@@ -10,7 +10,7 @@ vi.mock("@/services/multiplayerService", () => ({
   publishMyPublicKey: vi.fn(),
 }));
 
-import { getTeamVaultKey, clearTeamKeyCache, deleteTeamKey } from "./teamVaultSync.ts";
+import { getTeamVaultKey, clearTeamKeyCache, deleteTeamKey, getCachedTeamKeyVersion } from "./teamVaultSync.ts";
 
 function futureJwt(): string {
   const exp = Math.floor(Date.now() / 1000) + 3600;
@@ -59,6 +59,29 @@ test("success unwraps the wrapped key, returns bytes, and caches (no 2nd fetch)"
   const again = await getTeamVaultKey("t1"); // cache hit
   expect(again).toEqual([1, 2, 3]);
   expect(h.appFetch).toHaveBeenCalledTimes(1);
+});
+
+test("caches the key_version alongside the key", async () => {
+  keychain({ server_url: "https://s", jwt: futureJwt() });
+  h.appFetch.mockResolvedValue(res(200, { wrapped_key: "wk", wrapped_by_user_id: "u1", key_version: 3 }));
+  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.unwrap.mockResolvedValue(new Uint8Array([1, 2, 3]));
+
+  await getTeamVaultKey("t1");
+  expect(getCachedTeamKeyVersion("t1")).toBe(3);
+});
+
+test("clearTeamKeyCache/deleteTeamKey also clear the cached version", async () => {
+  keychain({ server_url: "https://s", jwt: futureJwt() });
+  h.appFetch.mockResolvedValue(res(200, { wrapped_key: "wk", wrapped_by_user_id: "u1", key_version: 2 }));
+  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.unwrap.mockResolvedValue(new Uint8Array([1]));
+
+  await getTeamVaultKey("t1");
+  expect(getCachedTeamKeyVersion("t1")).toBe(2);
+
+  deleteTeamKey("t1");
+  expect(getCachedTeamKeyVersion("t1")).toBeUndefined();
 });
 
 test("a local unwrap failure → 'key_mismatch', not 'error'", async () => {

--- a/src/services/teamVaultSync.getTeamVaultKeyAtVersion.test.ts
+++ b/src/services/teamVaultSync.getTeamVaultKeyAtVersion.test.ts
@@ -1,9 +1,9 @@
 import { test, expect, vi, beforeEach } from "vitest";
 
-const h = vi.hoisted(() => ({ invoke: vi.fn(), appFetch: vi.fn(), listMembers: vi.fn(), unwrap: vi.fn() }));
+const h = vi.hoisted(() => ({ invoke: vi.fn(), appFetch: vi.fn(), getUserPublicKey: vi.fn(), unwrap: vi.fn() }));
 vi.mock("@tauri-apps/api/core", () => ({ invoke: h.invoke }));
 vi.mock("@/services/http", () => ({ appFetch: h.appFetch }));
-vi.mock("@/services/teamService", () => ({ listMembers: h.listMembers }));
+vi.mock("@/services/teamService", () => ({ getUserPublicKey: h.getUserPublicKey }));
 vi.mock("@/services/multiplayerService", () => ({
   unwrapSessionKey: h.unwrap,
   wrapSessionKeyForUser: vi.fn(),
@@ -24,13 +24,13 @@ const res = (status: number, body: unknown = {}) =>
   ({ status, ok: status >= 200 && status < 300, json: async () => body, headers: { get: () => null } });
 
 beforeEach(() => {
-  h.invoke.mockReset(); h.appFetch.mockReset(); h.listMembers.mockReset(); h.unwrap.mockReset();
+  h.invoke.mockReset(); h.appFetch.mockReset(); h.getUserPublicKey.mockReset(); h.unwrap.mockReset();
 });
 
 test("fetches the historical epoch, unwraps it, and hits the versioned URL", async () => {
   keychain({ server_url: "https://s", jwt: futureJwt() });
   h.appFetch.mockResolvedValue(res(200, { wrapped_key: "old-wk", wrapped_by_user_id: "u1", key_version: 1 }));
-  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "u1", handle: "u1", public_key: "pk" });
   h.unwrap.mockResolvedValue(new Uint8Array([9, 9, 9]));
 
   const key = await getTeamVaultKeyAtVersion("t1", 1);
@@ -49,7 +49,7 @@ test("caches per (teamId, version) — a second call for the same version does n
   // first test already populated instead of exercising the cache-miss path.
   keychain({ server_url: "https://s", jwt: futureJwt() });
   h.appFetch.mockResolvedValue(res(200, { wrapped_key: "old-wk", wrapped_by_user_id: "u1", key_version: 1 }));
-  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "u1", handle: "u1", public_key: "pk" });
   h.unwrap.mockResolvedValue(new Uint8Array([1]));
 
   await getTeamVaultKeyAtVersion("t2", 1);
@@ -63,7 +63,7 @@ test("a different version is a separate cache entry and a separate fetch", async
   h.appFetch
     .mockResolvedValueOnce(res(200, { wrapped_key: "v1", wrapped_by_user_id: "u1", key_version: 1 }))
     .mockResolvedValueOnce(res(200, { wrapped_key: "v2", wrapped_by_user_id: "u1", key_version: 2 }));
-  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "u1", handle: "u1", public_key: "pk" });
   h.unwrap.mockResolvedValueOnce(new Uint8Array([1])).mockResolvedValueOnce(new Uint8Array([2]));
 
   const k1 = await getTeamVaultKeyAtVersion("t3", 1);
@@ -77,7 +77,7 @@ test("a different version is a separate cache entry and a separate fetch", async
 test("clearTeamKeyCache() also wipes the historical-epoch cache (I-D): a re-fetch is forced afterward", async () => {
   keychain({ server_url: "https://s", jwt: futureJwt() });
   h.appFetch.mockResolvedValue(res(200, { wrapped_key: "old-wk", wrapped_by_user_id: "u1", key_version: 1 }));
-  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "u1", handle: "u1", public_key: "pk" });
   h.unwrap.mockResolvedValue(new Uint8Array([4, 4, 4]));
 
   await getTeamVaultKeyAtVersion("t-logout", 1);
@@ -90,4 +90,19 @@ test("clearTeamKeyCache() also wipes the historical-epoch cache (I-D): a re-fetc
   // clearing _teamKeyAtVersionCache/_teamKeyAtVersionInFlight, this second
   // call would be served from the stale in-memory cache with no new fetch.
   expect(h.appFetch).toHaveBeenCalledTimes(2);
+});
+
+test("resolves the wrapping user directly, so a historical epoch wrapped by a since-removed member is still recoverable (#217)", async () => {
+  keychain({ server_url: "https://s", jwt: futureJwt() });
+  h.appFetch.mockResolvedValue(res(200, { wrapped_key: "old-wk", wrapped_by_user_id: "removed-user", key_version: 1 }));
+  // No current membership row for "removed-user" — a roster lookup would
+  // find nothing. getUserPublicKey resolves users independent of the
+  // current team roster.
+  h.getUserPublicKey.mockResolvedValue({ user_id: "removed-user", handle: "gone", public_key: "pk" });
+  h.unwrap.mockResolvedValue(new Uint8Array([5, 5, 5]));
+
+  const key = await getTeamVaultKeyAtVersion("t-removed-wrapper", 1);
+
+  expect(key).toEqual([5, 5, 5]);
+  expect(h.getUserPublicKey).toHaveBeenCalledWith("removed-user");
 });

--- a/src/services/teamVaultSync.getTeamVaultKeyAtVersion.test.ts
+++ b/src/services/teamVaultSync.getTeamVaultKeyAtVersion.test.ts
@@ -1,0 +1,75 @@
+import { test, expect, vi, beforeEach } from "vitest";
+
+const h = vi.hoisted(() => ({ invoke: vi.fn(), appFetch: vi.fn(), listMembers: vi.fn(), unwrap: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: h.invoke }));
+vi.mock("@/services/http", () => ({ appFetch: h.appFetch }));
+vi.mock("@/services/teamService", () => ({ listMembers: h.listMembers }));
+vi.mock("@/services/multiplayerService", () => ({
+  unwrapSessionKey: h.unwrap,
+  wrapSessionKeyForUser: vi.fn(),
+  publishMyPublicKey: vi.fn(),
+}));
+
+import { getTeamVaultKeyAtVersion } from "./teamVaultSync.ts";
+
+function futureJwt(): string {
+  const exp = Math.floor(Date.now() / 1000) + 3600;
+  const b64 = btoa(JSON.stringify({ exp })).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return `h.${b64}.s`;
+}
+const keychain = (map: Record<string, string | null>) =>
+  h.invoke.mockImplementation(async (cmd: string, args: { key: string }) =>
+    cmd === "keychain_get" ? (map[args.key] ?? null) : null);
+const res = (status: number, body: unknown = {}) =>
+  ({ status, ok: status >= 200 && status < 300, json: async () => body, headers: { get: () => null } });
+
+beforeEach(() => {
+  h.invoke.mockReset(); h.appFetch.mockReset(); h.listMembers.mockReset(); h.unwrap.mockReset();
+});
+
+test("fetches the historical epoch, unwraps it, and hits the versioned URL", async () => {
+  keychain({ server_url: "https://s", jwt: futureJwt() });
+  h.appFetch.mockResolvedValue(res(200, { wrapped_key: "old-wk", wrapped_by_user_id: "u1", key_version: 1 }));
+  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.unwrap.mockResolvedValue(new Uint8Array([9, 9, 9]));
+
+  const key = await getTeamVaultKeyAtVersion("t1", 1);
+
+  expect(key).toEqual([9, 9, 9]);
+  expect(h.appFetch).toHaveBeenCalledWith(
+    expect.stringContaining("/v1/teams/t1/vault-key/1"),
+    expect.anything(),
+  );
+});
+
+test("caches per (teamId, version) — a second call for the same version does not refetch", async () => {
+  // A distinct teamId from the other tests in this file: _teamKeyAtVersionCache
+  // is module state with no reset between tests (per-file isolation only, see
+  // vitest.config.ts), so reusing "t1" here would silently hit the entry the
+  // first test already populated instead of exercising the cache-miss path.
+  keychain({ server_url: "https://s", jwt: futureJwt() });
+  h.appFetch.mockResolvedValue(res(200, { wrapped_key: "old-wk", wrapped_by_user_id: "u1", key_version: 1 }));
+  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.unwrap.mockResolvedValue(new Uint8Array([1]));
+
+  await getTeamVaultKeyAtVersion("t2", 1);
+  await getTeamVaultKeyAtVersion("t2", 1);
+
+  expect(h.appFetch).toHaveBeenCalledTimes(1);
+});
+
+test("a different version is a separate cache entry and a separate fetch", async () => {
+  keychain({ server_url: "https://s", jwt: futureJwt() });
+  h.appFetch
+    .mockResolvedValueOnce(res(200, { wrapped_key: "v1", wrapped_by_user_id: "u1", key_version: 1 }))
+    .mockResolvedValueOnce(res(200, { wrapped_key: "v2", wrapped_by_user_id: "u1", key_version: 2 }));
+  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.unwrap.mockResolvedValueOnce(new Uint8Array([1])).mockResolvedValueOnce(new Uint8Array([2]));
+
+  const k1 = await getTeamVaultKeyAtVersion("t3", 1);
+  const k2 = await getTeamVaultKeyAtVersion("t3", 2);
+
+  expect(k1).toEqual([1]);
+  expect(k2).toEqual([2]);
+  expect(h.appFetch).toHaveBeenCalledTimes(2);
+});

--- a/src/services/teamVaultSync.getTeamVaultKeyAtVersion.test.ts
+++ b/src/services/teamVaultSync.getTeamVaultKeyAtVersion.test.ts
@@ -10,7 +10,7 @@ vi.mock("@/services/multiplayerService", () => ({
   publishMyPublicKey: vi.fn(),
 }));
 
-import { getTeamVaultKeyAtVersion } from "./teamVaultSync.ts";
+import { getTeamVaultKeyAtVersion, clearTeamKeyCache } from "./teamVaultSync.ts";
 
 function futureJwt(): string {
   const exp = Math.floor(Date.now() / 1000) + 3600;
@@ -71,5 +71,23 @@ test("a different version is a separate cache entry and a separate fetch", async
 
   expect(k1).toEqual([1]);
   expect(k2).toEqual([2]);
+  expect(h.appFetch).toHaveBeenCalledTimes(2);
+});
+
+test("clearTeamKeyCache() also wipes the historical-epoch cache (I-D): a re-fetch is forced afterward", async () => {
+  keychain({ server_url: "https://s", jwt: futureJwt() });
+  h.appFetch.mockResolvedValue(res(200, { wrapped_key: "old-wk", wrapped_by_user_id: "u1", key_version: 1 }));
+  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.unwrap.mockResolvedValue(new Uint8Array([4, 4, 4]));
+
+  await getTeamVaultKeyAtVersion("t-logout", 1);
+  expect(h.appFetch).toHaveBeenCalledTimes(1);
+
+  clearTeamKeyCache();
+
+  await getTeamVaultKeyAtVersion("t-logout", 1);
+  // A raw historical DEK must not survive a session-end wipe: without
+  // clearing _teamKeyAtVersionCache/_teamKeyAtVersionInFlight, this second
+  // call would be served from the stale in-memory cache with no new fetch.
   expect(h.appFetch).toHaveBeenCalledTimes(2);
 });

--- a/src/services/teamVaultSync.hydrate.test.ts
+++ b/src/services/teamVaultSync.hydrate.test.ts
@@ -63,3 +63,28 @@ test("a row that fails to decrypt is dropped, not spread as garbage", async () =
 
   expect(useConnectionStore.getState().teamConnections.t1 ?? []).toEqual([]);
 });
+
+// I-F: a wrong-epoch or malformed row must leave a trace instead of silently
+// vanishing from the vault with nothing in the logs.
+test("a row that fails to decrypt is logged, naming the team and object (I-F)", async () => {
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  const { decodeObjectMetadata } = await import("@/services/teamObjectEnvelope");
+  vi.mocked(decodeObjectMetadata).mockRejectedValueOnce(new Error("bad key"));
+
+  await _hydrateTeamObjectStores("t-log", [
+    {
+      object_id: "c-poisoned",
+      object_type: "connection",
+      metadata: { v: 2, enc: "corrupt" },
+      updated_at: "2026-09-01T00:00:00.000Z",
+      updated_by: "u1",
+    },
+  ] as never);
+
+  expect(console.warn).toHaveBeenCalled();
+  const logged = vi.mocked(console.warn).mock.calls.flat().join(" ");
+  expect(logged).toContain("t-log");
+  expect(logged).toContain("c-poisoned");
+
+  vi.restoreAllMocks();
+});

--- a/src/services/teamVaultSync.keymgmt.test.ts
+++ b/src/services/teamVaultSync.keymgmt.test.ts
@@ -4,6 +4,7 @@ const h = vi.hoisted(() => ({
   invoke: vi.fn(),
   appFetch: vi.fn(),
   listMembers: vi.fn(),
+  getUserPublicKey: vi.fn(),
   getMyUserId: vi.fn(),
   updatePublicKey: vi.fn(),
   wrap: vi.fn(),
@@ -15,6 +16,7 @@ vi.mock("@/services/http", () => ({ appFetch: h.appFetch }));
 vi.mock("@/i18n", () => ({ default: { t: (k: string) => k } }));
 vi.mock("@/services/teamService", () => ({
   listMembers: h.listMembers,
+  getUserPublicKey: h.getUserPublicKey,
   getMyUserId: h.getMyUserId,
   updatePublicKey: h.updatePublicKey,
 }));
@@ -24,7 +26,7 @@ vi.mock("@/services/multiplayerService", () => ({
   publishMyPublicKey: h.publishPublicKey,
 }));
 
-import { initTeamVaultKey, distributeKeyToNewMember, clearTeamKeyCache } from "./teamVaultSync";
+import { initTeamVaultKey, distributeKeyToNewMember, clearTeamKeyCache, getCachedTeamKeyVersion } from "./teamVaultSync";
 
 function futureJwt(): string {
   const exp = Math.floor(Date.now() / 1000) + 3600;
@@ -71,7 +73,7 @@ test("initTeamVaultKey generates a fresh key when none exists (404) and wraps fo
 
 test("initTeamVaultKey reuses the existing key when the server already has one", async () => {
   h.unwrap.mockResolvedValue(new Uint8Array(32).fill(1));
-  h.listMembers.mockResolvedValue([{ user_id: "w", public_key: "wpk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "w", handle: "w", public_key: "wpk" });
   h.appFetch.mockImplementation(async (url: string, init?: RequestInit) => {
     if (url.endsWith("/vault-key") && (!init || init.method === "GET"))
       return res(200, { wrapped_key: "wk", wrapped_by_user_id: "w" });
@@ -106,7 +108,7 @@ test("distributeKeyToNewMember returns early when the team key cannot be fetched
 
 test("distributeKeyToNewMember uploads a single wrapped key for the new member", async () => {
   h.unwrap.mockResolvedValue(new Uint8Array(32).fill(1));
-  h.listMembers.mockResolvedValue([{ user_id: "w", public_key: "wpk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "w", handle: "w", public_key: "wpk" });
   h.appFetch.mockImplementation(async (url: string, init?: RequestInit) => {
     if (url.endsWith("/vault-key") && (!init || init.method === "GET"))
       return res(200, { wrapped_key: "wk", wrapped_by_user_id: "w" });
@@ -118,4 +120,18 @@ test("distributeKeyToNewMember uploads a single wrapped key for the new member",
   const put = h.appFetch.mock.calls.find(([, init]) => init?.method === "PUT")!;
   const body = JSON.parse(put[1].body);
   expect(body.keys).toEqual([{ user_id: "u9", wrapped_key: "wrapped-for-pk9" }]);
+});
+
+test("initTeamVaultKey caches epoch 1 for a freshly minted key, keeping key and version in lockstep", async () => {
+  h.appFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+    if (url.endsWith("/vault-key") && (!init || init.method === "GET")) return res(404);
+    if (url.endsWith("/vault-key") && init?.method === "PUT") return res(200);
+    throw new Error(`unexpected ${url}`);
+  });
+
+  await initTeamVaultKey("team-7", [] as any);
+
+  // A cached key with no corresponding version breaks every caller that
+  // trusts "a key is cached implies a version is cached" (#217).
+  expect(getCachedTeamKeyVersion("team-7")).toBe(1);
 });

--- a/src/services/teamVaultSync.legacyBlob.test.ts
+++ b/src/services/teamVaultSync.legacyBlob.test.ts
@@ -3,7 +3,7 @@ import { test, expect, vi, beforeEach } from "vitest";
 const h = vi.hoisted(() => ({
   invoke: vi.fn(),
   appFetch: vi.fn(),
-  listMembers: vi.fn(),
+  getUserPublicKey: vi.fn(),
   unwrap: vi.fn(),
   getSecret: vi.fn(),
   storeSecret: vi.fn(),
@@ -11,7 +11,7 @@ const h = vi.hoisted(() => ({
 }));
 vi.mock("@tauri-apps/api/core", () => ({ invoke: h.invoke }));
 vi.mock("@/services/http", () => ({ appFetch: h.appFetch }));
-vi.mock("@/services/teamService", () => ({ listMembers: h.listMembers }));
+vi.mock("@/services/teamService", () => ({ getUserPublicKey: h.getUserPublicKey }));
 vi.mock("@/services/multiplayerService", () => ({
   unwrapSessionKey: h.unwrap,
   wrapSessionKeyForUser: vi.fn(),
@@ -43,7 +43,7 @@ const methodOf = (init?: RequestInit) => init?.method ?? "GET";
 beforeEach(() => {
   h.invoke.mockReset();
   h.appFetch.mockReset();
-  h.listMembers.mockReset();
+  h.getUserPublicKey.mockReset();
   h.unwrap.mockReset();
   h.getSecret.mockReset();
   h.storeSecret.mockReset();
@@ -106,7 +106,7 @@ test("blob behind the current version: decrypts with the OLD key, re-encrypts wi
     }
     throw new Error(`unexpected fetch ${url} ${method}`);
   });
-  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "u1", handle: "u1", public_key: "pk" });
   h.unwrap.mockResolvedValue(new Uint8Array([1])); // old epoch's raw key
 
   await reencryptLegacyBlobIfStale("t1", 3, [9, 9, 9]);

--- a/src/services/teamVaultSync.legacyBlob.test.ts
+++ b/src/services/teamVaultSync.legacyBlob.test.ts
@@ -1,0 +1,122 @@
+import { test, expect, vi, beforeEach } from "vitest";
+
+const h = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  appFetch: vi.fn(),
+  listMembers: vi.fn(),
+  unwrap: vi.fn(),
+  getSecret: vi.fn(),
+  storeSecret: vi.fn(),
+  deleteSecret: vi.fn(),
+}));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: h.invoke }));
+vi.mock("@/services/http", () => ({ appFetch: h.appFetch }));
+vi.mock("@/services/teamService", () => ({ listMembers: h.listMembers }));
+vi.mock("@/services/multiplayerService", () => ({
+  unwrapSessionKey: h.unwrap,
+  wrapSessionKeyForUser: vi.fn(),
+  publishMyPublicKey: vi.fn(),
+}));
+vi.mock("@/services/vault", () => ({
+  getSecret: h.getSecret,
+  storeSecret: h.storeSecret,
+  deleteSecret: h.deleteSecret,
+}));
+vi.mock("@/services/teamObjects", () => ({ listTeamObjects: vi.fn(async () => []) }));
+
+import { reencryptLegacyBlobIfStale, clearTeamKeyCache } from "./teamVaultSync.ts";
+
+function futureJwt(): string {
+  const exp = Math.floor(Date.now() / 1000) + 3600;
+  const b64 = btoa(JSON.stringify({ exp })).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return `h.${b64}.s`;
+}
+const keychain = (map: Record<string, string | null>) =>
+  h.invoke.mockImplementation(async (cmd: string, args: { key: string }) => {
+    if (cmd === "keychain_get") return map[args.key] ?? null;
+    return null;
+  });
+const res = (status: number, body: unknown = {}) =>
+  ({ status, ok: status >= 200 && status < 300, json: async () => body, headers: { get: () => null } });
+const methodOf = (init?: RequestInit) => init?.method ?? "GET";
+
+beforeEach(() => {
+  h.invoke.mockReset();
+  h.appFetch.mockReset();
+  h.listMembers.mockReset();
+  h.unwrap.mockReset();
+  h.getSecret.mockReset();
+  h.storeSecret.mockReset();
+  h.deleteSecret.mockReset();
+  clearTeamKeyCache();
+});
+
+test("no legacy blob (404): does not PUT anything", async () => {
+  keychain({ server_url: "https://s", jwt: futureJwt() });
+  h.appFetch.mockImplementation(async (url: string) => {
+    if (url.endsWith("/sync-blob")) return res(404);
+    throw new Error(`unexpected fetch ${url}`);
+  });
+
+  await reencryptLegacyBlobIfStale("t1", 3, [9, 9, 9]);
+
+  expect(h.appFetch).toHaveBeenCalledTimes(1);
+  expect(h.appFetch.mock.calls.every(([, init]) => methodOf(init) === "GET")).toBe(true);
+});
+
+test("blob already at the current version: does not PUT anything", async () => {
+  keychain({ server_url: "https://s", jwt: futureJwt() });
+  h.appFetch.mockImplementation(async (url: string) => {
+    if (url.endsWith("/sync-blob")) return res(200, { blob: btoa("x"), updated_at: "", key_version: 3 });
+    throw new Error(`unexpected fetch ${url}`);
+  });
+
+  await reencryptLegacyBlobIfStale("t1", 3, [9, 9, 9]);
+
+  expect(h.appFetch).toHaveBeenCalledTimes(1);
+  expect(h.appFetch.mock.calls.every(([, init]) => methodOf(init) === "GET")).toBe(true);
+});
+
+test("blob behind the current version: decrypts with the OLD key, re-encrypts with the passed current key, and PUTs the passed current version", async () => {
+  keychain({ server_url: "https://s", jwt: futureJwt() });
+  h.invoke.mockImplementation(async (cmd: string, args: Record<string, unknown>) => {
+    if (cmd === "keychain_get") return args.key === "server_url" ? "https://s" : futureJwt();
+    if (cmd === "backup_decrypt") {
+      const encKey = args.encKey as number[];
+      if (encKey[0] !== 1) throw new Error("decrypted with the wrong (non-historical) key");
+      return { files: { metadata: "old-file" }, secrets: { "password:c1": "hunter2" } };
+    }
+    if (cmd === "encrypt_payload") {
+      const encKey = args.encKey as number[];
+      if (encKey[0] !== 9) throw new Error("re-encrypted with the wrong (non-current) key");
+      return [9, 9, 9];
+    }
+    return null;
+  });
+  h.appFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+    const method = methodOf(init);
+    if (url.endsWith("/sync-blob") && method === "GET") {
+      return res(200, { blob: btoa("old-blob-bytes"), updated_at: "", key_version: 1 });
+    }
+    if (url.endsWith("/vault-key/1") && method === "GET") {
+      return res(200, { wrapped_key: "wk-old", wrapped_by_user_id: "u1", key_version: 1 });
+    }
+    if (url.endsWith("/sync-blob") && method === "PUT") {
+      return res(200, {});
+    }
+    throw new Error(`unexpected fetch ${url} ${method}`);
+  });
+  h.listMembers.mockResolvedValue([{ user_id: "u1", public_key: "pk" }]);
+  h.unwrap.mockResolvedValue(new Uint8Array([1])); // old epoch's raw key
+
+  await reencryptLegacyBlobIfStale("t1", 3, [9, 9, 9]);
+
+  // Went to the historical vault-key route for the blob's own (stale) epoch.
+  expect(h.appFetch.mock.calls.some(([url, init]) => url.endsWith("/vault-key/1") && methodOf(init) === "GET")).toBe(true);
+
+  const putCall = h.appFetch.mock.calls.find(([url, init]) => url.endsWith("/sync-blob") && methodOf(init) === "PUT");
+  expect(putCall).toBeTruthy();
+  const body = JSON.parse((putCall![1] as RequestInit).body as string);
+  expect(body.key_version).toBe(3);
+  expect(body.blob).toBe(btoa(String.fromCharCode(9, 9, 9)));
+});

--- a/src/services/teamVaultSync.reconcile.test.ts
+++ b/src/services/teamVaultSync.reconcile.test.ts
@@ -8,6 +8,7 @@ const h = vi.hoisted(() => ({
   invoke: vi.fn(),
   appFetch: vi.fn(),
   listMembers: vi.fn(),
+  getUserPublicKey: vi.fn(),
   getMyUserId: vi.fn(),
   getVaultKeyHolders: vi.fn(),
   wrap: vi.fn(),
@@ -19,6 +20,7 @@ vi.mock("@/services/http", () => ({ appFetch: h.appFetch }));
 vi.mock("@/i18n", () => ({ default: { t: (k: string) => k } }));
 vi.mock("@/services/teamService", () => ({
   listMembers: h.listMembers,
+  getUserPublicKey: h.getUserPublicKey,
   getMyUserId: h.getMyUserId,
   getVaultKeyHolders: h.getVaultKeyHolders,
 }));
@@ -54,6 +56,7 @@ beforeEach(() => {
   h.publishPublicKey.mockResolvedValue("MYPUB");
   h.getMyUserId.mockResolvedValue("me");
   h.listMembers.mockResolvedValue(MEMBERS);
+  h.getUserPublicKey.mockResolvedValue({ user_id: "me", handle: "me", public_key: "MYPUB" });
   h.unwrap.mockResolvedValue(new Uint8Array(32));
   h.wrap.mockImplementation(async (_key: Uint8Array, pub: string) => `wrapped-for-${pub}`);
 });

--- a/src/services/teamVaultSync.ts
+++ b/src/services/teamVaultSync.ts
@@ -53,6 +53,10 @@ interface BlobPayload {
 // ─── In-memory key cache (process memory only — gone on logout/close) ─────────
 
 const _teamKeyCache = new Map<string, number[]>();
+// Epoch the cached key in _teamKeyCache belongs to, one entry per team.
+// Kept in lockstep with _teamKeyCache: every write/clear of one writes/clears
+// the other, so a caller can never read a key and a version that disagree.
+const _teamKeyVersionCache = new Map<string, number>();
 // In-flight fetch/unwrap promises, keyed by team. Without this, N concurrent
 // getTeamVaultKey(teamId) calls on a cold cache (e.g. decoding N encrypted
 // objects during hydration, #229) each start their own GET vault-key +
@@ -87,13 +91,21 @@ export function clearTeamKeyCache(): void {
   const teamIds = new Set([..._teamKeyCache.keys(), ..._teamKeyInFlight.keys(), ..._teamKeyGeneration.keys()]);
   for (const teamId of teamIds) _bumpGeneration(teamId);
   _teamKeyCache.clear();
+  _teamKeyVersionCache.clear();
   _teamKeyInFlight.clear();
 }
 
 export function deleteTeamKey(teamId: string): void {
   _bumpGeneration(teamId);
   _teamKeyCache.delete(teamId);
+  _teamKeyVersionCache.delete(teamId);
   _teamKeyInFlight.delete(teamId);
+}
+
+/** The epoch of the key currently cached for `teamId`, or undefined if nothing
+ * is cached yet — call getTeamVaultKey(teamId) first to populate it. */
+export function getCachedTeamKeyVersion(teamId: string): number | undefined {
+  return _teamKeyVersionCache.get(teamId);
 }
 
 // ─── Key management ───────────────────────────────────────────────────────────
@@ -131,14 +143,15 @@ export async function getTeamVaultKey(teamId: string): Promise<number[]> {
   // this chain would only protect the caller that happened to start the
   // fetch.
   const generation = _currentGeneration(teamId);
-  const inFlight = _fetchAndUnwrapTeamVaultKey(teamId).then((keyBytes) => {
+  const inFlight = _fetchAndUnwrapTeamVaultKey(teamId).then(({ bytes, version }) => {
     // The key was evicted (deleteTeamKey/clearTeamKeyCache) while this fetch
     // was on the wire — most importantly, a member just kicked from the team
     // (#216). Do not resurrect it into the cache, and do not hand it back to
     // any caller either; treat it the same as any other failed fetch.
     if (_currentGeneration(teamId) !== generation) throw "error";
-    _teamKeyCache.set(teamId, keyBytes);
-    return keyBytes;
+    _teamKeyCache.set(teamId, bytes);
+    _teamKeyVersionCache.set(teamId, version);
+    return bytes;
   });
   _teamKeyInFlight.set(teamId, inFlight);
   // Detached cleanup subscriber: always drop the in-flight entry once the
@@ -151,7 +164,13 @@ export async function getTeamVaultKey(teamId: string): Promise<number[]> {
   return inFlight;
 }
 
-async function _fetchAndUnwrapTeamVaultKey(teamId: string): Promise<number[]> {
+/** Shared by the "current epoch" and "specific historical epoch" fetch paths:
+ * GET the given vault-key URL, resolve the wrapping member, unwrap. Thrown
+ * error strings match _fetchAndUnwrapTeamVaultKey's existing contract. */
+async function _fetchAndUnwrapVaultKeyUrl(
+  teamId: string,
+  path: string,
+): Promise<{ bytes: number[]; version: number }> {
   if (!navigator.onLine) throw "offline";
 
   const serverUrl = await getServerUrl();
@@ -159,7 +178,7 @@ async function _fetchAndUnwrapTeamVaultKey(teamId: string): Promise<number[]> {
 
   let res: Response;
   try {
-    res = await fetchWithAuth(`${serverUrl}/v1/teams/${teamId}/vault-key`, { method: "GET" });
+    res = await fetchWithAuth(`${serverUrl}${path}`, { method: "GET" });
   } catch {
     throw "offline";
   }
@@ -169,9 +188,10 @@ async function _fetchAndUnwrapTeamVaultKey(teamId: string): Promise<number[]> {
   if (res.status === 404) throw "awaiting_key";
   if (!res.ok) throw "error";
 
-  const { wrapped_key, wrapped_by_user_id } = await res.json() as {
+  const { wrapped_key, wrapped_by_user_id, key_version } = await res.json() as {
     wrapped_key: string;
     wrapped_by_user_id: string;
+    key_version: number;
   };
 
   const members = await teamService.listMembers(teamId);
@@ -184,7 +204,51 @@ async function _fetchAndUnwrapTeamVaultKey(teamId: string): Promise<number[]> {
   } catch {
     throw "key_mismatch";
   }
-  return Array.from(rawKey);
+  return { bytes: Array.from(rawKey), version: key_version };
+}
+
+async function _fetchAndUnwrapTeamVaultKey(teamId: string): Promise<{ bytes: number[]; version: number }> {
+  return _fetchAndUnwrapVaultKeyUrl(teamId, `/v1/teams/${teamId}/vault-key`);
+}
+
+// Historical-epoch key cache, keyed by "teamId:version" — separate from the
+// current-epoch cache above since a client may need both at once while a
+// rotation is draining (some rows still on the old epoch, new rows on the new).
+const _teamKeyAtVersionCache = new Map<string, number[]>();
+const _teamKeyAtVersionInFlight = new Map<string, Promise<number[]>>();
+
+/**
+ * Fetch and unwrap a *specific* historical epoch's key, for decoding a row
+ * whose kv/key_version is behind the team's current epoch. Never evicted by
+ * clearTeamKeyCache/deleteTeamKey — those model "the current epoch changed
+ * under us," which has no bearing on a fixed historical epoch's key.
+ *
+ * The cache/in-flight-dedup shape below mirrors getTeamVaultKey's above on
+ * purpose, not left un-factored by oversight: getTeamVaultKey's version also
+ * carries the eviction-generation guard (a kicked member's key must not be
+ * resurrected mid-fetch, #216), which does not apply here — a historical
+ * epoch's key is immutable and this cache is never evicted. Sharing a helper
+ * would need a generation-guard on/off parameter, which costs more than the
+ * ~10 duplicated lines it would save.
+ */
+export async function getTeamVaultKeyAtVersion(teamId: string, version: number): Promise<number[]> {
+  const cacheKey = `${teamId}:${version}`;
+  const cached = _teamKeyAtVersionCache.get(cacheKey);
+  if (cached) return cached;
+
+  const existing = _teamKeyAtVersionInFlight.get(cacheKey);
+  if (existing) return existing;
+
+  const inFlight = _fetchAndUnwrapVaultKeyUrl(teamId, `/v1/teams/${teamId}/vault-key/${version}`).then(
+    ({ bytes }) => {
+      _teamKeyAtVersionCache.set(cacheKey, bytes);
+      return bytes;
+    },
+  );
+  _teamKeyAtVersionInFlight.set(cacheKey, inFlight);
+  inFlight.finally(() => _teamKeyAtVersionInFlight.delete(cacheKey)).catch(() => {});
+
+  return inFlight;
 }
 
 /**

--- a/src/services/teamVaultSync.ts
+++ b/src/services/teamVaultSync.ts
@@ -176,7 +176,6 @@ export async function getTeamVaultKey(teamId: string): Promise<number[]> {
  * GET the given vault-key URL, resolve the wrapping member, unwrap. Thrown
  * error strings match _fetchAndUnwrapTeamVaultKey's existing contract. */
 async function _fetchAndUnwrapVaultKeyUrl(
-  teamId: string,
   path: string,
 ): Promise<{ bytes: number[]; version: number }> {
   if (!navigator.onLine) throw "offline";
@@ -202,8 +201,13 @@ async function _fetchAndUnwrapVaultKeyUrl(
     key_version: number;
   };
 
-  const members = await teamService.listMembers(teamId);
-  const wrapper = members.find((m) => m.user_id === wrapped_by_user_id);
+  // Looked up directly rather than via the current member roster: a
+  // historical epoch's key can be wrapped by someone since removed from the
+  // team — the very event that triggers rotation — and the roster would
+  // never find them again, permanently blocking recovery of that epoch.
+  const wrapper = await teamService.getUserPublicKey(wrapped_by_user_id).catch(() => {
+    throw "error";
+  });
   if (!wrapper) throw "error";
 
   let rawKey: Uint8Array;
@@ -216,7 +220,7 @@ async function _fetchAndUnwrapVaultKeyUrl(
 }
 
 async function _fetchAndUnwrapTeamVaultKey(teamId: string): Promise<{ bytes: number[]; version: number }> {
-  return _fetchAndUnwrapVaultKeyUrl(teamId, `/v1/teams/${teamId}/vault-key`);
+  return _fetchAndUnwrapVaultKeyUrl(`/v1/teams/${teamId}/vault-key`);
 }
 
 // Historical-epoch key cache, keyed by "teamId:version" — separate from the
@@ -247,7 +251,7 @@ export async function getTeamVaultKeyAtVersion(teamId: string, version: number):
   const existing = _teamKeyAtVersionInFlight.get(cacheKey);
   if (existing) return existing;
 
-  const inFlight = _fetchAndUnwrapVaultKeyUrl(teamId, `/v1/teams/${teamId}/vault-key/${version}`).then(
+  const inFlight = _fetchAndUnwrapVaultKeyUrl(`/v1/teams/${teamId}/vault-key/${version}`).then(
     ({ bytes }) => {
       _teamKeyAtVersionCache.set(cacheKey, bytes);
       return bytes;
@@ -284,12 +288,14 @@ export async function initTeamVaultKey(
   if (!serverUrl) throw new Error(i18n.t("common.error.notConnectedToServer"));
 
   let rawKey: Uint8Array;
+  let mintedFreshKey = false;
   try {
-    const existingBytes = await getTeamVaultKey(teamId);
+    const existingBytes = await getTeamVaultKey(teamId); // also primes the version cache
     rawKey = new Uint8Array(existingBytes);
   } catch (err) {
     if (err !== "awaiting_key") throw new Error(i18n.t("common.error.keyFetchFailed", { error: String(err) }));
     rawKey = crypto.getRandomValues(new Uint8Array(32));
+    mintedFreshKey = true;
   }
 
   const myPublicKey = await publishMyPublicKey();
@@ -318,6 +324,10 @@ export async function initTeamVaultKey(
   if (!res.ok) throw new Error(i18n.t("common.error.failedToUploadVaultKeys", { status: res.status }));
 
   _teamKeyCache.set(teamId, Array.from(rawKey));
+  // A reused existing key already had its version cached by getTeamVaultKey
+  // above — never clobber that. Only a freshly minted key has no epoch on
+  // the server yet, and a team's first-ever key is always epoch 1.
+  if (mintedFreshKey) _teamKeyVersionCache.set(teamId, 1);
 }
 
 /**

--- a/src/services/teamVaultSync.ts
+++ b/src/services/teamVaultSync.ts
@@ -251,6 +251,16 @@ export async function getTeamVaultKeyAtVersion(teamId: string, version: number):
   return inFlight;
 }
 
+// The "current epoch, or bust out to vault-key/:version" branch below is the
+// same three-line shape at every call site that decodes a versioned row
+// (this file's own blob path, teamObjectEnvelope.ts, teamVaultSecrets.ts) —
+// deliberately NOT extracted into a shared helper here. Their unit tests each
+// mock this whole module down to just getTeamVaultKey/getCachedTeamKeyVersion/
+// getTeamVaultKeyAtVersion so they can exercise the branch as *their own*
+// logic; a helper living in this module would be undefined under that mock,
+// which would silently swap "test the branch" for "test that a mock was
+// called." See #217 task-2 brief.
+
 /**
  * Initialise the team vault key. Tries to reuse any existing key first (404 →
  * generates fresh). Uploads wrapped copies for self and all provided members.
@@ -478,9 +488,15 @@ async function _fetchTeamData(teamId: string, options: TeamVaultRefreshOptions):
       stateStore.setStatus(teamId, "error");
       return;
     }
-    const { blob: blobB64 } = await res.json() as { blob: string; updated_at: string };
+    const { blob: blobB64, key_version: blobVersion } = await res.json() as {
+      blob: string; updated_at: string; key_version: number;
+    };
     const blobBytes = base64ToBytes(blobB64);
-    blobPayload = await invoke<BlobPayload>("backup_decrypt", { encKey: key, blob: blobBytes });
+    const currentVersion = getCachedTeamKeyVersion(teamId);
+    const blobKey = currentVersion !== undefined && blobVersion !== currentVersion
+      ? await getTeamVaultKeyAtVersion(teamId, blobVersion)
+      : key;
+    blobPayload = await invoke<BlobPayload>("backup_decrypt", { encKey: blobKey, blob: blobBytes });
   } catch {
     if (options.background) return;
     await clearTeamStoresAndSecrets(teamId);

--- a/src/services/teamVaultSync.ts
+++ b/src/services/teamVaultSync.ts
@@ -26,7 +26,7 @@ import { getServerUrl } from "@/services/authTokens";
 import { fetchAuthRateLimited as fetchWithAuth } from "@/services/authFetch";
 import { useTeamVaultStateStore } from "@/stores/teamVaultStateStore";
 import { storeSecret, deleteSecret } from "@/services/vault";
-import { logFailure } from "@/lib/logger";
+import { logFailure, logSettledFailures } from "@/lib/logger";
 import type { Connection, Identity, SshKey, Folder, Snippet, PortForwardingRule } from "@/types";
 import type { TeamMember } from "@/services/teamService";
 import { listTeamObjects, type TeamObjectRecord } from "@/services/teamObjects";
@@ -38,6 +38,7 @@ import {
 import { classifyTeamObjectListError } from "@/services/teamVaultLoadErrors";
 import {
   base64ToBytes,
+  bytesToBase64,
   parseTeamVaultBlobFiles,
 } from "@/services/teamVaultSyncCore";
 
@@ -93,6 +94,13 @@ export function clearTeamKeyCache(): void {
   _teamKeyCache.clear();
   _teamKeyVersionCache.clear();
   _teamKeyInFlight.clear();
+  // This is the session-end wipe (logout/vault lock, see teamDataManager's
+  // onSessionEnd) — raw historical DEKs must not survive it either, even
+  // though deleteTeamKey (the per-team epoch-change eviction) deliberately
+  // leaves these alone: a single team's epoch changing has no bearing on
+  // another epoch's key.
+  _teamKeyAtVersionCache.clear();
+  _teamKeyAtVersionInFlight.clear();
 }
 
 export function deleteTeamKey(teamId: string): void {
@@ -529,6 +537,46 @@ async function _fetchTeamData(teamId: string, options: TeamVaultRefreshOptions):
 }
 
 /**
+ * Re-encrypts the team's legacy whole-blob (#229 removed the writer for new
+ * data, but old teams may still carry one) under the current key epoch, if
+ * it exists and is behind. No-op if there is no blob (404) or it's already
+ * current. Part of the #217 reencrypt pass alongside objects and secrets —
+ * without this, a team with a legacy blob rotates once and then can never
+ * rotate again (a stale blob keeps `draining` true forever).
+ */
+export async function reencryptLegacyBlobIfStale(teamId: string, currentVersion: number, currentKey: number[]): Promise<void> {
+  const serverUrl = await getServerUrl();
+  if (!serverUrl) return;
+
+  let res: Response;
+  try {
+    res = await fetchWithAuth(`${serverUrl}/v1/teams/${teamId}/sync-blob`, { method: "GET" });
+  } catch {
+    return;
+  }
+  if (res.status === 404 || !res.ok) return;
+
+  const { blob: blobB64, key_version: blobVersion } = await res.json() as {
+    blob: string; updated_at: string; key_version: number;
+  };
+  if (blobVersion >= currentVersion) return; // already current or ahead — nothing to do
+
+  const oldKey = await getTeamVaultKeyAtVersion(teamId, blobVersion);
+  const blobPayload = await invoke<BlobPayload>("backup_decrypt", { encKey: oldKey, blob: base64ToBytes(blobB64) });
+  const reencrypted: number[] = await invoke("encrypt_payload", {
+    encKey: currentKey,
+    files: blobPayload.files,
+    secrets: blobPayload.secrets,
+  });
+
+  await fetchWithAuth(`${serverUrl}/v1/teams/${teamId}/sync-blob`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ blob: bytesToBase64(reencrypted), key_version: currentVersion }),
+  });
+}
+
+/**
  * True when the client still lists `teamId` among the caller's teams. The
  * server drops revoked teams from that list and `onTeamRemoved` clears the
  * store, so this separates "your role can't do that" from "you were removed".
@@ -549,7 +597,10 @@ export async function _hydrateTeamObjectStores(teamId: string, objects: TeamObje
   // be written straight back on the next save.
   const decoded = await Promise.all(
     active.map(async (o) => {
-      const metadata = await decodeObjectMetadata(teamId, o.metadata).catch(() => null);
+      const metadata = await decodeObjectMetadata(teamId, o.metadata).catch((e) => {
+        logFailure(`teamVaultSync: decode object team=${teamId} object=${o.object_id}`)(e);
+        return null;
+      });
       return metadata === null ? null : { ...o, metadata };
     }),
   );
@@ -591,13 +642,8 @@ export async function _hydrateTeamObjectStores(teamId: string, objects: TeamObje
  */
 async function deleteSecrets(keys: string[]): Promise<string[]> {
   const results = await Promise.allSettled(keys.map((k) => deleteSecret(k)));
-  const failed: string[] = [];
-  results.forEach((r, i) => {
-    if (r.status === "rejected") {
-      failed.push(keys[i]);
-      logFailure(`keychain wipe of ${keys[i]}`)(r.reason);
-    }
-  });
+  logSettledFailures(results, (i) => `keychain wipe of ${keys[i]}`);
+  const failed = results.flatMap((r, i) => (r.status === "rejected" ? [keys[i]] : []));
   return failed;
 }
 


### PR DESCRIPTION
## Summary

Client half of #217, depends on the already-merged-and-deployed server PR (VoltiusApp/server#16). Makes the client read/write team-vault ciphertext version-aware, and adds the opportunistic rotate-and-drain pass that runs on team membership changes.

- Version-aware key cache: `getCachedTeamKeyVersion`, `getTeamVaultKeyAtVersion`, on top of the unchanged `getTeamVaultKey` signature.
- Version-aware encode/decode for objects, secrets, and the legacy vault blob.
- `teamKeyRotation.ts`: `checkAndRotateTeamKey` — on every `team_members:<teamId>` event, either mints a new epoch (wraps a fresh 32-byte DEK for every current member with a public key) or resumes draining a previous rotation (re-encrypts stale objects, secrets, and the legacy blob under the current epoch), never both in the same call.
- Wired into `sync.ts`'s realtime handler, fire-and-forget.

Design: `docs/superpowers/specs/2026-09-09-team-dek-rotation-design.md`. Plan: `docs/superpowers/plans/2026-09-09-team-dek-rotation-client.md`.

**Two rounds of review caught real bugs before this reached anyone**, both worth knowing about since they're the kind unit tests structurally struggle to catch:
- Task-level: the rotation reference code re-wrapped the *existing* DEK instead of generating a fresh one (zero cryptographic effect), and the object-reencrypt loop double-encrypted ciphertext instead of decrypt-then-re-encrypt (would have destroyed metadata on every rotated row). Both fixed and re-verified.
- Final whole-branch review: a cold-cache ordering bug in `decodeObjectMetadata` (stale rows silently dropped on app restart during a drain), and the legacy vault blob was never wired into the drain at all — a team with one would rotate once and then be permanently stuck unable to rotate again. Both fixed and re-verified.

## Test plan

- [x] 89/89 passing across all 13 directly-relevant test files (`teamVaultSync*`, `teamKeyRotation`, `teamObjectEnvelope`, `teamVaultSecrets`, `logger`)
- [x] `tsc --noEmit` clean
- [x] Full repo-wide `vitest run` — green on CI (`build` job, "Frontend tests" step) for `ca824d69`, [run 34444158144](https://github.com/VoltiusApp/voltius/actions/runs/34444158144). The same job's `cargo fmt --check`, `clippy -D warnings` and `cargo test --workspace` are green too. Local runs were OOM-killed on this box under system-wide memory pressure, unrelated to this change; CI is the confirmation.
- [ ] Live two-account e2e verification against a real server (rotate, confirm both accounts stay in sync through the transition) — not yet done, flagged as the natural next step before this ships to users.
