### PR TITLE
fix(mobile): draggable selection handles, char-precise across lines

### DIFF
--- a/src/components/mobile/MobileTerminalGestures.tsx
+++ b/src/components/mobile/MobileTerminalGestures.tsx
@@ -13,6 +13,8 @@ import {
   wordRangeAt,
   isBlankCell,
   extendSelection,
+  selectionLength,
+  cellPixel,
   type Cell,
   type CellMetrics,
 } from "./mobileTerminalGesturesCore";
@@ -24,7 +26,9 @@ const LONG_PRESS_MS = 380;
 const MOVE_THRESHOLD_PX = 10;
 const DOUBLE_TAP = { ms: 300, px: 24 };
 
-type Phase = "idle" | "pending" | "scrolling" | "selecting" | "pinching";
+type Phase = "idle" | "pending" | "scrolling" | "selecting" | "pinching" | "draggingHandle";
+
+type HandlePositions = { start: { x: number; y: number }; end: { x: number; y: number } };
 
 /**
  * Mobile-only unified terminal gesture layer. One-finger immediate drag scrolls;
@@ -41,6 +45,7 @@ export default function MobileTerminalGestures({ sessionId, active }: { sessionI
   const rootRef = useRef<HTMLDivElement>(null);
   const [hintKey, setHintKey] = useState(0);
   const [toolbar, setToolbar] = useState<{ x: number; y: number; mode: "select" | "paste" } | null>(null);
+  const [handles, setHandles] = useState<HandlePositions | null>(null);
   const toolbarOpen = useRef(false);
   const anchorStart = useRef<Cell | null>(null);
   const anchorEnd = useRef<Cell | null>(null);
@@ -54,30 +59,50 @@ export default function MobileTerminalGestures({ sessionId, active }: { sessionI
   const longPressFired = useRef(false);
   const lastTap = useRef<TapPoint | null>(null);
   const pinch = useRef<{ dist: number; size: number } | null>(null);
+  const dragHandle = useRef<"start" | "end" | null>(null);
+  const dragFixed = useRef<Cell | null>(null);
+
+  const metrics = (): CellMetrics | null => {
+    const api = getTerminalApi(sessionId);
+    const el = api?.screenEl();
+    if (!api || !el) return null;
+    const r = el.getBoundingClientRect();
+    const cols = api.cols();
+    const rows = api.rows();
+    if (!cols || !rows) return null;
+    return {
+      left: r.left,
+      top: r.top,
+      cellWidth: r.width / cols,
+      cellHeight: r.height / rows,
+      cols,
+      rows,
+      viewportTop: api.viewportTop(),
+    };
+  };
+
+  /** Re-derives the toolbar and both drag handles from xterm's own settled selection. */
+  const refreshSelectionUI = () => {
+    const api = getTerminalApi(sessionId);
+    const m = metrics();
+    const pos = api?.getSelectionPosition();
+    if (!api || !m || !pos) { setHandles(null); return; }
+    const root = rootRef.current?.getBoundingClientRect();
+    const rx = root?.left ?? 0;
+    const ry = root?.top ?? 0;
+    const startPx = cellPixel(m, { col: pos.start.x, line: pos.start.y }, 0);
+    const endPx = cellPixel(m, { col: pos.end.x, line: pos.end.y }, 1);
+    setHandles({
+      start: { x: startPx.x - rx, y: startPx.y - ry + m.cellHeight },
+      end: { x: endPx.x - rx, y: endPx.y - ry + m.cellHeight },
+    });
+    setToolbar({ x: startPx.x - rx, y: startPx.y - ry, mode: "select" });
+  };
 
   useEffect(() => {
     if (!active) return;
     const container = rootRef.current?.parentElement;
     if (!container) return;
-
-    const metrics = (): CellMetrics | null => {
-      const api = getTerminalApi(sessionId);
-      const el = api?.screenEl();
-      if (!api || !el) return null;
-      const r = el.getBoundingClientRect();
-      const cols = api.cols();
-      const rows = api.rows();
-      if (!cols || !rows) return null;
-      return {
-        left: r.left,
-        top: r.top,
-        cellWidth: r.width / cols,
-        cellHeight: r.height / rows,
-        cols,
-        rows,
-        viewportTop: api.viewportTop(),
-      };
-    };
 
     const clearLongPress = () => {
       if (longPressTimer.current) { clearTimeout(longPressTimer.current); longPressTimer.current = null; }
@@ -85,6 +110,7 @@ export default function MobileTerminalGestures({ sessionId, active }: { sessionI
 
     const closeToolbar = () => {
       setToolbar(null);
+      setHandles(null);
       anchorStart.current = null;
       anchorEnd.current = null;
     };
@@ -92,17 +118,6 @@ export default function MobileTerminalGestures({ sessionId, active }: { sessionI
     const showPaste = (x: number, y: number) => {
       const root = rootRef.current?.getBoundingClientRect();
       setToolbar({ x: x - (root?.left ?? 0), y: y - (root?.top ?? 0), mode: "paste" });
-    };
-
-    const showSelectionToolbar = () => {
-      const api = getTerminalApi(sessionId);
-      const m = metrics();
-      const pos = api?.getSelectionPosition();
-      if (!api || !m || !pos) return;
-      const root = rootRef.current?.getBoundingClientRect();
-      const left = m.left + pos.start.x * m.cellWidth - (root?.left ?? 0);
-      const top = m.top + (pos.start.y - m.viewportTop) * m.cellHeight - (root?.top ?? 0);
-      setToolbar({ x: left, y: top, mode: "select" });
     };
 
     const onLongPress = (x: number, y: number) => {
@@ -129,10 +144,24 @@ export default function MobileTerminalGestures({ sessionId, active }: { sessionI
       start.current = null;
       carry.current = 0;
       longPressFired.current = false;
+      dragHandle.current = null;
+      dragFixed.current = null;
       clearLongPress();
     };
 
     const onTouchStart = (e: TouchEvent) => {
+      const handleEl = (e.target as Element | null)?.closest("[data-selection-handle]") as HTMLElement | null;
+      if (handleEl) {
+        const api = getTerminalApi(sessionId);
+        const pos = api?.getSelectionPosition();
+        if (!pos) return;
+        const which = handleEl.dataset.selectionHandle as "start" | "end";
+        dragHandle.current = which;
+        dragFixed.current = which === "start" ? { col: pos.end.x, line: pos.end.y } : { col: pos.start.x, line: pos.start.y };
+        phase.current = "draggingHandle";
+        setToolbar(null);
+        return;
+      }
       if (toolbarOpen.current) {
         const target = e.target as Element | null;
         if (target?.closest("[data-mobile-term-toolbar]")) return; // let the toolbar button handle its own tap
@@ -166,6 +195,20 @@ export default function MobileTerminalGestures({ sessionId, active }: { sessionI
     };
 
     const onTouchMove = (e: TouchEvent) => {
+      if (phase.current === "draggingHandle") {
+        e.preventDefault();
+        const m = metrics();
+        const api = getTerminalApi(sessionId);
+        const t = e.touches[0];
+        if (!m || !api || !dragFixed.current || !t) return;
+        const focus = cellFromPoint(m, t.clientX, t.clientY);
+        const sel = extendSelection(dragFixed.current, dragFixed.current, focus);
+        api.select(sel.start.col, sel.start.line, selectionLength(sel.start, sel.end, m.cols));
+        const root = rootRef.current?.getBoundingClientRect();
+        const live = { x: t.clientX - (root?.left ?? 0), y: t.clientY - (root?.top ?? 0) };
+        setHandles((h) => (h ? { ...h, [dragHandle.current!]: live } : h));
+        return;
+      }
       if (phase.current === "pinching") {
         const p = pinch.current;
         if (!p || e.touches.length < 2) return;
@@ -215,14 +258,20 @@ export default function MobileTerminalGestures({ sessionId, active }: { sessionI
         if (!m || !api || !anchorStart.current || !anchorEnd.current) return;
         const focus = cellFromPoint(m, t.clientX, t.clientY);
         const sel = extendSelection(anchorStart.current, anchorEnd.current, focus);
-        if (sel.kind === "line") api.select(sel.startCol, sel.line, sel.len);
-        else api.selectLines(sel.start, sel.end);
+        api.select(sel.start.col, sel.start.line, selectionLength(sel.start, sel.end, m.cols));
       }
     };
 
     const onTouchEnd = (e: TouchEvent) => {
       clearLongPress();
       const wasPhase = phase.current;
+
+      if (wasPhase === "draggingHandle") {
+        e.preventDefault();
+        reset();
+        refreshSelectionUI();
+        return;
+      }
 
       if (wasPhase === "pinching") {
         e.preventDefault();
@@ -234,7 +283,7 @@ export default function MobileTerminalGestures({ sessionId, active }: { sessionI
       if (longPressFired.current) {
         e.preventDefault();
         e.stopPropagation();
-        if (wasPhase === "selecting") showSelectionToolbar();
+        if (wasPhase === "selecting") refreshSelectionUI();
         reset();
         return;
       }
@@ -318,6 +367,36 @@ export default function MobileTerminalGestures({ sessionId, active }: { sessionI
           Tab
         </span>
       )}
+      {handles && (
+        <>
+          {(["start", "end"] as const).map((which) => (
+            <div
+              key={which}
+              data-selection-handle={which}
+              className="absolute pointer-events-auto"
+              style={{
+                left: `${handles[which].x}px`,
+                top: `${handles[which].y}px`,
+                width: 32,
+                height: 32,
+                transform: "translate(-50%, 0)",
+              }}
+              onMouseDown={(e) => e.preventDefault()}
+            >
+              <div
+                style={{
+                  width: 18,
+                  height: 18,
+                  margin: "0 auto",
+                  background: "var(--t-accent)",
+                  borderRadius: "50% 50% 50% 0",
+                  transform: "rotate(135deg)",
+                }}
+              />
+            </div>
+          ))}
+        </>
+      )}
       {toolbar && (
         <div
           data-mobile-term-toolbar
@@ -342,6 +421,7 @@ export default function MobileTerminalGestures({ sessionId, active }: { sessionI
                   if (sel) void writeClipboard(sel);
                   getTerminalApi(sessionId)?.clearSelection();
                   setToolbar(null);
+                  setHandles(null);
                   anchorStart.current = null;
                   anchorEnd.current = null;
                 }}
@@ -351,7 +431,10 @@ export default function MobileTerminalGestures({ sessionId, active }: { sessionI
               <button
                 data-toolbar-selectall
                 className="px-3 py-1.5 rounded-md text-xs font-medium text-(--t-text-primary)"
-                onClick={() => getTerminalApi(sessionId)?.selectAll()}
+                onClick={() => {
+                  getTerminalApi(sessionId)?.selectAll();
+                  refreshSelectionUI();
+                }}
               >
                 {t("mobile.terminalGestures.selectAll")}
               </button>
@@ -366,6 +449,7 @@ export default function MobileTerminalGestures({ sessionId, active }: { sessionI
               });
               getTerminalApi(sessionId)?.clearSelection();
               setToolbar(null);
+              setHandles(null);
               anchorStart.current = null;
               anchorEnd.current = null;
             }}

--- a/src/components/mobile/mobileTerminalGesturesCore.test.ts
+++ b/src/components/mobile/mobileTerminalGesturesCore.test.ts
@@ -4,6 +4,8 @@ import {
   isBlankCell,
   linesFromPixelDelta,
   extendSelection,
+  selectionLength,
+  cellPixel,
   fontSizeFromPinch,
   touchDistance,
   type CellMetrics,
@@ -40,27 +42,46 @@ eq(linesFromPixelDelta(8, 16, 0), { lines: 0, carry: 0.5 }, "half a cell carries
 eq(linesFromPixelDelta(8, 16, 0.5), { lines: 1, carry: 0 }, "carry completes a line");
 eq(linesFromPixelDelta(-24, 16, 0), { lines: -1, carry: -0.5 }, "negative truncates toward zero");
 
-// extendSelection: same line → char-precise; cross-line → whole lines.
+// extendSelection: char-precise, same line or crossing lines.
 eq(
   extendSelection({ col: 3, line: 100 }, { col: 6, line: 100 }, { col: 9, line: 100 }),
-  { kind: "line", startCol: 3, line: 100, len: 7 },
+  { start: { col: 3, line: 100 }, end: { col: 9, line: 100 } },
   "same line extends to focus",
 );
 eq(
   extendSelection({ col: 3, line: 100 }, { col: 6, line: 100 }, { col: 1, line: 100 }),
-  { kind: "line", startCol: 1, line: 100, len: 6 },
+  { start: { col: 1, line: 100 }, end: { col: 6, line: 100 } },
   "same line extends left of anchor",
 );
 eq(
   extendSelection({ col: 3, line: 100 }, { col: 6, line: 100 }, { col: 2, line: 104 }),
-  { kind: "lines", start: 100, end: 104 },
-  "cross line → whole lines",
+  { start: { col: 3, line: 100 }, end: { col: 2, line: 104 } },
+  "cross line downward stays char-precise",
 );
 eq(
   extendSelection({ col: 3, line: 100 }, { col: 6, line: 100 }, { col: 2, line: 97 }),
-  { kind: "lines", start: 97, end: 100 },
-  "cross line upward → whole lines",
+  { start: { col: 2, line: 97 }, end: { col: 6, line: 100 } },
+  "cross line upward stays char-precise",
 );
+eq(
+  extendSelection({ col: 3, line: 100 }, { col: 3, line: 100 }, { col: 0, line: 100 }),
+  { start: { col: 0, line: 100 }, end: { col: 3, line: 100 } },
+  "two-point range (handle drag) — focus before fixed",
+);
+eq(
+  extendSelection({ col: 3, line: 100 }, { col: 3, line: 100 }, { col: 1, line: 102 }),
+  { start: { col: 3, line: 100 }, end: { col: 1, line: 102 } },
+  "two-point range (handle drag) — focus on a later line",
+);
+
+// selectionLength: char count term.select(col, row, length) needs, wrapping at `cols`.
+eq(selectionLength({ col: 3, line: 100 }, { col: 9, line: 100 }, 80), 7, "same line inclusive count");
+eq(selectionLength({ col: 3, line: 100 }, { col: 2, line: 104 }, 80), 4 * 80 - 1 + 1, "wraps 4 full lines via cols");
+eq(selectionLength({ col: 0, line: 100 }, { col: 0, line: 100 }, 80), 1, "single cell");
+
+// cellPixel: left edge (colOffset 0) vs right edge (colOffset 1) of a cell, in client coords.
+eq(cellPixel(m, { col: 3, line: 102 }, 0), { x: 10 + 3 * 8, y: 20 + 2 * 16 }, "left edge");
+eq(cellPixel(m, { col: 3, line: 102 }, 1), { x: 10 + 4 * 8, y: 20 + 2 * 16 }, "right edge");
 
 // touchDistance / fontSizeFromPinch: two fingers scale the terminal font size.
 eq(touchDistance({ clientX: 0, clientY: 0 }, { clientX: 3, clientY: 4 }), 5, "euclidean distance");

--- a/src/components/mobile/mobileTerminalGesturesCore.ts
+++ b/src/components/mobile/mobileTerminalGesturesCore.ts
@@ -53,23 +53,28 @@ export function linesFromPixelDelta(
   return { lines, carry: total - lines };
 }
 
-export type Selection =
-  | { kind: "line"; startCol: number; line: number; len: number }
-  | { kind: "lines"; start: number; end: number };
+export type Selection = { start: Cell; end: Cell };
 
-/**
- * Extend a selection seeded by the word [anchorStart..anchorEnd] (same line) out to `focus`.
- * Same line → character-precise range; crossing lines → whole-line range (xterm public-API limit).
- */
+const isBefore = (a: Cell, b: Cell) => a.line < b.line || (a.line === b.line && a.col < b.col);
+const minCell = (a: Cell, b: Cell) => (isBefore(a, b) ? a : b);
+const maxCell = (a: Cell, b: Cell) => (isBefore(a, b) ? b : a);
+
+/** Extend a selection seeded by [anchorStart..anchorEnd] out to `focus`, char-precise across lines. */
 export function extendSelection(anchorStart: Cell, anchorEnd: Cell, focus: Cell): Selection {
-  if (focus.line === anchorStart.line && anchorStart.line === anchorEnd.line) {
-    const lo = Math.min(anchorStart.col, focus.col);
-    const hi = Math.max(anchorEnd.col, focus.col);
-    return { kind: "line", startCol: lo, line: anchorStart.line, len: hi - lo + 1 };
-  }
-  const start = Math.min(anchorStart.line, focus.line);
-  const end = Math.max(anchorEnd.line, focus.line);
-  return { kind: "lines", start, end };
+  return { start: minCell(anchorStart, focus), end: maxCell(anchorEnd, focus) };
+}
+
+/** Char count `term.select(col, row, length)` needs to cover [start..end] inclusive, given terminal width. */
+export function selectionLength(start: Cell, end: Cell, cols: number): number {
+  return (end.line - start.line) * cols + (end.col - start.col) + 1;
+}
+
+/** Client-coord point at a cell's left (colOffset 0) or right (colOffset 1) edge. */
+export function cellPixel(m: CellMetrics, cell: Cell, colOffset: 0 | 1): { x: number; y: number } {
+  return {
+    x: m.left + (cell.col + colOffset) * m.cellWidth,
+    y: m.top + (cell.line - m.viewportTop) * m.cellHeight,
+  };
 }
 
 /** Distance between the first two touch points of a gesture. */


### PR DESCRIPTION
## Summary
- Add native-style draggable handles at selection start/end after a long-press-drag release, so a mis-dragged endpoint can be fixed without redoing the whole gesture.
- Fix cross-line selection to be character-precise instead of snapping to whole lines — `xterm`'s `select(col, row, length)` already wraps `length` across rows via terminal width, so the old whole-line fallback wasn't a real API limit.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `mobileTerminalGesturesCore.test.ts` extended for char-precise cross-line ranges + new helpers, passing
- [x] Full mobile test suite run — 2 pre-existing unrelated failures confirmed independent (canvas/jsdom timeout in `MobileHeader.test.tsx` / `MobileSftpScreen.test.tsx`)
- [ ] On-device Android verification (not yet done)