### PR TITLE
docs(skill): mark the team key-distribution bug as fixed

### DIFF
--- a/.claude/skills/testing-voltius-team-features-e2e/SKILL.md
+++ b/.claude/skills/testing-voltius-team-features-e2e/SKILL.md
@@ -97,4 +97,4 @@ docker ps | grep voltius                               # prod voltius-server/vol
 
 ## Known real bug this harness surfaced
 
-The **async key-distribution window** (VoltiusApp/voltius#41): an invitee who accepts while the sole key-holder is offline stays keyless (silent `GET vault-key → 404` loop) until the inviter reconnects. If you reproduce team-vault access failures, check `team_vault_keys` for a missing member row before assuming a crypto bug.
+The **async key-distribution window** (VoltiusApp/voltius#41): an invitee who accepts while the sole key-holder is offline stayed keyless (silent `GET vault-key → 404` loop). **FIXED in v0.13.0 and closed 2026-07-29** — `reconcileTeamVaultKeys()` (`teamVaultSync.ts:383`) wraps the key for any keyless member, triggered on login (`teamDataManager.ts:47`) and on membership change (`sync.ts:939`), so it self-heals when a key-holder next signs in. If you still reproduce team-vault access failures, check `team_vault_keys` for a missing member row before assuming a crypto bug — but do not report #41 as open.


### PR DESCRIPTION
The team E2E skill's "Known real bug this harness surfaced" section still described VoltiusApp/voltius#41 — the async key-distribution window — as a live hazard.

It was fixed in v0.13.0 and closed on 2026-07-29. The fix is present in the code shipping today:

- `reconcileTeamVaultKeys()` (`teamVaultSync.ts:383`) compares `team_members` against the server's key-holder list and wraps the key for anyone missing it, returning early if the caller cannot unwrap the key itself
- triggered on login (`teamDataManager.ts:47`, whose comment names #41) and on membership change (`sync.ts:939`)

So the documented scenario — an invitee accepts while the sole key-holder is offline — self-heals when that key-holder next signs in, rather than waiting for a coincidental membership event.

Reading the skill as current caused a seven-month-old bug to be reported as an open risk against shipping Teams. The section now records it as fixed, keeps the `team_vault_keys` debugging hint, and says explicitly not to report #41 as open.
