### PR TITLE
fix(deeplink): use a live settings section in tests

### DIFF
--- a/src/services/deepLink.test.ts
+++ b/src/services/deepLink.test.ts
@@ -209,7 +209,7 @@ test("a navigate link reaches the handler without opening a prompt", () => {
   const seen: string[] = [];
   useDeepLinkStore.getState().setUnpromptedHandler((i) => seen.push(i.route));
   useDeepLinkStore.getState().setReady(true);
-  handleDeepLink("voltius://settings?section=vaults");
+  handleDeepLink("voltius://settings?section=sync");
   handleDeepLink("voltius://billing");
   expect(seen).toEqual(["settings", "billing"]);
   expect(useDeepLinkStore.getState().prompt).toBeNull();
@@ -229,7 +229,7 @@ test("the same navigate link delivered twice reaches the handler once", () => {
   const seen: string[] = [];
   useDeepLinkStore.getState().setUnpromptedHandler((i) => seen.push(i.route));
   useDeepLinkStore.getState().setReady(true);
-  handleDeepLink("voltius://settings?section=vaults");
-  handleDeepLink("voltius://settings?section=vaults");
+  handleDeepLink("voltius://settings?section=sync");
+  handleDeepLink("voltius://settings?section=sync");
   expect(seen).toEqual(["settings"]);
 });


### PR DESCRIPTION
## Summary
- `7ebde608` dropped the `"vaults"` `SETTINGS_SECTIONS` id and fixed `deepLinkUrl.test.ts` to match, but missed `deepLink.test.ts`, which kept building settings deep links with the now-invalid section
- `parseDeepLink` silently rejected them, leaving `build` red on `main` (2 failures in `src/services/deepLink.test.ts`)
- Swap `section=vaults` for `section=sync`, same substitution already applied in `deepLinkUrl.test.ts`

## Test plan
- [x] `npx vitest run src/services/deepLink.test.ts` — 23/23 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)