### PR TITLE
feat(billing): let the client request a plan, seat count and interval

### DIFF
--- a/src/services/billingCheckout.test.ts
+++ b/src/services/billingCheckout.test.ts
@@ -1,0 +1,50 @@
+import { test, expect, vi, beforeEach } from "vitest";
+
+const invoke = vi.fn(async (_cmd: string, args: { key: string }) =>
+  args.key === "server_url" ? "https://srv.test" : "jwt-token",
+);
+const appFetch = vi.fn(async (_url: string, _opts: RequestInit) =>
+  new Response(JSON.stringify({ checkout_url: "https://ls.test/c" }), { status: 200 }),
+);
+const openUrl = vi.fn(async (_url: string) => {});
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (c: string, a: { key: string }) => invoke(c, a) }));
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: (u: string) => openUrl(u) }));
+vi.mock("@/services/http", () => ({ appFetch: (u: string, o: RequestInit) => appFetch(u, o) }));
+
+import { openBillingCheckout } from "./billingCheckout";
+
+function sentBody(): Record<string, unknown> {
+  const calls = appFetch.mock.calls;
+  return JSON.parse(calls[calls.length - 1][1].body as string);
+}
+
+beforeEach(() => {
+  appFetch.mockClear();
+  openUrl.mockClear();
+});
+
+test("sends only the plan when nothing else is specified", async () => {
+  await openBillingCheckout("pro");
+  expect(sentBody()).toEqual({ plan: "pro" });
+});
+
+test("forwards a yearly interval so the annual variant is reachable", async () => {
+  await openBillingCheckout("teams", { interval: "yearly" });
+  expect(sentBody()).toEqual({ plan: "teams", interval: "yearly" });
+});
+
+test("forwards a seat count for per-seat plans", async () => {
+  await openBillingCheckout("teams", { seats: 10, interval: "monthly" });
+  expect(sentBody()).toEqual({ plan: "teams", seats: 10, interval: "monthly" });
+});
+
+test("accepts the business plan", async () => {
+  await openBillingCheckout("business", { seats: 4 });
+  expect(sentBody()).toEqual({ plan: "business", seats: 4 });
+});
+
+test("opens the checkout url the server returns", async () => {
+  await expect(openBillingCheckout("pro")).resolves.toBe(true);
+  expect(openUrl).toHaveBeenCalledWith("https://ls.test/c");
+});

--- a/src/services/billingCheckout.ts
+++ b/src/services/billingCheckout.ts
@@ -5,7 +5,13 @@ import { checkoutRequiresEmailVerification } from "@/utils/emailVerification";
 
 export const EMAIL_VERIFICATION_REQUIRED_EVENT = "voltius:email-verification-required";
 
-export type BillingPlan = "pro" | "teams";
+export type BillingPlan = "pro" | "teams" | "business";
+export type BillingInterval = "monthly" | "yearly";
+
+export interface CheckoutOptions {
+  seats?: number;
+  interval?: BillingInterval;
+}
 
 async function readResponseBody(res: Response): Promise<unknown> {
   try {
@@ -15,7 +21,7 @@ async function readResponseBody(res: Response): Promise<unknown> {
   }
 }
 
-export async function openBillingCheckout(plan: BillingPlan): Promise<boolean> {
+export async function openBillingCheckout(plan: BillingPlan, options: CheckoutOptions = {}): Promise<boolean> {
   const [serverUrl, jwt] = await Promise.all([
     invoke<string | null>("keychain_get", { key: "server_url" }),
     invoke<string | null>("keychain_get", { key: "jwt" }),
@@ -25,7 +31,11 @@ export async function openBillingCheckout(plan: BillingPlan): Promise<boolean> {
   const res = await appFetch(`${serverUrl}/v1/billing/checkout`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Authorization: `Bearer ${jwt}` },
-    body: JSON.stringify({ plan }),
+    body: JSON.stringify({
+      plan,
+      ...(options.seats !== undefined && { seats: options.seats }),
+      ...(options.interval && { interval: options.interval }),
+    }),
   });
   const body = await readResponseBody(res);
 


### PR DESCRIPTION
Client half of VoltiusApp/server#20.

`openBillingCheckout` sent only `{ plan }`, so the server defaulted every purchase to **monthly at three seats**:

- the yearly variants were unreachable from the app, even though the pricing page leads with annual prices
- a ten-person team could not buy ten seats from the app

`BillingPlan` now includes `business`, and the function accepts optional `seats` and `interval`, omitting each when unset so every existing caller keeps its current behaviour.

No UI passes these yet — the seat and interval picker lives in the web portal, which already sends both. This is the plumbing that would let the app offer one; building that picker is a separate piece of work with real design choices.

## Testing

Five new tests, the first coverage this module has had:

```
sends only the plan when nothing else is specified
forwards a yearly interval so the annual variant is reachable
forwards a seat count for per-seat plans
accepts the business plan
opens the checkout url the server returns
```

`tsc --noEmit` exit 0.

## Order of deployment

This is inert without the server change. `interval: "yearly"` reaches a server that still ignores it until VoltiusApp/server#20 ships, and `plan: "business"` returns 400 until then and until a Business variant exists.
