### PR TITLE
fix(storage): make entity file loads fallible instead of swallowing errors

### DIFF
--- a/src-tauri/src/commands/connections.rs
+++ b/src-tauri/src/commands/connections.rs
@@ -197,7 +197,7 @@ fn build_connection(
 
 #[tauri::command]
 pub fn connection_save(data: ConnectionFormData) -> Result<Connection, String> {
-    let mut connections = load_connections();
+    let mut connections = load_connections()?;
     let now = Utc::now().to_rfc3339();
     check_vault_write(&requested_vault(&data.vault_id))?;
     let conn = build_connection(Uuid::new_v4().to_string(), data, &now, None, None);
@@ -217,7 +217,7 @@ pub fn connection_save(data: ConnectionFormData) -> Result<Connection, String> {
 /// migration idempotent.
 #[tauri::command]
 pub fn connection_adopt(id: String, data: ConnectionFormData) -> Result<Connection, String> {
-    let mut connections = load_connections();
+    let mut connections = load_connections()?;
     let now = Utc::now().to_rfc3339();
     check_vault_write(&requested_vault(&data.vault_id))?;
 
@@ -234,7 +234,7 @@ pub fn connection_adopt(id: String, data: ConnectionFormData) -> Result<Connecti
 
 #[tauri::command]
 pub fn connection_update(id: String, data: ConnectionFormData) -> Result<Connection, String> {
-    let mut connections = load_connections();
+    let mut connections = load_connections()?;
     let existing = find_mut(&mut connections, &id)?.clone();
     check_vault_write(&[effective_vault(&data.vault_id, &existing.vault_id)])?;
 
@@ -250,7 +250,7 @@ pub fn connection_update(id: String, data: ConnectionFormData) -> Result<Connect
 
 #[tauri::command]
 pub fn connection_set_distro(id: String, distro: String) -> Result<(), String> {
-    let mut connections = load_connections();
+    let mut connections = load_connections()?;
     let conn = find_mut(&mut connections, &id)?;
     let now = Utc::now().to_rfc3339();
     conn.distro = Some(distro);
@@ -261,7 +261,7 @@ pub fn connection_set_distro(id: String, distro: String) -> Result<(), String> {
 
 #[tauri::command]
 pub fn connection_set_last_used(id: String) -> Result<(), String> {
-    let mut connections = load_connections();
+    let mut connections = load_connections()?;
     let conn = find_mut(&mut connections, &id)?;
     let now = Utc::now().to_rfc3339();
     conn.last_used_at = Some(now.clone());

--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -51,7 +51,7 @@ fn build_folder(id: String, data: FolderFormData, now: &str, created_at: Option<
 /// here — and authorizes the destination vault before stamping anything.
 #[tauri::command]
 pub fn folder_update(id: String, data: FolderFormData) -> Result<Folder, String> {
-    let mut folders = load_folders();
+    let mut folders = load_folders()?;
     let folder = find_mut(&mut folders, &id)?;
     let effective = effective_vault(&data.vault_id, &folder.vault_id);
     check_vault_write(std::slice::from_ref(&effective))?;
@@ -78,7 +78,7 @@ pub fn folder_update(id: String, data: FolderFormData) -> Result<Folder, String>
 /// destroy items the user filed in the folder after creating it.
 #[tauri::command]
 pub fn folder_delete(id: String, cascade: Option<bool>) -> Result<(), String> {
-    let mut folders = load_folders();
+    let mut folders = load_folders()?;
     if !folders.iter().any(|f| f.id == id) {
         return Err(format!("Folder {} not found", id));
     }
@@ -90,10 +90,10 @@ pub fn folder_delete(id: String, cascade: Option<bool>) -> Result<(), String> {
         HashSet::from([id.clone()])
     };
 
-    let mut connections = load_connections();
-    let mut identities = load_identities();
-    let mut keys = load_keys();
-    let mut rules = load_port_forwarding_rules();
+    let mut connections = load_connections()?;
+    let mut identities = load_identities()?;
+    let mut keys = load_keys()?;
+    let mut rules = load_port_forwarding_rules()?;
 
     let in_tree = |folder_id: &Option<String>| {
         cascading && folder_id.as_deref().is_some_and(|f| doomed.contains(f))
@@ -138,21 +138,21 @@ pub fn folder_move_objects(
     let now = Utc::now().to_rfc3339();
     match object_type.as_str() {
         "connection" => {
-            let mut items = load_connections();
+            let mut items = load_connections()?;
             refile_into_folder(&mut items, &object_ids, &folder_id, &now, |c| {
                 &mut c.folder_id
             })?;
             save_connections(&items)
         }
         "identity" => {
-            let mut items = load_identities();
+            let mut items = load_identities()?;
             refile_into_folder(&mut items, &object_ids, &folder_id, &now, |i| {
                 &mut i.folder_id
             })?;
             save_identities(&items)
         }
         "key" => {
-            let mut items = load_keys();
+            let mut items = load_keys()?;
             refile_into_folder(&mut items, &object_ids, &folder_id, &now, |k| {
                 &mut k.folder_id
             })?;

--- a/src-tauri/src/commands/identities.rs
+++ b/src-tauri/src/commands/identities.rs
@@ -58,7 +58,7 @@ fn build_identity(
 
 #[tauri::command]
 pub fn identity_update(id: String, data: IdentityFormData) -> Result<Identity, String> {
-    let mut identities = load_identities();
+    let mut identities = load_identities()?;
     let identity = find_mut(&mut identities, &id)?;
     let now = Utc::now().to_rfc3339();
     let effective = retarget_vault(identity, &data.vault_id, &now);

--- a/src-tauri/src/commands/keys.rs
+++ b/src-tauri/src/commands/keys.rs
@@ -45,7 +45,7 @@ fn build_key(id: String, data: SshKeyFormData, now: &str, created_at: Option<Str
 
 #[tauri::command]
 pub fn key_update(id: String, data: SshKeyFormData) -> Result<SshKey, String> {
-    let mut keys = load_keys();
+    let mut keys = load_keys()?;
     let key = find_mut(&mut keys, &id)?;
     let now = Utc::now().to_rfc3339();
     let effective = retarget_vault(key, &data.vault_id, &now);

--- a/src-tauri/src/commands/port_forwarding_rules.rs
+++ b/src-tauri/src/commands/port_forwarding_rules.rs
@@ -73,7 +73,7 @@ pub fn pf_rule_update(
     id: String,
     data: PortForwardingRuleFormData,
 ) -> Result<PortForwardingRule, String> {
-    let mut rules = load_port_forwarding_rules();
+    let mut rules = load_port_forwarding_rules()?;
     let rule = find_mut(&mut rules, &id)?;
     let now = Utc::now().to_rfc3339();
     let effective = retarget_vault(rule, &data.vault_id, &now);
@@ -103,7 +103,7 @@ pub fn pf_rule_update(
 
 #[tauri::command]
 pub fn pf_rule_duplicate(id: String) -> Result<PortForwardingRule, String> {
-    let rules = load_port_forwarding_rules();
+    let rules = load_port_forwarding_rules()?;
     let source = rules
         .iter()
         .find(|r| r.id == id && is_alive(&r.deleted_at, &r.updated_at))
@@ -127,7 +127,7 @@ pub fn pf_rule_duplicate(id: String) -> Result<PortForwardingRule, String> {
 
 #[tauri::command]
 pub fn pf_rule_move_folder(id: String, folder_id: Option<String>) -> Result<(), String> {
-    let mut rules = load_port_forwarding_rules();
+    let mut rules = load_port_forwarding_rules()?;
     let now = Utc::now().to_rfc3339();
     let rule = find_mut(&mut rules, &id)?;
     rule.folder_id = folder_id;

--- a/src-tauri/src/commands/snippets.rs
+++ b/src-tauri/src/commands/snippets.rs
@@ -77,7 +77,7 @@ fn build_snippet(
 
 #[tauri::command]
 pub fn snippet_update(id: String, data: SnippetFormData) -> Result<Snippet, String> {
-    let mut snippets = load_snippets();
+    let mut snippets = load_snippets()?;
     let snippet = find_mut(&mut snippets, &id)?;
     let now = Utc::now().to_rfc3339();
     let effective = retarget_vault(snippet, &data.vault_id, &now);
@@ -170,7 +170,7 @@ pub fn snippet_folder_update(
     id: String,
     data: SnippetFolderFormData,
 ) -> Result<SnippetFolder, String> {
-    let mut folders = load_snippet_folders();
+    let mut folders = load_snippet_folders()?;
     let folder = find_mut(&mut folders, &id)?;
     let now = Utc::now().to_rfc3339();
     merge_fields!(folder, data, &now, name, parent_id, color, icon);
@@ -184,14 +184,14 @@ pub fn snippet_folder_update(
 /// filed in that subtree.
 #[tauri::command]
 pub fn snippet_folder_delete(id: String) -> Result<(), String> {
-    let mut folders = load_snippet_folders();
+    let mut folders = load_snippet_folders()?;
     if !folders.iter().any(|f| f.id == id) {
         return Err(format!("SnippetFolder {} not found", id));
     }
     let now = Utc::now().to_rfc3339();
     let doomed = subtree_ids(&folders, &id, |f| f.parent_id.as_deref());
 
-    let mut snippets = load_snippets();
+    let mut snippets = load_snippets()?;
     let in_tree =
         |folder_id: &Option<String>| folder_id.as_deref().is_some_and(|f| doomed.contains(f));
 

--- a/src-tauri/src/commands/vault_object.rs
+++ b/src-tauri/src/commands/vault_object.rs
@@ -275,7 +275,7 @@ macro_rules! vault_list_command {
         $(#[$meta])*
         #[tauri::command]
         pub fn $name() -> Result<Vec<$ty>, String> {
-            Ok($crate::commands::vault_object::live($load()))
+            Ok($crate::commands::vault_object::live($load()?))
         }
     };
 }
@@ -287,7 +287,7 @@ macro_rules! vault_create_command {
         $(#[$meta])*
         #[tauri::command]
         pub fn $name(data: $form) -> Result<$ty, String> {
-            let mut items = $load();
+            let mut items = $load()?;
             let now = chrono::Utc::now().to_rfc3339();
             $crate::vault_auth::check_vault_write(
                 &$crate::commands::vault_object::requested_vault(&data.vault_id),
@@ -308,7 +308,7 @@ macro_rules! vault_adopt_command {
         $(#[$meta])*
         #[tauri::command]
         pub fn $name(id: String, data: $form) -> Result<$ty, String> {
-            let mut items = $load();
+            let mut items = $load()?;
             let now = chrono::Utc::now().to_rfc3339();
             $crate::vault_auth::check_vault_write(
                 &$crate::commands::vault_object::requested_vault(&data.vault_id),
@@ -329,7 +329,7 @@ macro_rules! vault_delete_command {
         $(#[$meta])*
         #[tauri::command]
         pub fn $name(id: String) -> Result<(), String> {
-            let mut items = $load();
+            let mut items = $load()?;
             let now = chrono::Utc::now().to_rfc3339();
             let item = $crate::commands::vault_object::find_mut(&mut items, &id)?;
             $crate::vault_auth::check_vault_write(std::slice::from_ref(&item.vault_id))?;

--- a/src-tauri/src/known_hosts.rs
+++ b/src-tauri/src/known_hosts.rs
@@ -61,7 +61,11 @@ impl KnownHostsStore {
 
     /// Load from disk, migrating the old HashMap-based format if present.
     pub fn load() -> Arc<Self> {
-        let mut entries = load_known_hosts();
+        // A corrupt file is already renamed aside by load_json, so this fallback loses nothing.
+        let mut entries = load_known_hosts().unwrap_or_else(|e| {
+            eprintln!("known_hosts: {e}");
+            Vec::new()
+        });
 
         // Migrate old app_data_dir-based key-value JSON (HashMap<"host:port", fingerprint>)
         let old_paths: Vec<std::path::PathBuf> = {

--- a/src-tauri/src/port_forward/mod.rs
+++ b/src-tauri/src/port_forward/mod.rs
@@ -797,7 +797,10 @@ impl PortForwardManager {
         }
 
         use crate::storage::config::{load_port_forwarding_rules, TunnelType as CfgTunnelType};
-        let rules = load_port_forwarding_rules();
+        let rules = load_port_forwarding_rules().unwrap_or_else(|e| {
+            eprintln!("port_forwarding_rules: {e}");
+            Vec::new()
+        });
         for rule in rules {
             if rule.deleted_at.is_some() {
                 continue;

--- a/src-tauri/src/storage/config.rs
+++ b/src-tauri/src/storage/config.rs
@@ -399,9 +399,10 @@ fn migrate_enum_fields(obj: &mut serde_json::Map<String, serde_json::Value>) {
     }
 }
 
-fn parse_with_migration<T: serde::de::DeserializeOwned>(data: &str) -> Vec<T> {
-    let raw: Vec<serde_json::Value> = serde_json::from_str(data).unwrap_or_default();
-    raw.into_iter()
+fn parse_with_migration<T: serde::de::DeserializeOwned>(data: &str) -> Result<Vec<T>, String> {
+    let raw: Vec<serde_json::Value> = serde_json::from_str(data).map_err(|e| e.to_string())?;
+    Ok(raw
+        .into_iter()
         .filter_map(|mut v| {
             if let serde_json::Value::Object(ref mut map) = v {
                 migrate_vault_id(map);
@@ -410,7 +411,7 @@ fn parse_with_migration<T: serde::de::DeserializeOwned>(data: &str) -> Vec<T> {
             }
             serde_json::from_value(v).ok()
         })
-        .collect()
+        .collect())
 }
 
 // ─── File helpers ────────────────────────────────────────────────────────────
@@ -444,25 +445,42 @@ pub fn known_hosts_file() -> PathBuf {
 
 // ─── Generic JSON load/save ──────────────────────────────────────────────────
 
-/// Load a JSON value from `path`, returning `T::default()` if the file is
-/// missing, unreadable, or malformed. Mirrors the historical
-/// `unwrap_or_default()` behavior: errors are swallowed, never surfaced.
-fn load_json<T: serde::de::DeserializeOwned + Default>(path: PathBuf) -> T {
+/// Renames a corrupt file aside so a later save can't overwrite the only copy.
+fn side_band_corrupt_file(path: &std::path::Path) {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return;
+    };
+    let ts = chrono::Utc::now().format("%Y%m%d%H%M%S%3f");
+    let corrupt = path.with_file_name(format!("{name}.corrupt-{ts}"));
+    let _ = fs::rename(path, corrupt);
+}
+
+/// `T::default()` if `path` is absent; `Err` (never a silent empty value) if it
+/// exists but can't be read or parsed.
+fn load_json<T: serde::de::DeserializeOwned + Default>(path: PathBuf) -> Result<T, String> {
     if !path.exists() {
-        return T::default();
+        return Ok(T::default());
     }
-    let data = fs::read_to_string(path).unwrap_or_default();
-    serde_json::from_str(&data).unwrap_or_default()
+    let data =
+        fs::read_to_string(&path).map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    serde_json::from_str(&data).map_err(|e| {
+        side_band_corrupt_file(&path);
+        format!("failed to parse {}: {e}", path.display())
+    })
 }
 
 /// Like [`load_json`] but applies the `vault_ids` → `vault_id` migration to
-/// each record (see [`parse_with_migration`]). Used by the entity stores.
-fn load_json_migrated<T: serde::de::DeserializeOwned>(path: PathBuf) -> Vec<T> {
+/// each record (see [`parse_with_migration`]).
+fn load_json_migrated<T: serde::de::DeserializeOwned>(path: PathBuf) -> Result<Vec<T>, String> {
     if !path.exists() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
-    let data = fs::read_to_string(path).unwrap_or_default();
-    parse_with_migration(&data)
+    let data =
+        fs::read_to_string(&path).map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    parse_with_migration(&data).map_err(|e| {
+        side_band_corrupt_file(&path);
+        format!("failed to parse {}: {e}", path.display())
+    })
 }
 
 /// Pretty-print `value` as JSON and write it to `path`.
@@ -471,7 +489,7 @@ fn save_json<T: Serialize + ?Sized>(path: PathBuf, value: &T) -> Result<(), Stri
     fs::write(path, data).map_err(|e| e.to_string())
 }
 
-pub fn load_connections() -> Vec<Connection> {
+pub fn load_connections() -> Result<Vec<Connection>, String> {
     load_json_migrated(connections_file())
 }
 
@@ -479,7 +497,7 @@ pub fn save_connections(connections: &[Connection]) -> Result<(), String> {
     save_json(connections_file(), connections)
 }
 
-pub fn load_identities() -> Vec<Identity> {
+pub fn load_identities() -> Result<Vec<Identity>, String> {
     load_json_migrated(identities_file())
 }
 
@@ -487,7 +505,7 @@ pub fn save_identities(identities: &[Identity]) -> Result<(), String> {
     save_json(identities_file(), identities)
 }
 
-pub fn load_keys() -> Vec<SshKey> {
+pub fn load_keys() -> Result<Vec<SshKey>, String> {
     load_json_migrated(keys_file())
 }
 
@@ -495,7 +513,7 @@ pub fn save_keys(keys: &[SshKey]) -> Result<(), String> {
     save_json(keys_file(), keys)
 }
 
-pub fn load_folders() -> Vec<Folder> {
+pub fn load_folders() -> Result<Vec<Folder>, String> {
     load_json(folders_file())
 }
 
@@ -522,7 +540,7 @@ pub struct KnownHost {
     pub clocks: HashMap<String, String>,
 }
 
-pub fn load_known_hosts() -> Vec<KnownHost> {
+pub fn load_known_hosts() -> Result<Vec<KnownHost>, String> {
     load_json(known_hosts_file())
 }
 
@@ -757,7 +775,7 @@ fn port_forwarding_rules_file() -> PathBuf {
     config_dir().join("port_forwarding_rules.json")
 }
 
-pub fn load_port_forwarding_rules() -> Vec<PortForwardingRule> {
+pub fn load_port_forwarding_rules() -> Result<Vec<PortForwardingRule>, String> {
     load_json_migrated(port_forwarding_rules_file())
 }
 
@@ -783,8 +801,8 @@ fn migrate_snippet_steps(s: &mut Snippet) {
     }
 }
 
-pub fn load_snippets() -> Vec<Snippet> {
-    let mut snippets: Vec<Snippet> = load_json_migrated(snippets_file());
+pub fn load_snippets() -> Result<Vec<Snippet>, String> {
+    let mut snippets: Vec<Snippet> = load_json_migrated(snippets_file())?;
     let needs = snippets.iter().any(|s| s.content.is_some());
     for s in snippets.iter_mut() {
         migrate_snippet_steps(s);
@@ -792,7 +810,7 @@ pub fn load_snippets() -> Vec<Snippet> {
     if needs {
         let _ = save_snippets(&snippets);
     }
-    snippets
+    Ok(snippets)
 }
 
 pub fn save_snippets(snippets: &[Snippet]) -> Result<(), String> {
@@ -836,7 +854,7 @@ fn snippet_folders_file() -> PathBuf {
     config_dir().join("snippet_folders.json")
 }
 
-pub fn load_snippet_folders() -> Vec<SnippetFolder> {
+pub fn load_snippet_folders() -> Result<Vec<SnippetFolder>, String> {
     load_json_migrated(snippet_folders_file())
 }
 
@@ -1165,13 +1183,14 @@ mod tests {
 
     #[test]
     fn parse_reads_valid_array() {
-        let got: Vec<Mini> = parse_with_migration(r#"[{"id":"a"},{"id":"b"}]"#);
+        let got: Vec<Mini> = parse_with_migration(r#"[{"id":"a"},{"id":"b"}]"#).unwrap();
         assert_eq!(got, vec![Mini { id: "a".into() }, Mini { id: "b".into() }]);
     }
 
     #[test]
     fn parse_applies_migration_to_each_record() {
-        let got: Vec<WithVault> = parse_with_migration(r#"[{"id":"a","vault_ids":["team","x"]}]"#);
+        let got: Vec<WithVault> =
+            parse_with_migration(r#"[{"id":"a","vault_ids":["team","x"]}]"#).unwrap();
         assert_eq!(
             got,
             vec![WithVault {
@@ -1182,22 +1201,21 @@ mod tests {
     }
 
     #[test]
-    fn parse_returns_empty_on_malformed_json() {
-        // Pinned current behavior: `unwrap_or_default()` swallows parse errors.
-        let got: Vec<Mini> = parse_with_migration("not valid json {");
-        assert!(got.is_empty());
+    fn parse_errors_on_malformed_json() {
+        let got: Result<Vec<Mini>, String> = parse_with_migration("not valid json {");
+        assert!(got.is_err());
     }
 
     #[test]
-    fn parse_returns_empty_when_top_level_is_not_an_array() {
-        let got: Vec<Mini> = parse_with_migration(r#"{"id":"a"}"#);
-        assert!(got.is_empty());
+    fn parse_errors_when_top_level_is_not_an_array() {
+        let got: Result<Vec<Mini>, String> = parse_with_migration(r#"{"id":"a"}"#);
+        assert!(got.is_err());
     }
 
     #[test]
     fn parse_silently_drops_records_that_fail_to_deserialize() {
         // Pinned current behavior: a bad record is filtered out, not surfaced.
-        let got: Vec<Mini> = parse_with_migration(r#"[{"id":"a"},{"nope":"b"}]"#);
+        let got: Vec<Mini> = parse_with_migration(r#"[{"id":"a"},{"nope":"b"}]"#).unwrap();
         assert_eq!(got, vec![Mini { id: "a".into() }]);
     }
 
@@ -1215,11 +1233,11 @@ mod tests {
         std::env::set_var("XDG_CONFIG_HOME", &dir);
 
         // A missing file loads as empty, not an error.
-        assert!(load_identities().is_empty());
+        assert!(load_identities().unwrap().is_empty());
 
         // save → load preserves the record.
         save_connections(&[sample_connection()]).expect("save");
-        let loaded = load_connections();
+        let loaded = load_connections().unwrap();
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].id, "conn-1");
         assert_eq!(loaded[0].vault_id, "team");
@@ -1228,11 +1246,56 @@ mod tests {
         let legacy = r#"[{"id":"c2","tags":[],"created_at":"t","last_used_at":null,
             "updated_at":"t","deleted_at":null,"clocks":{},"vault_ids":["legacy-team","x"]}]"#;
         std::fs::write(config_dir().join("connections.json"), legacy).unwrap();
-        let migrated = load_connections();
+        let migrated = load_connections().unwrap();
         assert_eq!(migrated.len(), 1);
         assert_eq!(migrated[0].vault_id, "legacy-team");
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── #250: a corrupt entity file must error, not silently look empty ──────
+
+    #[test]
+    fn load_json_migrated_is_empty_for_a_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let items: Vec<KnownHost> =
+            load_json_migrated(dir.path().join("connections.json")).unwrap();
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn load_json_migrated_errors_on_a_corrupt_file_instead_of_returning_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("connections.json");
+        fs::write(&path, "not json").unwrap();
+
+        let result: Result<Vec<KnownHost>, String> = load_json_migrated(path.clone());
+        assert!(result.is_err());
+
+        // The bad file is renamed aside, not left for the next save to overwrite.
+        assert!(!path.exists());
+        let siblings: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(siblings.len(), 1);
+        let corrupt_name = siblings[0].file_name().to_string_lossy().into_owned();
+        assert!(
+            corrupt_name.starts_with("connections.json.corrupt-"),
+            "{corrupt_name}"
+        );
+        assert_eq!(fs::read_to_string(siblings[0].path()).unwrap(), "not json");
+    }
+
+    #[test]
+    fn load_json_errors_on_a_corrupt_file_instead_of_returning_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("folders.json");
+        fs::write(&path, "not json").unwrap();
+
+        let result: Result<Vec<Folder>, String> = load_json(path.clone());
+        assert!(result.is_err());
+        assert!(!path.exists());
     }
 }
 


### PR DESCRIPTION
## Summary
- `load_json`/`load_json_migrated` (and every `load_*` wrapper: connections, identities, keys, folders, known_hosts, port_forwarding_rules, snippets, snippet_folders) now return `Result` instead of swallowing a read/parse error into an empty `Vec`.
- A corrupt file is renamed aside (`<name>.json.corrupt-<timestamp>`) before erroring, so data stays recoverable instead of getting overwritten by the next create/adopt/update/delete.
- Propagated `?` through the shared `vault_object.rs` command macros and every bespoke command function that loads before saving.
- Two read-only, non-fallible call sites (`KnownHostsStore::load()` at startup, `auto_activate_rules`) log and fall back to empty since the corrupt file is already preserved.

## Test plan
- [x] `cargo test --lib` — 352 passed
- [x] `cargo fmt --check` — clean
- [x] `cargo build --lib` — clean
- [x] New regression tests: missing file → empty; corrupt file → `Err` + side-banded with original content intact (both `load_json` and `load_json_migrated`)

Fixes #250