### PR TITLE
fix(teams): act on membership_changed directly instead of diffing

### DIFF
--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -23,7 +23,7 @@ import { buildDecryptKeyCandidates } from "@/services/vaultKeyCandidates";
 import { getMyX25519Keypair } from "@/services/multiplayerService";
 import { initTeamVaultKey } from "@/services/teamVaultSync";
 import { onTeamLogin } from "@/services/teamDataManager";
-import { handleMembershipChangedEvent } from "@/services/teamMembershipEvents";
+import { handleMembershipChangedEvent, parseMembershipChangedEvent } from "@/services/teamMembershipEvents";
 import * as teamService from "@/services/teamService";
 import { appFetch } from "@/services/http";
 import { SseDataLineParser } from "@/services/realtimeSseEvents";
@@ -841,6 +841,58 @@ async function refetchActiveSessions(): Promise<void> {
   await useTeamSessionStore.getState().fetchActiveSessions().catch(() => {});
 }
 
+async function onTeamMembershipAdded(teamId: string): Promise<void> {
+  const { joinAndLoadTeamVault } = await import("@/services/teamDataManager");
+  await joinAndLoadTeamVault(teamId);
+}
+
+async function onTeamMembershipRemoved(tid: string): Promise<void> {
+  // Evict the in-memory vault key immediately so the kicked member can't
+  // use a cached key to decrypt data after losing access.
+  const { deleteTeamKey } = await import("@/services/teamVaultSync");
+  deleteTeamKey(tid);
+
+  // Remove all per-team slices from the team store (members, roles, etc.)
+  useTeamStore.getState().removeTeam(tid);
+
+  // Unlink any local vault that was pointing at this team so the vault
+  // button disappears from the sidebar rather than staying as a broken
+  // cloud-linked vault.
+  const { useVaultStore } = await import("@/stores/vaultStore");
+  const vaultStore = useVaultStore.getState();
+  for (const vault of vaultStore.vaults.filter((v) => v.teamId === tid)) {
+    vaultStore.setVaultTeamId(vault.id, null);
+  }
+
+  const [
+    { useTeamVaultStateStore },
+    { useConnectionStore },
+    { useIdentityStore },
+    { useKeyStore },
+    { useFolderStore },
+    { useSnippetStore },
+    { useSnippetFolderStore },
+    { usePortForwardingStore },
+  ] = await Promise.all([
+    import("@/stores/teamVaultStateStore"),
+    import("@/stores/connectionStore"),
+    import("@/stores/identityStore"),
+    import("@/stores/keyStore"),
+    import("@/stores/folderStore"),
+    import("@/stores/snippetStore"),
+    import("@/stores/snippetFolderStore"),
+    import("@/stores/portForwardingStore"),
+  ]);
+  useTeamVaultStateStore.getState().setStatus(tid, "forbidden");
+  useConnectionStore.getState().clearTeamConnections(tid);
+  useIdentityStore.getState().clearTeamIdentities(tid);
+  useKeyStore.getState().clearTeamKeys(tid);
+  useFolderStore.getState().clearTeamFolders(tid);
+  useSnippetStore.getState().clearTeamSnippets(tid);
+  useSnippetFolderStore.getState().clearTeamSnippetFolders(tid);
+  usePortForwardingStore.getState().clearTeamRules(tid);
+}
+
 async function handleRealtimeEvent(eventData: string, myDeviceId: string): Promise<void> {
   if (eventData.startsWith("team:")) {
     const teamId = eventData.slice(5);
@@ -864,67 +916,26 @@ async function handleRealtimeEvent(eventData: string, myDeviceId: string): Promi
     useTeamStore.getState().loadPendingInvitations(teamId).catch(() => {});
   } else if (eventData.startsWith("pending_invitations_changed:")) {
     useTeamStore.getState().loadMyPendingInvitations().catch(() => {});
+  } else if (eventData.startsWith("membership_changed:")) {
+    const parsed = parseMembershipChangedEvent(eventData);
+    if (!parsed) return;
+    if (parsed.kind === "added") {
+      await useTeamStore.getState().loadTeams();
+      await onTeamMembershipAdded(parsed.teamId);
+    } else {
+      await onTeamMembershipRemoved(parsed.teamId);
+    }
   } else if (eventData === "membership_changed") {
-    // Also fired at every recipient of a freshly wrapped vault key. Those users
-    // are already members, so the delta below is zero and nothing would re-read
-    // the key that just landed (issue #70).
-    const { refreshAwaitingKeyTeams } = await import("@/services/teamDataManager");
-    refreshAwaitingKeyTeams().catch(() => {});
-
+    // Compat: bare event from a server pod on an older build.
     handleMembershipChangedEvent({
       getTeamIds: () => useTeamStore.getState().teams.map((t) => t.id),
       loadTeams: () => useTeamStore.getState().loadTeams(),
-      onTeamAdded: async (teamId) => {
-        const { joinAndLoadTeamVault } = await import("@/services/teamDataManager");
-        await joinAndLoadTeamVault(teamId);
-      },
-      onTeamRemoved: async (tid) => {
-        // Evict the in-memory vault key immediately so the kicked member can't
-        // use a cached key to decrypt data after losing access.
-        const { deleteTeamKey } = await import("@/services/teamVaultSync");
-        deleteTeamKey(tid);
-
-        // Remove all per-team slices from the team store (members, roles, etc.)
-        useTeamStore.getState().removeTeam(tid);
-
-        // Unlink any local vault that was pointing at this team so the vault
-        // button disappears from the sidebar rather than staying as a broken
-        // cloud-linked vault.
-        const { useVaultStore } = await import("@/stores/vaultStore");
-        const vaultStore = useVaultStore.getState();
-        for (const vault of vaultStore.vaults.filter((v) => v.teamId === tid)) {
-          vaultStore.setVaultTeamId(vault.id, null);
-        }
-
-        const [
-          { useTeamVaultStateStore },
-          { useConnectionStore },
-          { useIdentityStore },
-          { useKeyStore },
-          { useFolderStore },
-          { useSnippetStore },
-          { useSnippetFolderStore },
-          { usePortForwardingStore },
-        ] = await Promise.all([
-          import("@/stores/teamVaultStateStore"),
-          import("@/stores/connectionStore"),
-          import("@/stores/identityStore"),
-          import("@/stores/keyStore"),
-          import("@/stores/folderStore"),
-          import("@/stores/snippetStore"),
-          import("@/stores/snippetFolderStore"),
-          import("@/stores/portForwardingStore"),
-        ]);
-        useTeamVaultStateStore.getState().setStatus(tid, "forbidden");
-        useConnectionStore.getState().clearTeamConnections(tid);
-        useIdentityStore.getState().clearTeamIdentities(tid);
-        useKeyStore.getState().clearTeamKeys(tid);
-        useFolderStore.getState().clearTeamFolders(tid);
-        useSnippetStore.getState().clearTeamSnippets(tid);
-        useSnippetFolderStore.getState().clearTeamSnippetFolders(tid);
-        usePortForwardingStore.getState().clearTeamRules(tid);
-      },
+      onTeamAdded: onTeamMembershipAdded,
+      onTeamRemoved: onTeamMembershipRemoved,
     }).catch(() => {});
+  } else if (eventData === "vault_key_changed") {
+    const { refreshAwaitingKeyTeams } = await import("@/services/teamDataManager");
+    refreshAwaitingKeyTeams().catch(() => {});
   } else if (eventData.startsWith("presence:")) {
     const parts = eventData.split(":");
     const userId = parts[1];

--- a/src/services/teamDataManager.ts
+++ b/src/services/teamDataManager.ts
@@ -112,12 +112,10 @@ function applyFirstViewNav(teamId: string): void {
 /**
  * Re-fetch every team vault currently stuck in `awaiting_key`.
  *
- * The server notifies each recipient of a wrapped key with `membership_changed`
- * (`put_vault_keys` in server/src/routes/team_sync.rs), but the joiner is
- * already in the team by then, so the membership delta is zero and
- * `onTeamAdded` never fires — the key lands and nothing re-reads it. Without
- * this the honest waiting state is also a permanent one until the user hits
- * Retry or restarts.
+ * The server notifies each recipient of a wrapped key with `vault_key_changed`
+ * (`put_vault_keys` in server/src/routes/team_sync.rs), not `membership_changed`,
+ * since the joiner is already a member by then. Without this the waiting state
+ * is permanent until the user hits Retry or restarts.
  *
  * Deliberately a foreground fetch: `{ background: true }` suppresses every
  * status write, including the "loaded" that a team with no blob yet reaches, so

--- a/src/services/teamMembershipEvents.test.ts
+++ b/src/services/teamMembershipEvents.test.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "vitest";
+import { parseMembershipChangedEvent, getTeamMembershipDelta } from "@/services/teamMembershipEvents";
+
+test("parses an added event", () => {
+  expect(parseMembershipChangedEvent("membership_changed:added:team-1")).toEqual({
+    kind: "added",
+    teamId: "team-1",
+  });
+});
+
+test("parses a removed event", () => {
+  expect(parseMembershipChangedEvent("membership_changed:removed:team-1")).toEqual({
+    kind: "removed",
+    teamId: "team-1",
+  });
+});
+
+test("returns null for the bare legacy event", () => {
+  expect(parseMembershipChangedEvent("membership_changed")).toBeNull();
+});
+
+test("returns null for an unrecognized kind", () => {
+  expect(parseMembershipChangedEvent("membership_changed:renamed:team-1")).toBeNull();
+});
+
+test("returns null for an unrelated event", () => {
+  expect(parseMembershipChangedEvent("team_members:team-1")).toBeNull();
+});
+
+test("computes added and removed team ids", () => {
+  expect(getTeamMembershipDelta(["a", "b"], ["b", "c"])).toEqual({
+    added: ["c"],
+    removed: ["a"],
+  });
+});

--- a/src/services/teamMembershipEvents.ts
+++ b/src/services/teamMembershipEvents.ts
@@ -5,6 +5,24 @@ export interface TeamMembershipEventDeps {
   onTeamRemoved?: (teamId: string) => Promise<void> | void;
 }
 
+export interface MembershipChangedEvent {
+  kind: "added" | "removed";
+  teamId: string;
+}
+
+/** Parses `membership_changed:added:{team_id}` / `membership_changed:removed:{team_id}`. */
+export function parseMembershipChangedEvent(eventData: string): MembershipChangedEvent | null {
+  const prefix = "membership_changed:";
+  if (!eventData.startsWith(prefix)) return null;
+  const rest = eventData.slice(prefix.length);
+  const sep = rest.indexOf(":");
+  if (sep === -1) return null;
+  const kind = rest.slice(0, sep);
+  const teamId = rest.slice(sep + 1);
+  if ((kind !== "added" && kind !== "removed") || !teamId) return null;
+  return { kind, teamId };
+}
+
 export function getTeamMembershipDelta(prevTeamIds: string[], nextTeamIds: string[]) {
   const prev = new Set(prevTeamIds);
   const next = new Set(nextTeamIds);


### PR DESCRIPTION
## Summary
- Closes #236.
- The server (VoltiusApp/server#18) now sends `membership_changed:added:{team_id}` / `membership_changed:removed:{team_id}`, so this client acts on that exact team directly instead of re-fetching the whole team list, diffing it, and retrying with backoff on a zero delta.
- The bare `membership_changed` event still falls back to the old diff-based path, for a server pod on an older build mid-rollout.
- Vault-key-wrap notifications now arrive as their own `vault_key_changed` event instead of riding a fake membership change (issue #70's zero-delta case).

## Test plan
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec vitest run src/services/teamMembershipEvents.test.ts` (new coverage for the event parser + existing delta logic)