### PR TITLE
fix(ui): stop vault header collapsing on narrow windows

### DIFF
--- a/src/components/layout/VaultHeader.tsx
+++ b/src/components/layout/VaultHeader.tsx
@@ -271,7 +271,7 @@ export default function VaultHeader() {
         </div>
 
         <div className="flex flex-col justify-center min-w-0">
-          <div className="flex items-center gap-2 flex-wrap">
+          <div className="flex items-center gap-2 min-w-0">
             <button
               ref={triggerRef}
               type="button"
@@ -279,30 +279,26 @@ export default function VaultHeader() {
               aria-expanded={admin.pos !== null}
               aria-label={t("layout.vaultMenu.openMenu")}
               onClick={() => triggerRef.current && admin.openAtElement(triggerRef.current)}
-              className="flex items-center gap-1.5 rounded-lg px-1.5 py-0.5 -ml-1.5 transition-colors"
+              className="flex items-center gap-1.5 rounded-lg px-1.5 py-0.5 -ml-1.5 transition-colors min-w-0"
               style={{ background: admin.pos !== null ? "var(--t-bg-elevated)" : "transparent", border: "none", cursor: "pointer" }}
             >
               <span className="text-base font-semibold truncate" style={{ color: "var(--t-text-primary)" }}>
                 {displayName}
               </span>
-              <Icon icon="lucide:chevron-down" width={12} style={{ color: "var(--t-text-dim)" }} />
+              <Icon icon="lucide:chevron-down" width={12} className="shrink-0" style={{ color: "var(--t-text-dim)" }} />
             </button>
-            {team && <Badge label={t("layout.vaultHeader.teamBadge")} />}
-            {members !== null && (
-              <Badge label={t("layout.vaultHeader.memberCount", { count: members.length })} accent />
-            )}
-            {showSync && (
-              <span className="text-xs" style={{ color: "var(--t-text-dim)" }}>{t("layout.vaultHeader.lastSync", { time: lastSync })}</span>
-            )}
           </div>
-          <div className="flex items-center gap-3 text-xs mt-0.5 flex-wrap" style={{ color: "var(--t-text-dim)" }}>
+          <div className="flex items-center gap-3 text-xs mt-0.5 flex-nowrap overflow-hidden" style={{ color: "var(--t-text-dim)" }}>
             {isE2EE && (
-              <span className="flex items-center gap-1">
+              <span className="flex items-center gap-1 shrink-0">
                 <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--t-status-connected)" }} />
                 {t("layout.vaultHeader.e2ee")}
               </span>
             )}
             <ContentCounts counts={counts} />
+            {showSync && (
+              <span className="truncate">{t("layout.vaultHeader.lastSync", { time: lastSync })}</span>
+            )}
           </div>
         </div>
       </div>
@@ -310,7 +306,7 @@ export default function VaultHeader() {
       {/* Center zone: command palette */}
       <button
         onClick={() => setOmniOpen(true)}
-        className="flex items-center gap-2 px-3.5 h-9 rounded-lg transition-colors justify-self-center w-[clamp(20rem,30vw,27.5rem)]"
+        className="flex items-center gap-2 px-3.5 h-9 rounded-lg transition-colors justify-self-center w-[clamp(11rem,30vw,27.5rem)]"
         style={{
           background: "var(--t-bg-chrome-field)",
           color: "var(--t-text-secondary)",
@@ -369,24 +365,5 @@ export default function VaultHeader() {
 
       <VaultAdminSurface admin={admin} target={target} />
     </div>
-  );
-}
-
-function Badge({ label, accent }: { label: string; accent?: boolean }) {
-  return (
-    <span
-      className="px-2 py-0.5 rounded-full text-xs font-medium shrink-0"
-      style={{
-        background: accent
-          ? "color-mix(in srgb, var(--t-accent) 15%, transparent)"
-          : "var(--t-bg-elevated)",
-        color: accent ? "var(--t-accent)" : "var(--t-text-secondary)",
-        border: accent
-          ? "1px solid color-mix(in srgb, var(--t-accent) 30%, transparent)"
-          : "1px solid var(--t-border)",
-      }}
-    >
-      {label}
-    </span>
   );
 }

--- a/src/i18n/locales/en/layout.json
+++ b/src/i18n/locales/en/layout.json
@@ -208,9 +208,6 @@
     },
     "vaultHeader": {
       "members": "Members",
-      "teamBadge": "team",
-      "memberCount_one": "{{count}} member",
-      "memberCount_other": "{{count}} members",
       "lastSync": "Last sync {{time}}",
       "e2ee": "E2EE",
       "noOneOnline": "no one online",

--- a/src/i18n/locales/fr/layout.json
+++ b/src/i18n/locales/fr/layout.json
@@ -208,9 +208,6 @@
     },
     "vaultHeader": {
       "members": "Membres",
-      "teamBadge": "équipe",
-      "memberCount_one": "{{count}} membre",
-      "memberCount_other": "{{count}} membres",
       "lastSync": "Dernière synchro {{time}}",
       "e2ee": "E2EE",
       "noOneOnline": "personne en ligne",

--- a/src/i18n/locales/ru/layout.json
+++ b/src/i18n/locales/ru/layout.json
@@ -209,11 +209,6 @@
     },
     "vaultHeader": {
       "members": "Участники",
-      "teamBadge": "команда",
-      "memberCount_one": "{{count}} участник",
-      "memberCount_few": "{{count}} участника",
-      "memberCount_many": "{{count}} участников",
-      "memberCount_other": "{{count}} участников",
       "lastSync": "Последняя синхронизация {{time}}",
       "e2ee": "E2EE",
       "noOneOnline": "никого нет в сети",

--- a/src/i18n/locales/zh/layout.json
+++ b/src/i18n/locales/zh/layout.json
@@ -208,9 +208,6 @@
     },
     "vaultHeader": {
       "members": "成员",
-      "teamBadge": "团队",
-      "memberCount_one": "{{count}} 名成员",
-      "memberCount_other": "{{count}} 名成员",
       "lastSync": "上次同步 {{time}}",
       "e2ee": "E2EE",
       "noOneOnline": "无人在线",


### PR DESCRIPTION
## Problem

On a narrow window the vault header collapses. The name row is `flex-wrap` inside a header pinned to `height: 4.25rem`, so once the `team` and `N members` badges no longer fit beside the vault name they wrap onto a second line that overflows into the nav bar.

The grid makes it worse: `grid-cols-[1fr_auto_1fr]` with `px-5` + two `gap-5` and a command palette whose width floor was `clamp(20rem, ...)` reserves 400px before the name zone gets anything.

At 900px with a 6-member team, the `team` / `6 members` badges wrapped below the name, out of the header box and across the Hosts/Keychain nav row, with the vault name running under the command palette. After the change the header holds one line at the same width: the name ellipsizes, the menu chevron survives, and the member avatars plus `+3` still carry the team information on the right.

## Changes

- Remove the `team` and `N members` badges and the local `Badge` component. Both duplicated what the members avatar stack already shows on the right — team-ness is implied by the stack existing, and the count is the stack plus its `+N` chip.
- Drop the now-unused `layout.vaultHeader.teamBadge` / `memberCount*` strings from `en`, `fr`, `ru`, `zh`.
- Move the last-sync text out of the name row down to the metadata row, where the E2EE marker and content counts already live.
- Give the name row and menu button `min-w-0` and the chevron `shrink-0`, so the name ellipsizes instead of squeezing the chevron out of the button.
- Metadata row goes `flex-nowrap overflow-hidden` so it clips its tail instead of growing a third line inside the fixed height.
- Lower the palette floor to `clamp(11rem, 30vw, 27.5rem)` so it returns width on narrow windows.

## Verification

- `tsc --noEmit` clean.
- `vitest run src/components/layout` — 11 files, 67 tests passing.
- Driven live in the headless container with a 6-member team, at 1200px, 900px and 800px (the window minimum).
- The `build` check was red on this PR with two `src/services/deepLink.test.ts` failures that are already red on the `dev` tip it branched from (`f8aa8225`), unrelated to these files.
